### PR TITLE
Feature/api support for tickets

### DIFF
--- a/app/Console/Commands/IngestKeyCreate.php
+++ b/app/Console/Commands/IngestKeyCreate.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ServiceProduct;
+use App\Services\Support\IngestKeyManager;
+use Illuminate\Console\Command;
+use Random\RandomException;
+
+class IngestKeyCreate extends Command
+{
+    protected $signature = 'forge:ingest-keys:create {serviceProductId} {--name=}';
+    protected $description = 'Create an ingest key for a Service Product';
+
+    /**
+     * @throws RandomException
+     */
+    public function handle(IngestKeyManager $mgr): int
+    {
+        $sp = ServiceProduct::query()->findOrFail($this->argument('serviceProductId'));
+        $res = $mgr->generate($sp, $this->option('name'), auth()?->id());
+
+        $this->info('Key created. Copy this token now:');
+        $this->line($res['token']);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/IngestKeyCreate.php
+++ b/app/Console/Commands/IngestKeyCreate.php
@@ -18,7 +18,7 @@ class IngestKeyCreate extends Command
     public function handle(IngestKeyManager $mgr): int
     {
         $sp = ServiceProduct::query()->findOrFail($this->argument('serviceProductId'));
-        $res = $mgr->generate($sp, $this->option('name'), auth()?->id());
+        $res = $mgr->generate($sp, $this->option('name'), null);
 
         $this->info('Key created. Copy this token now:');
         $this->line($res['token']);

--- a/app/Console/Commands/IngestKeyRevoke.php
+++ b/app/Console/Commands/IngestKeyRevoke.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\ServiceProductIngestKey;
+use Illuminate\Console\Command;
+
+class IngestKeyRevoke extends Command
+{
+    protected $signature = 'forge:ingest-keys:revoke {keyId}';
+    protected $description = 'Revoke an ingest key';
+
+    public function handle(): int
+    {
+        $key = ServiceProductIngestKey::query()->findOrFail($this->argument('keyId'));
+        if ($key->isRevoked()) {
+            $this->warn('Key already revoked.');
+            return self::SUCCESS;
+        }
+
+        $key->revoked_at = now()->toImmutable();
+        $key->save();
+
+        $this->info('Key revoked.');
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Api/V1/TicketController.php
+++ b/app/Http/Controllers/Api/V1/TicketController.php
@@ -71,11 +71,7 @@ final class TicketController extends Controller
             ]);
 
             /** @var array<int,UploadedFile> $files */
-            //            $files = $payload['attachments'] ?? [];
-            //            foreach ($files as $file) {
-            //                $t->addMedia($file)->toMediaCollection('attachments');
-            //            }
-
+            // TODO: Implement attachment handling if required in the future.
             return $t->load([
                 'status:id,name',
                 'priority:id,name',

--- a/app/Http/Controllers/Api/V1/TicketController.php
+++ b/app/Http/Controllers/Api/V1/TicketController.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\StoreTicketRequest;
+use App\Http\Resources\Api\V1\TicketResource;
+use App\Models\SupportIdentity;
+use App\Models\Ticket;
+use App\Models\TicketPriority;
+use App\Models\TicketStatus;
+use App\Models\TicketType;
+use App\Services\Support\TextRedactor;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+final class TicketController extends Controller
+{
+    public function __construct(private TextRedactor $redactor)
+    {
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function store(StoreTicketRequest $request): JsonResponse
+    {
+        /** @var array<string,mixed> $payload */
+        $payload = $request->validated();
+
+        // Map severity -> priority (fallback gracefully)
+        $priority = $this->mapSeverityToPriorityId($payload['severity'] ?? null);
+
+        // Prefer a "Bug" type if it exists, else first type:
+        $typeId = TicketType::query()->where('name', 'Bug')->value('id')
+            ?? TicketType::query()->orderBy('name')->value('id');
+
+        // Pick a default "New/Open" status if defined, else first:
+        $statusId = TicketStatus::query()->whereIn('name', ['New', 'Open'])->value('id')
+            ?? TicketStatus::query()->orderBy('name')->value('id');
+
+        // Build or match the support identity
+        $identity = $this->resolveIdentity(
+            email: $payload['email'] ?? null,
+            playerId: $payload['player_id'] ?? null,
+        );
+
+        // Redact PII from description
+        $cleanDescription = $this->redactor->redact($payload['description']);
+
+        $ingestKey = $request->attributes->get('ingest_key'); // ServiceProductIngestKey|null
+        $serviceProductId = $ingestKey?->service_product_id ?? $payload['service_product_id'];
+
+        /** @var Ticket $ticket */
+        $ticket = DB::transaction(static function () use ($payload, $identity, $priority, $typeId, $statusId, $cleanDescription, $serviceProductId) {
+            $t = Ticket::query()->create([
+                'summary'            => $payload['summary'],
+                'description'        => $cleanDescription,
+                'service_product_id' => $serviceProductId,
+                'priority_id'        => $priority,
+                'type_id'            => $typeId,
+                'status_id'          => $statusId,
+                'support_identity_id'=> $identity?->getKey(),
+                'source'             => 'api',                // helpful flag
+                'channel'            => 'game',               // optional
+                'build'              => $payload['build'] ?? null,
+                'platform'           => $payload['platform'] ?? null,
+                'meta'               => $payload['metadata'] ?? [], // cast json on model
+            ]);
+
+            /** @var array<int,UploadedFile> $files */
+//            $files = $payload['attachments'] ?? [];
+//            foreach ($files as $file) {
+//                $t->addMedia($file)->toMediaCollection('attachments');
+//            }
+
+            return $t->load([
+                'status:id,name',
+                'priority:id,name',
+                'type:id,name',
+                'serviceProduct:id,name',
+            ]);
+        });
+
+        return (new TicketResource($ticket))
+            ->response()
+            ->setStatusCode(201);
+    }
+
+    private function resolveIdentity(?string $email, ?string $playerId): ?SupportIdentity
+    {
+        if ($email) {
+            /** @var SupportIdentity|null $identity */
+            $identity = SupportIdentity::query()->where('email', $email)->first();
+            if ($identity !== null) {
+                // backfill player id
+                if ($playerId && empty($identity->external_user_id)) {
+                    $identity->external_user_id = $playerId;
+                    $identity->save();
+                }
+                return $identity;
+            }
+
+            return SupportIdentity::query()->create([
+                'email'             => $email,
+                'external_user_id'  => $playerId,
+                'display_name'      => $email, // or null
+                'source'            => 'api',
+            ]);
+        }
+
+        if ($playerId) {
+            return SupportIdentity::query()->firstOrCreate(
+                ['external_user_id' => $playerId],
+                ['source' => 'api']
+            );
+        }
+
+        return null; // completely anonymous
+    }
+
+    private function mapSeverityToPriorityId(?string $severity): ?string
+    {
+        if ($severity === null) {
+            return TicketPriority::query()->where('name', 'Medium')->value('id')
+                ?? TicketPriority::query()->orderBy('name')->value('id');
+        }
+
+        $map = [
+            'critical' => ['Critical', 'P0'],
+            'major'    => ['High', 'P1'],
+            'minor'    => ['Medium', 'P2'],
+            'trivial'  => ['Low', 'P3'],
+        ];
+
+        $candidates = $map[strtolower($severity)] ?? ['Medium'];
+        return TicketPriority::query()->whereIn('name', $candidates)->value('id')
+            ?? TicketPriority::query()->orderBy('name')->value('id');
+    }
+}

--- a/app/Http/Controllers/Api/V1/TicketController.php
+++ b/app/Http/Controllers/Api/V1/TicketController.php
@@ -62,7 +62,7 @@ final class TicketController extends Controller
                 'priority_id'        => $priority,
                 'type_id'            => $typeId,
                 'status_id'          => $statusId,
-                'support_identity_id'=> $identity?->getKey(),
+                'support_identity_id' => $identity?->getKey(),
                 'source'             => 'api',                // helpful flag
                 'channel'            => 'game',               // optional
                 'build'              => $payload['build'] ?? null,
@@ -71,10 +71,10 @@ final class TicketController extends Controller
             ]);
 
             /** @var array<int,UploadedFile> $files */
-//            $files = $payload['attachments'] ?? [];
-//            foreach ($files as $file) {
-//                $t->addMedia($file)->toMediaCollection('attachments');
-//            }
+            //            $files = $payload['attachments'] ?? [];
+            //            foreach ($files as $file) {
+            //                $t->addMedia($file)->toMediaCollection('attachments');
+            //            }
 
             return $t->load([
                 'status:id,name',

--- a/app/Http/Middleware/VerifyIngestKey.php
+++ b/app/Http/Middleware/VerifyIngestKey.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\ServiceProductIngestKey;
+use App\Services\Support\IngestKeyManager;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class VerifyIngestKey
+{
+    public function __construct(private IngestKeyManager $manager)
+    {
+    }
+
+    public function __invoke(Request $request, Closure $next): Response
+    {
+        // Extract token from either header:
+        $raw = $request->header('X-Forge-Api-Key') ?: $request->header('Authorization');
+        $parsed = $this->manager->parseToken($raw);
+
+        if ($parsed === null) {
+            abort(401, 'Invalid ingest key.');
+        }
+
+        /** @var ServiceProductIngestKey|null $key */
+        $key = ServiceProductIngestKey::query()->find($parsed['id']);
+        if ($key === null || $key->isRevoked()) {
+            abort(401, 'Invalid ingest key.');
+        }
+
+        if (! $this->manager->verify($parsed['secret'], $key->secret_hash)) {
+            abort(401, 'Invalid ingest key.');
+        }
+
+        // Stamp last_used_at (quiet)
+        $key->forceFill(['last_used_at' => now()->toImmutable()])->saveQuietly();
+
+        // Attach for downstream consumers
+        $request->attributes->set('ingest_key', $key);
+
+        // if client sent service_product_id and it's not this key's product -> forbid
+        $incoming = $request->input('service_product_id');
+        if (is_string($incoming) && $incoming !== $key->service_product_id) {
+            abort(403, 'Key is not valid for the requested product.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/Api/V1/StoreTicketRequest.php
+++ b/app/Http/Requests/Api/V1/StoreTicketRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * @property-read string $summary
+ * @property-read string $description
+ * @property-read string|null $email
+ * @property-read string|null $player_id
+ * @property-read string|null $build
+ * @property-read string|null $platform
+ * @property-read string|null $severity
+ * @property-read array<string,mixed>|null $metadata
+ * @property-read string|null $service_product_id
+ */
+final class StoreTicketRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'summary'            => ['required', 'string', 'min:4', 'max:200'],
+            'description'        => ['required', 'string', 'min:10', 'max:8000'],
+            'service_product_id' => ['required', 'string', 'exists:service_products,id'],
+
+            'email'              => ['nullable', 'email:rfc,dns', 'max:255'],
+            'player_id'          => ['nullable', 'string', 'max:255'],
+            'build'              => ['nullable', 'string', 'max:64'],
+            'platform'           => ['nullable', 'string', 'max:32'], // e.g., pc, xbox, ps, switch, linux, macos
+            'severity'           => ['nullable', 'in:trivial,minor,major,critical'],
+            'metadata'           => ['nullable', 'array'],
+
+            // Attachments via multipart/form-data:
+            'attachments'        => ['nullable', 'array', 'max:5'],
+            'attachments.*'      => ['file', 'mimetypes:text/plain,text/markdown,application/zip,application/x-zip-compressed,image/png,image/jpeg,video/mp4', 'max:10240'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'service_product_id.exists' => 'Unknown product.',
+        ];
+    }
+}

--- a/app/Http/Resources/Api/V1/TicketResource.php
+++ b/app/Http/Resources/Api/V1/TicketResource.php
@@ -19,7 +19,7 @@ final class TicketResource extends JsonResource
             'priority'  => $this->priority->only(['id', 'name']) ?? null,
             'type'      => $this->type->only(['id', 'name']) ?? null,
             'product'   => $this->serviceProduct?->only(['id','name']),
-            'created_at'=> $this->created_at?->toIso8601String(),
+            'created_at' => $this->created_at?->toIso8601String(),
             'links'     => [
                 'html' => route('tickets.show', ['ticket' => $this->getKey()], false) ?? null,
             ],

--- a/app/Http/Resources/Api/V1/TicketResource.php
+++ b/app/Http/Resources/Api/V1/TicketResource.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Resources\Api\V1;
+
+use App\Models\Ticket;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin Ticket */
+final class TicketResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id'        => (string) $this->getKey(),
+            'key'       => $this->key ?? null, // if you have a human key like FORGE-123
+            'summary'   => $this->summary,
+            'status'    => $this->status->only(['id', 'name']) ?? null,
+            'priority'  => $this->priority->only(['id', 'name']) ?? null,
+            'type'      => $this->type->only(['id', 'name']) ?? null,
+            'product'   => $this->serviceProduct?->only(['id','name']),
+            'created_at'=> $this->created_at?->toIso8601String(),
+            'links'     => [
+                'html' => route('tickets.show', ['ticket' => $this->getKey()], false) ?? null,
+            ],
+        ];
+    }
+}

--- a/app/Models/ServiceProduct.php
+++ b/app/Models/ServiceProduct.php
@@ -67,6 +67,11 @@ class ServiceProduct extends BaseModel
         return $this->hasMany(ServiceProductPriorityMap::class);
     }
 
+    public function ingestKeys(): HasMany
+    {
+        return $this->hasMany(ServiceProductIngestKey::class);
+    }
+
     /**
      * Resolve mapped Issue Type ID for a given Ticket Type, honoring project allowed sets.
      * @param int $ticketTypeId

--- a/app/Models/ServiceProductIngestKey.php
+++ b/app/Models/ServiceProductIngestKey.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+/**
+ * @property-read string $id
+ * @property string $service_product_id
+ * @property string|null $name
+ * @property string $secret_hash
+ * @property string|null $created_by
+ * @property CarbonImmutable|null $last_used_at
+ * @property CarbonImmutable|null $revoked_at
+ */
+class ServiceProductIngestKey extends Model
+{
+    use HasUlids;
+
+    /** @var array<int,string> */
+    protected $fillable = ['service_product_id', 'name', 'secret_hash', 'created_by', 'last_used_at', 'revoked_at'];
+
+    protected $casts = [
+        'last_used_at' => 'immutable_datetime',
+        'revoked_at'   => 'immutable_datetime',
+    ];
+
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    public static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(static function ($model) {
+            $model->id = Str::ulid();
+        });
+    }
+
+    public function serviceProduct(): BelongsTo
+    {
+        return $this->belongsTo(ServiceProduct::class);
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function isRevoked(): bool
+    {
+        return $this->revoked_at !== null;
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -55,6 +55,13 @@ class AppServiceProvider extends ServiceProvider
             return Limit::perMinute(120)->by($key);
         });
 
+        RateLimiter::for('ticket-ingest', static function (Request $request) {
+            $key = $request->attributes->get('ingest_key');
+            $bucket = $key?->id ?? $request->ip();
+
+            return [Limit::perMinute(20)->by('ingest:' . $bucket)];
+        });
+
         Paginator::useBootstrapFive();
         Sanctum::usePersonalAccessTokenModel(PersonalAccessToken::class);
         Issue::observe(IssueObserver::class);

--- a/app/Services/Support/IngestKeyManager.php
+++ b/app/Services/Support/IngestKeyManager.php
@@ -31,7 +31,7 @@ final class IngestKeyManager
 
         $id = $key->id;
 
-        $token = "fki_". $id . $this->b64url($secret);
+        $token = "fki_" . $id . "." . $this->b64url($secret);
 
         return ['token' => $token, 'key' => $key];
     }

--- a/app/Services/Support/IngestKeyManager.php
+++ b/app/Services/Support/IngestKeyManager.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Services\Support;
+
+use App\Models\ServiceProduct;
+use App\Models\ServiceProductIngestKey;
+use Illuminate\Support\Str;
+use Random\RandomException;
+
+/**
+ * Manages per-ServiceProduct ingest keys.
+ *
+ * Token format (shown once):  fki_<ulid>.<base64url(32-byte-secret)>
+ */
+final class IngestKeyManager
+{
+    /** @return array{token:string, key:ServiceProductIngestKey}
+     * @throws RandomException
+     */
+    public function generate(ServiceProduct $product, ?string $name = null, ?string $createdBy = null): array
+    {
+        $secret = $this->randomSecret();
+        $hash   = $this->hmac($secret);
+
+        $key = ServiceProductIngestKey::create([
+            'service_product_id' => $product->getKey(),
+            'name' => $name,
+            'secret_hash' => $hash,
+            'created_by' => $createdBy,
+        ]);
+
+        $id = $key->id;
+
+        $token = "fki_". $id . $this->b64url($secret);
+
+        return ['token' => $token, 'key' => $key];
+    }
+
+    public function revoke(ServiceProductIngestKey $key): void
+    {
+        if (! $key->isRevoked()) {
+            $key->revoked_at = now()->toImmutable();
+            $key->save();
+        }
+    }
+
+    public function parseToken(?string $provided): ?array
+    {
+        if (! is_string($provided) || $provided === '') {
+            return null;
+        }
+        // Accept either "X-Forge-Api-Key: <token>" or "Authorization: Bearer <token>"
+        if (str_starts_with($provided, 'Bearer ')) {
+            $provided = substr($provided, 7);
+        }
+
+        $parts = explode('.', $provided, 2);
+        if (count($parts) !== 2) {
+            return null;
+        }
+
+        [$pfxId, $secretB64] = $parts;
+        if (! str_starts_with($pfxId, 'fki_')) {
+            return null;
+        }
+
+        $id     = substr($pfxId, 4);
+        $secret = $this->b64urlDecode($secretB64);
+        if ($secret === null) {
+            return null;
+        }
+
+        return ['id' => $id, 'secret' => $secret];
+    }
+
+    public function verify(string $secret, string $storedHash): bool
+    {
+        return hash_equals($storedHash, $this->hmac($secret));
+    }
+
+    /**
+     * @throws RandomException
+     */
+    private function randomSecret(): string
+    {
+        return random_bytes(32);
+    }
+
+    private function b64url(string $bin): string
+    {
+        return rtrim(strtr(base64_encode($bin), '+/', '-_'), '=');
+    }
+
+    private function b64urlDecode(string $b64): ?string
+    {
+        $pad = strlen($b64) % 4;
+        if ($pad > 0) {
+            $b64 .= str_repeat('=', 4 - $pad);
+        }
+        $raw = base64_decode(strtr($b64, '-_', '+/'), true);
+        return $raw === false ? null : $raw;
+    }
+
+    private function hmac(string $secret): string
+    {
+        $appKey = (string) config('app.key');
+        if (str_starts_with($appKey, 'base64:')) {
+            $appKey = base64_decode(substr($appKey, 7)) ?: '';
+        }
+        return hash_hmac('sha256', $secret, $appKey);
+    }
+}

--- a/app/Services/Support/IngestKeyManager.php
+++ b/app/Services/Support/IngestKeyManager.php
@@ -105,7 +105,11 @@ final class IngestKeyManager
     {
         $appKey = (string) config('app.key');
         if (str_starts_with($appKey, 'base64:')) {
-            $appKey = base64_decode(substr($appKey, 7)) ?: '';
+            $decoded = base64_decode(substr($appKey, 7), true);
+            if ($decoded === false) {
+                throw new \RuntimeException('Failed to decode base64 app key. Please check your APP_KEY configuration.');
+            }
+            $appKey = $decoded;
         }
         return hash_hmac('sha256', $secret, $appKey);
     }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Http\Middleware\EnsureSupportIdentity;
 use App\Http\Middleware\SetPermissionsTeamContext;
+use App\Http\Middleware\VerifyIngestKey;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -18,6 +19,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->append(SetPermissionsTeamContext::class);
         $middleware->alias([
             'support.identity' => EnsureSupportIdentity::class,
+            'ingest.key' => VerifyIngestKey::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/database/migrations/2025_09_18_130529_create_service_product_ingest_keys_table.php
+++ b/database/migrations/2025_09_18_130529_create_service_product_ingest_keys_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('service_product_ingest_keys', static function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->ulid('service_product_id');
+            $table->string('name', 100)->nullable(); // label to identify this key
+            $table->string('secret_hash', 64);       // hex sha256 HMAC
+            $table->uuid('created_by')->nullable();
+            $table->timestampTz('last_used_at')->nullable();
+            $table->timestampTz('revoked_at')->nullable();
+            $table->timestampsTz();
+
+            $table->foreign('service_product_id')->references('id')->on('service_products')->cascadeOnDelete();
+            $table->foreign('created_by')->references('id')->on('users')->nullOnDelete();
+
+            $table->index(['service_product_id', 'revoked_at']);
+            $table->index('last_used_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('service_product_ingest_keys');
+    }
+};

--- a/database/migrations/2025_09_18_130529_create_service_product_ingest_keys_table.php
+++ b/database/migrations/2025_09_18_130529_create_service_product_ingest_keys_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::create('service_product_ingest_keys', static function (Blueprint $table) {

--- a/resources/views/livewire/staff/support/products/edit.blade.php
+++ b/resources/views/livewire/staff/support/products/edit.blade.php
@@ -1,4 +1,5 @@
 <div class="vstack gap-3">
+    {{-- Product Details --}}
     <div class="card">
         <div class="card-header fw-semibold">Product Details</div>
         <form wire:submit.prevent="save" class="card-body vstack gap-3">
@@ -90,5 +91,97 @@
                 <button class="btn btn-primary">Save</button>
             </div>
         </form>
+    </div>
+
+    {{-- Ingest Keys --}}
+    <div class="card">
+        <div class="card-header fw-semibold d-flex align-items-center justify-content-between">
+            <span>API Ingest Keys</span>
+        </div>
+
+        <div class="card-body vstack gap-3">
+            {{-- One-time token alert --}}
+            @if($newKeyToken)
+                <div class="alert alert-warning d-flex align-items-start gap-2">
+                    <div>
+                        <div class="fw-semibold">Copy this token now — it won't be shown again.</div>
+                        <code class="user-select-all d-inline-block mt-1" x-data
+                              x-on:click="$clipboard('{{ $newKeyToken }}')">{{ $newKeyToken }}</code>
+                    </div>
+                    <button type="button" class="btn-close ms-auto" aria-label="Close"
+                            wire:click="$set('newKeyToken', null)"></button>
+                </div>
+            @endif
+
+            {{-- Generate new key --}}
+            <div class="row g-2 align-items-end">
+                <div class="col-md-6">
+                    <label class="form-label mb-1">Label (optional)</label>
+                    <input type="text" class="form-control" wire:model.defer="newKeyLabel" placeholder="e.g. UE4 build server, QA rig">
+                    @error('newKeyLabel') <div class="text-danger small">{{ $message }}</div> @enderror
+                </div>
+                <div class="col-md-6 d-flex gap-2">
+                    <button type="button" class="btn btn-success ms-auto"
+                            wire:click="generateKey">Generate Key</button>
+                </div>
+            </div>
+
+            {{-- Keys table --}}
+            @if($this->ingestKeys->isEmpty())
+                <div class="text-body-secondary small">No keys yet.</div>
+            @else
+                <div class="table-responsive">
+                    <table class="table table-sm align-middle">
+                        <thead>
+                        <tr>
+                            <th style="width:30%">Label</th>
+                            <th style="width:15%">Status</th>
+                            <th style="width:20%">Last Used</th>
+                            <th style="width:20%">Created</th>
+                            <th style="width:15%" class="text-end">Actions</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @foreach($this->ingestKeys as $k)
+                            <tr>
+                                <td>
+                                    <div class="fw-semibold">{{ $k->name ?? '—' }}</div>
+                                    <div class="small text-body-secondary">ID: {{ $k->id }}</div>
+                                </td>
+                                <td>
+                                    @if($k->revoked_at)
+                                        <span class="badge text-bg-secondary">Revoked</span>
+                                    @else
+                                        <span class="badge text-bg-success">Active</span>
+                                    @endif
+                                </td>
+                                <td class="small">
+                                    {{ $k->last_used_at?->diffForHumans() ?? '—' }}
+                                </td>
+                                <td class="small">
+                                    {{ $k->created_at?->format('Y-m-d H:i') }}
+                                </td>
+                                <td class="text-end">
+                                    @if(!$k->revoked_at)
+                                        <button type="button" class="btn btn-outline-danger btn-sm"
+                                                wire:click="revokeKey('{{ $k->id }}')"
+                                                wire:confirm="Revoke this key? Clients using it will stop working.">
+                                            Revoke
+                                        </button>
+                                    @else
+                                        <button type="button" class="btn btn-outline-danger btn-sm"
+                                                wire:click="deleteKey('{{ $k->id }}')"
+                                                wire:confirm="Delete this revoked key permanently?">
+                                            Delete
+                                        </button>
+                                    @endif
+                                </td>
+                            </tr>
+                        @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            @endif
+        </div>
     </div>
 </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,13 +12,21 @@ Route::get('/user', static function (Request $request) {
 Route::post('/webhooks/github', [GitHubWebhookController::class, 'handle'])
     ->name('webhooks.github');
 
+
+Route::prefix('v1')->name('api.v1.')->group(function () {
+    // Public (throttled) ingest; optionally protect with 'ingest.key' later.
+    Route::post('tickets', [V1\TicketController::class, 'store'])
+        ->name('tickets.store')
+        ->middleware(['ingest.key', 'throttle:ticket-ingest']);
+});
+
 Route::prefix('v1')->middleware(['auth:sanctum', 'throttle:api'])->group(function (): void {
     Route::get('me', V1\MeController::class)->name('api.v1.me');
 
     Route::get('projects', [V1\ProjectController::class, 'index'])->name('api.v1.projects.index');
     Route::get('projects/{project}', [V1\ProjectController::class, 'show'])->name('api.v1.projects.show');
 
-    Route::get('lookups', \App\Http\Controllers\Api\V1\LookupsController::class);
+    Route::get('lookups', V1\LookupsController::class);
 
     Route::get('issues', [V1\IssueController::class, 'index'])->name('api.v1.issues.index');
     Route::post('issues', [V1\IssueController::class, 'store'])->name('api.v1.issues.store');


### PR DESCRIPTION
## Summary by Sourcery

Support API now allows external clients to ingest tickets securely using per-product keys: keys can be created, revoked, and managed via the UI or CLI, and incoming requests are validated, rate-limited, and transformed into Ticket records with PII redaction before returning structured JSON.

New Features:
- Add POST /api/v1/tickets endpoint with ingest key authentication, request validation, severity/type/status mapping, description redaction, and JSON response
- Introduce ServiceProductIngestKey model, migration, and IngestKeyManager service for generating, parsing, verifying, and revoking API ingest keys
- Add VerifyIngestKey middleware to enforce key validation and rate limiting with a custom 'ticket-ingest' limiter
- Extend the Livewire support product editor with UI support for listing, generating, revoking, and deleting ingest keys
- Add artisan commands to create and revoke ingest keys from the CLI

Enhancements:
- Register 'ingest.key' middleware alias and configure rate limiting in AppServiceProvider
- Add TicketResource API resource for consistent ticket JSON output