### PR TITLE
Add public-facing project tracker with embeddable Kanban board

### DIFF
--- a/app/Filament/Resources/Projects/Schemas/ProjectForm.php
+++ b/app/Filament/Resources/Projects/Schemas/ProjectForm.php
@@ -33,7 +33,8 @@ class ProjectForm
                         Forms\Components\TextInput::make('name')
                             ->required()->maxLength(120)
                             ->live(onBlur: true)
-                            ->afterStateUpdated(fn ($state, Set $set) => $set('key', app(\App\Support\Keys\ProjectKeyGenerator::class)->suggest((string) $state, 3))
+                            ->afterStateUpdated(
+                                fn ($state, Set $set) => $set('key', app(\App\Support\Keys\ProjectKeyGenerator::class)->suggest((string) $state, 3))
                             ),
                         Forms\Components\TextInput::make('key')
                             ->required()
@@ -45,7 +46,7 @@ class ProjectForm
                             ->formatStateUsing(fn ($state) => \Illuminate\Support\Str::upper($state)),
                         Forms\Components\Textarea::make('description')->rows(4)->columnSpanFull(),
                         Forms\Components\Select::make('stage')
-                            ->options(collect(ProjectStage::cases())->mapWithKeys(fn($c)=>[$c->value=>ucfirst($c->value)])->all())
+                            ->options(collect(ProjectStage::cases())->mapWithKeys(fn ($c) => [$c->value => ucfirst($c->value)])->all())
                             ->required(),
                         Forms\Components\Select::make('lead_id')
                             ->label('Project Lead')

--- a/app/Filament/Resources/Projects/Schemas/ProjectForm.php
+++ b/app/Filament/Resources/Projects/Schemas/ProjectForm.php
@@ -54,6 +54,20 @@ class ProjectForm
                             ->preload()
                             ->nullable(),
                     ])->columns(2),
+                    Section::make('Public Tracker')->schema([
+                        Forms\Components\Toggle::make('public_tracker_enabled')->label('Enable public tracker'),
+                        Forms\Components\TextInput::make('public_slug')
+                            ->helperText('Public URL slug (must be unique).')
+                            ->unique(ignoreRecord: true)
+                            ->visible(fn ($get) => $get('public_tracker_enabled') === true),
+                        Forms\Components\Toggle::make('count_private_in_progress')
+                            ->label('Include private issues in progress counters')
+                            ->visible(fn ($get) => $get('public_tracker_enabled') === true),
+                        Forms\Components\KeyValue::make('embed_domains')
+                            ->label('Allowed embed parent origins (frame-ancestors)')
+                            ->keyLabel('index')->valueLabel('origin')
+                            ->visible(fn ($get) => $get('public_tracker_enabled') === true),
+                    ])->columns(2),
                 ]),
                 Grid::make(1)->schema([
                     Section::make('Dates')->schema([

--- a/app/Filament/Resources/Projects/Schemas/ProjectForm.php
+++ b/app/Filament/Resources/Projects/Schemas/ProjectForm.php
@@ -74,7 +74,21 @@ class ProjectForm
                             ])
                             ->addActionLabel('Add origin')
                             ->visible(fn ($get) => $get('public_tracker_enabled') === true)
-                            ->columns(1),
+                            ->columns(1)
+                            ->formatStateUsing(function ($state) {
+                                // Convert array of strings to array of objects with 'origin' key
+                                if (is_array($state) && (count($state) === 0 || is_string(array_values($state)[0]))) {
+                                    return collect($state)->map(fn ($item) => ['origin' => $item])->all();
+                                }
+                                return $state;
+                            })
+                            ->dehydrateStateUsing(function ($state) {
+                                // Convert array of objects with 'origin' key to array of strings
+                                if (is_array($state) && (count($state) === 0 || is_array(array_values($state)[0]))) {
+                                    return collect($state)->pluck('origin')->filter()->values()->all();
+                                }
+                                return $state;
+                            }),
                     ])->columns(2),
                 ]),
                 Grid::make(1)->schema([

--- a/app/Filament/Resources/Projects/Schemas/ProjectForm.php
+++ b/app/Filament/Resources/Projects/Schemas/ProjectForm.php
@@ -64,10 +64,17 @@ class ProjectForm
                         Forms\Components\Toggle::make('count_private_in_progress')
                             ->label('Include private issues in progress counters')
                             ->visible(fn ($get) => $get('public_tracker_enabled') === true),
-                        Forms\Components\KeyValue::make('embed_domains')
+                        Forms\Components\Repeater::make('embed_domains')
                             ->label('Allowed embed parent origins (frame-ancestors)')
-                            ->keyLabel('index')->valueLabel('origin')
-                            ->visible(fn ($get) => $get('public_tracker_enabled') === true),
+                            ->schema([
+                                Forms\Components\TextInput::make('origin')
+                                    ->label('Origin')
+                                    ->required()
+                                    ->placeholder('https://example.com')
+                            ])
+                            ->addActionLabel('Add origin')
+                            ->visible(fn ($get) => $get('public_tracker_enabled') === true)
+                            ->columns(1),
                     ])->columns(2),
                 ]),
                 Grid::make(1)->schema([

--- a/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
+++ b/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
+++ b/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
@@ -25,8 +25,8 @@ class PublicProjectIssuesController extends Controller
             $escaped = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $s);
             $likePattern = "%{$escaped}%";
             $q->where(static function ($qq) use ($likePattern): void {
-                $qq->where('title', 'like', $likePattern, 'and', false)
-                   ->orWhere('key', 'like', $likePattern, 'and', false);
+                $qq->where('title', 'like', $likePattern)
+                   ->orWhere('key', 'like', $likePattern);
             });
         }
         return JsonResource::collection($q->limit(500)->get()->map(fn ($i) => [

--- a/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
+++ b/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
@@ -19,8 +19,12 @@ class PublicProjectIssuesController extends Controller
             ->where('project_id', $project->id)
             ->where('is_public', true);
 
-        if ($s = $request->string('q')->toString()) {
-            $q->where(static function ($qq) use ($s): void {
+            // Escape special LIKE characters
+            $escaped = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $s);
+            $likePattern = "%{$escaped}%";
+            $q->where(static function ($qq) use ($likePattern): void {
+                $qq->where('title', 'like', $likePattern, 'and', false)
+                   ->orWhere('key', 'like', $likePattern, 'and', false);
                 $qq->where('title', 'like', "%{$s}%")->orWhere('key', 'like', "%{$s}%");
             });
         }

--- a/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
+++ b/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Issue;
+use App\Models\Project;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PublicProjectIssuesController extends Controller
+{
+    public function index(Request $request, string $slug): JsonResource
+    {
+        $project = Project::query()->where('public_slug', $slug)->firstOrFail();
+        abort_unless($project->isPubliclyEmbeddable(), 404);
+
+        $q = Issue::query()->with(['status','type','assignee','tags'])
+            ->where('project_id', $project->id)
+            ->where('is_public', true);
+
+        if ($s = $request->string('q')->toString()) {
+            $q->where(static function ($qq) use ($s): void {
+                $qq->where('title', 'like', "%{$s}%")->orWhere('key', 'like', "%{$s}%");
+            });
+        }
+
+        return JsonResource::collection($q->limit(500)->get()->map(fn ($i) => [
+            'id' => (string) $i->id,
+            'title' => $i->title,
+            'status' => $i->status?->only(['id','name','is_done']),
+            'type' => $i->type?->only(['id','name']),
+            'assignee' => $i->assignee?->only(['id','name']),
+            'tags' => $i->tags?->pluck('name')->all() ?? [],
+        ]));
+    }
+}

--- a/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
+++ b/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
@@ -32,7 +32,7 @@ class PublicProjectIssuesController extends Controller
         return JsonResource::collection($q->limit(500)->get()->map(fn ($i) => [
             'id' => (string) $i->id,
             'title' => $i->summary,
-            'description'=> $i->description,
+            'description' => $i->description,
             'status' => $i->status?->only(['id','name','is_done']),
             'type' => $i->type?->only(['id','name']),
             'assignee' => $i->assignee?->only(['id','name']),

--- a/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
+++ b/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
@@ -15,7 +15,7 @@ class PublicProjectIssuesController extends Controller
         $project = Project::query()->where('public_slug', $slug)->firstOrFail();
         abort_unless($project->isPubliclyEmbeddable(), 404);
 
-        $q = Issue::query()->with(['status','type','assignee','tags'])
+        $q = Issue::query()->with(['status','type','assignee','tags', 'parent'])
             ->where('project_id', $project->id)
             ->where('is_public', true);
 
@@ -31,10 +31,17 @@ class PublicProjectIssuesController extends Controller
         }
         return JsonResource::collection($q->limit(500)->get()->map(fn ($i) => [
             'id' => (string) $i->id,
-            'title' => $i->title,
+            'title' => $i->summary,
+            'description'=> $i->description,
             'status' => $i->status?->only(['id','name','is_done']),
             'type' => $i->type?->only(['id','name']),
             'assignee' => $i->assignee?->only(['id','name']),
+            'parent_id' => $i->parent?->only(['id','summary']),
+            'progress_percent' => $i->progress_percent,
+            'children_count' => $i->children_count,
+            'children_done_count' => $i->children_done_count,
+            'children_points_total' => $i->children_points_total,
+            'children_points_done' => $i->children_points_done,
             'tags' => $i->tags?->pluck('name')->all() ?? [],
         ]));
     }

--- a/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
+++ b/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
@@ -19,16 +19,16 @@ class PublicProjectIssuesController extends Controller
             ->where('project_id', $project->id)
             ->where('is_public', true);
 
+        $s = $request->input('s');
+        if (!empty($s)) {
             // Escape special LIKE characters
             $escaped = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $s);
             $likePattern = "%{$escaped}%";
             $q->where(static function ($qq) use ($likePattern): void {
                 $qq->where('title', 'like', $likePattern, 'and', false)
                    ->orWhere('key', 'like', $likePattern, 'and', false);
-                $qq->where('title', 'like', "%{$s}%")->orWhere('key', 'like', "%{$s}%");
             });
         }
-
         return JsonResource::collection($q->limit(500)->get()->map(fn ($i) => [
             'id' => (string) $i->id,
             'title' => $i->title,

--- a/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
+++ b/app/Http/Controllers/Api/V1/PublicProjectIssuesController.php
@@ -20,7 +20,7 @@ class PublicProjectIssuesController extends Controller
             ->where('is_public', true);
 
         $s = $request->input('s');
-        if (!empty($s)) {
+        if (filled($s)) {
             // Escape special LIKE characters
             $escaped = str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $s);
             $likePattern = "%{$escaped}%";

--- a/app/Http/Middleware/AllowPublicEmbed.php
+++ b/app/Http/Middleware/AllowPublicEmbed.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Http\Middleware;
 
 use Closure;

--- a/app/Http/Middleware/AllowPublicEmbed.php
+++ b/app/Http/Middleware/AllowPublicEmbed.php
@@ -15,7 +15,7 @@ class AllowPublicEmbed
 
         if ($request->route()?->getName() === 'embed.projects.show') {
             /** @var array<int, string> $allow */
-            $allow = config('security.embed_allowlist', []); // wire this to Settings if you prefer
+            $allow = config('security.embed_allowlist', []);
             if (! empty($allow)) {
                 $response->headers->set('Content-Security-Policy', "frame-ancestors " . implode(' ', $allow));
             }

--- a/app/Http/Middleware/AllowPublicEmbed.php
+++ b/app/Http/Middleware/AllowPublicEmbed.php
@@ -1,0 +1,25 @@
+<?php
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AllowPublicEmbed
+{
+    /** @param Closure(Request):Response $next */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        if ($request->route()?->getName() === 'embed.projects.show') {
+            /** @var array<int, string> $allow */
+            $allow = config('security.embed_allowlist', []); // wire this to Settings if you prefer
+            if (! empty($allow)) {
+                $response->headers->set('Content-Security-Policy', "frame-ancestors " . implode(' ', $allow));
+            }
+        }
+
+        return $response;
+    }
+}

--- a/app/Livewire/Public/ProjectKanban.php
+++ b/app/Livewire/Public/ProjectKanban.php
@@ -95,11 +95,11 @@ class ProjectKanban extends Component
 
     private function applyFilters(\Illuminate\Database\Eloquent\Builder $query): \Illuminate\Database\Eloquent\Builder
     {
+        if (filled($this->search)) {
             $query->where(function ($q) {
                 $search = '%' . $this->search . '%';
                 $q->where('title', 'like', $search)
                   ->orWhere('key', 'like', $search);
-                    ->orWhere('key', 'like', '%' . $this->search . '%');
             });
         }
 

--- a/app/Livewire/Public/ProjectKanban.php
+++ b/app/Livewire/Public/ProjectKanban.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Livewire\Public;
 
 use App\Models\Issue;

--- a/app/Livewire/Public/ProjectKanban.php
+++ b/app/Livewire/Public/ProjectKanban.php
@@ -1,0 +1,118 @@
+<?php
+namespace App\Livewire\Public;
+
+use App\Models\Issue;
+use App\Models\IssueStatus;
+use App\Models\Project;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\Url;
+use Livewire\Component;
+
+#[Layout('layouts.blank')] // minimal chrome for embed; use your blank layout
+class ProjectKanban extends Component
+{
+    public Project $project;
+
+    #[Url(as: 'q')]
+    public ?string $search = null;
+
+    #[Url]
+    public array $status = []; // selected status IDs
+
+    #[Url]
+    public array $type = [];   // selected type IDs (if you have IssueType)
+
+    #[Url]
+    public ?string $assignee = null;
+
+    #[Url]
+    public bool $compact = false;
+
+    /** @var array<int, array{id:string,title:string,status_id:string|null,type_id:string|null,assignee?:array{ id:string,name:string},tags?:array<string>}> */
+    public array $columns = [];
+
+    public int $progress = 0;  // 0..100
+    public int $totalCount = 0;
+    public int $doneCount = 0;
+
+    public function mount(Project $project): void
+    {
+        abort_unless($project->isPubliclyEmbeddable(), 404);
+        $this->project = $project;
+    }
+
+    public function render(): View
+    {
+        // Build base queries
+        $base = Issue::query()
+            ->with(['status', 'type', 'assignee', 'tags'])
+            ->where('project_id', $this->project->id);
+
+        // Visible (public) set for display
+        $visible = (clone $base)->publicVisible();
+        $visible = $this->applyFilters($visible)->get();
+
+        // Columns by status
+        /** @var Collection<int, IssueStatus> $statuses */
+        $statuses = IssueStatus::query()
+            ->where(function ($q) {
+                $q->whereNull('project_id')->orWhere('project_id', $this->project->id);
+            })
+            ->orderBy('sort_order')
+            ->get();
+
+        $this->columns = $statuses->map(function (IssueStatus $s) use ($visible) {
+            $items = $visible->where('status_id', $s->id)->map(fn (Issue $i) => [
+                'id' => (string) $i->id,
+                'title' => $i->title,
+                'status_id' => (string) $i->status_id,
+                'type_id' => $i->type_id ? (string) $i->type_id : null,
+                'assignee' => $i->assignee ? ['id' => (string) $i->assignee->id, 'name' => $i->assignee->name] : null,
+                'tags' => $i->tags?->pluck('name')->all() ?? [],
+            ])->values()->all();
+
+            return [
+                'status' => ['id' => (string) $s->id, 'name' => $s->name, 'is_done' => (bool) $s->is_done],
+                'items' => $items,
+            ];
+        })->values()->all();
+
+        // Progress counters (optionally include private issues)
+        $countSource = $this->project->count_private_in_progress ? $base : (clone $base)->publicVisible();
+
+        $this->totalCount = (clone $countSource)->count();
+        $this->doneCount = (clone $countSource)
+            ->whereHas('status', static fn ($q) => $q->where('is_done', true))
+            ->count();
+
+        $this->progress = $this->totalCount > 0 ? (int) round(($this->doneCount / $this->totalCount) * 100) : 0;
+
+        return view('livewire.public.project-kanban');
+    }
+
+    private function applyFilters(\Illuminate\Database\Eloquent\Builder $query): \Illuminate\Database\Eloquent\Builder
+    {
+        if (filled($this->search)) {
+            $query->where(static function ($q): void {
+                $q->where('title', 'like', '%' . $this->search . '%')
+                    ->orWhere('key', 'like', '%' . $this->search . '%');
+            });
+        }
+
+        if (! empty($this->status)) {
+            $query->whereIn('status_id', $this->status);
+        }
+
+        if (! empty($this->type)) {
+            $query->whereIn('type_id', $this->type);
+        }
+
+        if (filled($this->assignee)) {
+            $query->where('assignee_id', $this->assignee);
+        }
+
+        return $query;
+    }
+}

--- a/app/Livewire/Public/ProjectKanban.php
+++ b/app/Livewire/Public/ProjectKanban.php
@@ -95,9 +95,10 @@ class ProjectKanban extends Component
 
     private function applyFilters(\Illuminate\Database\Eloquent\Builder $query): \Illuminate\Database\Eloquent\Builder
     {
-        if (filled($this->search)) {
-            $query->where(static function ($q): void {
-                $q->where('title', 'like', '%' . $this->search . '%')
+            $query->where(function ($q) {
+                $search = '%' . $this->search . '%';
+                $q->where('title', 'like', $search)
+                  ->orWhere('key', 'like', $search);
                     ->orWhere('key', 'like', '%' . $this->search . '%');
             });
         }

--- a/app/Models/Issue.php
+++ b/app/Models/Issue.php
@@ -5,8 +5,10 @@ namespace App\Models;
 use App\Support\ActivityContext;
 use App\Traits\HasExternalId;
 use App\Traits\IsPermissible;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -46,6 +48,7 @@ class Issue extends BaseModel implements HasMedia
         'summary',
         'starts_at',
         'due_at',
+        'is_public',
     ];
 
     protected $guarded = ['id', 'key', 'number'];
@@ -66,6 +69,7 @@ class Issue extends BaseModel implements HasMedia
         'starts_at' => 'immutable_datetime',
         'due_at'    => 'immutable_datetime',
         'closed_at' => 'immutable_datetime',
+        'is_public' => 'bool',
     ];
 
     public static function boot(): void
@@ -89,6 +93,16 @@ class Issue extends BaseModel implements HasMedia
                 $model->number = $model->number ?: $next;
                 $model->key = $model->key ?: "{$projectKey}-{$model->number}";
             }
+        });
+    }
+
+    protected static function booted(): void
+    {
+        static::saved(static function (Issue $i): void {
+            cache()->tags(['project-public-'.$i->project_id])->flush();
+        });
+        static::deleted(static function (Issue $i): void {
+            cache()->tags(['project-public-'.$i->project_id])->flush();
         });
     }
 
@@ -351,5 +365,11 @@ class Issue extends BaseModel implements HasMedia
             get: fn () => $this->issue_priority_id,
             set: static fn ($value) => ['issue_priority_id' => $value],
         );
+    }
+
+    /** @return Builder<Model, static> */
+    public function scopePublicVisible(Builder $query): Builder
+    {
+        return $query->where('is_public', true);
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -39,7 +39,10 @@ class Project extends BaseModel
         'started_at',
         'due_at',
         'ended_at',
-        'archived_at'
+        'archived_at',
+        'public_tracker_enabled',
+        'count_private_in_progress',
+        'embed_domains',
     ];
 
     protected $casts = [
@@ -52,6 +55,9 @@ class Project extends BaseModel
         'due_at' => 'datetime',
         'ended_at' => 'datetime',
         'archived_at' => 'datetime',
+        'public_tracker_enabled' => 'bool',
+        'count_private_in_progress' => 'bool',
+        'embed_domains' => 'array',
     ];
 
     protected $attributes = [
@@ -320,5 +326,10 @@ class Project extends BaseModel
     {
         $s = $this->stage;
         return $s instanceof ProjectStage ? $s->label() : ucfirst((string) ($s ?? ''));
+    }
+
+    public function isPubliclyEmbeddable(): bool
+    {
+        return $this->public_tracker_enabled && filled($this->public_slug);
     }
 }

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -43,6 +43,7 @@ class Project extends BaseModel
         'public_tracker_enabled',
         'count_private_in_progress',
         'embed_domains',
+        'public_slug',
     ];
 
     protected $casts = [
@@ -58,6 +59,7 @@ class Project extends BaseModel
         'public_tracker_enabled' => 'bool',
         'count_private_in_progress' => 'bool',
         'embed_domains' => 'array',
+        'public_slug' => 'string',
     ];
 
     protected $attributes = [

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\AllowPublicEmbed;
 use App\Http\Middleware\EnsureSupportIdentity;
 use App\Http\Middleware\SetPermissionsTeamContext;
 use App\Http\Middleware\VerifyIngestKey;
@@ -24,9 +25,12 @@ return Application::configure(basePath: dirname(__DIR__))
             'ingest.key' => VerifyIngestKey::class,
         ]);
         $middleware->group('api', [
-            EnsureFrontendRequestsAreStateful::class, // 👈 add this FIRST
+            EnsureFrontendRequestsAreStateful::class,
             'throttle:api',
             SubstituteBindings::class,
+        ]);
+        $middleware->group('embed', [
+            AllowPublicEmbed::class
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/config/security.php
+++ b/config/security.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    // e.g. ['https://helicalgames.net', 'https://*.helicalgames.net']
+    'embed_allowlist' => [
+        'localhost',
+    ],
+];

--- a/database/migrations/2025_09_25_194642_add_public_tracker_fields.php
+++ b/database/migrations/2025_09_25_194642_add_public_tracker_fields.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('projects', static function (Blueprint $table): void {
+            $table->boolean('public_tracker_enabled')->default(false)->after('description');
+            $table->string('public_slug')->nullable()->unique()->after('public_tracker_enabled');
+            $table->boolean('count_private_in_progress')->default(true)->after('public_slug');
+            $table->json('embed_domains')->nullable()->after('count_private_in_progress'); // allowlist for frame-ancestors
+        });
+
+        Schema::table('issues', static function (Blueprint $table): void {
+            $table->boolean('is_public')->default(false)->index()->after('project_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('issues', static function (Blueprint $table): void {
+            $table->dropColumn('is_public');
+        });
+
+        Schema::table('projects', static function (Blueprint $table): void {
+            $table->dropColumn(['public_tracker_enabled', 'public_slug', 'count_private_in_progress', 'embed_domains']);
+        });
+    }
+};

--- a/database/migrations/2025_09_25_194642_add_public_tracker_fields.php
+++ b/database/migrations/2025_09_25_194642_add_public_tracker_fields.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('projects', static function (Blueprint $table): void {

--- a/resources/views/layouts/blank.blade.php
+++ b/resources/views/layouts/blank.blade.php
@@ -1,0 +1,84 @@
+<div class="container py-3" x-data x-init="window.parent?.postMessage({type:'forge-embed-height', height: document.body.scrollHeight}, '*')">
+    <div class="d-flex align-items-center gap-3 mb-3">
+        <h2 class="h4 mb-0">{{ $project->name }}</h2>
+        <div class="ms-auto d-flex align-items-center gap-3">
+            <div class="progress" style="width: 220px;" title="Progress (done / total)">
+                <div class="progress-bar" role="progressbar" style="width: {{ $progress }}%;" aria-valuenow="{{ $progress }}" aria-valuemin="0" aria-valuemax="100">
+                    {{ $progress }}%
+                </div>
+            </div>
+            <small class="text-body-secondary">{{ $doneCount }} / {{ $totalCount }}</small>
+        </div>
+    </div>
+
+    {{-- Filters --}}
+    <div class="card mb-3">
+        <div class="card-body">
+            <div class="row g-2 align-items-end">
+                <div class="col-md-4">
+                    <label class="form-label">Search</label>
+                    <input type="text" class="form-control" wire:model.live.debounce.300ms="search" placeholder="Title or key…">
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Assignee</label>
+                    <input type="text" class="form-control" wire:model.live.debounce.300ms="assignee" placeholder="User ID (optional)">
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Compact</label><br>
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" role="switch" wire:model.live="compact" id="compactSwitch">
+                        <label class="form-check-label" for="compactSwitch">Enable compact cards</label>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    {{-- Kanban --}}
+    <div class="row g-3">
+        @foreach ($columns as $col)
+            <div class="col-12 col-md-6 col-lg-3">
+                <div class="border rounded">
+                    <div class="px-3 py-2 d-flex justify-content-between align-items-center" @class([
+                        'bg-light' => ! $col['status']['is_done'],
+                        'bg-success-subtle' => $col['status']['is_done'],
+                    ])>
+                        <strong>{{ $col['status']['name'] }}</strong>
+                        <span class="badge text-bg-secondary">{{ count($col['items']) }}</span>
+                    </div>
+                    <div class="p-2" style="min-height: 200px;">
+                        @forelse ($col['items'] as $it)
+                            <div class="card mb-2 @if($compact) small @endif">
+                                <div class="card-body py-2">
+                                    <div class="d-flex justify-content-between">
+                                        <div class="fw-medium text-truncate" title="{{ $it['title'] }}">{{ $it['title'] }}</div>
+                                        <div class="ms-2 text-body-secondary">{{ $it['id'] }}</div>
+                                    </div>
+                                    @if(!$compact)
+                                        <div class="mt-1 d-flex flex-wrap gap-1">
+                                            @foreach(($it['tags'] ?? []) as $tag)
+                                                <span class="badge text-bg-light">{{ $tag }}</span>
+                                            @endforeach
+                                        </div>
+                                        @if($it['assignee'])
+                                            <div class="mt-1 text-body-secondary">Assignee: {{ $it['assignee']['name'] }}</div>
+                                        @endif
+                                    @endif
+                                </div>
+                            </div>
+                        @empty
+                            <div class="text-center text-body-secondary py-4">No issues</div>
+                        @endforelse
+                    </div>
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    <script>
+        // Auto-resize support for embed iframes
+        const resize = () => window.parent?.postMessage({type:'forge-embed-height', height: document.body.scrollHeight}, '*');
+        new ResizeObserver(resize).observe(document.body);
+        window.addEventListener('load', resize);
+    </script>
+</div>

--- a/resources/views/pages/embed/projects/[slug].blade.php
+++ b/resources/views/pages/embed/projects/[slug].blade.php
@@ -1,0 +1,26 @@
+<?php
+use function Laravel\Folio\{name, render};
+use Illuminate\View\View;
+use App\Models\Project;
+
+name('embed.projects.show');
+
+render(function (View $view, string $slug) {
+    $project = Project::where('public_slug', $slug)->firstOrFail();
+    return $view->with('project', $project);
+});
+?>
+<!doctype html>
+<html lang="en" data-theme="{{ $theme }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="robots" content="noindex">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>{{ $project->name }} · Public Tracker</title>
+    @vite(['resources/css/app.css','resources/js/app.js'])
+    <style>html,body{background:transparent}</style>
+</head>
+<body class="bg-transparent">
+<livewire:public.project-kanban :project="$project" />
+</body>
+</html>

--- a/resources/views/pages/embed/projects/[slug].blade.php
+++ b/resources/views/pages/embed/projects/[slug].blade.php
@@ -1,7 +1,8 @@
 <?php
-use function Laravel\Folio\{name, render};
 use Illuminate\View\View;
 use App\Models\Project;
+
+use function Laravel\Folio\{name, render};
 
 name('embed.projects.show');
 

--- a/resources/views/pages/public/projects/[slug]/index.blade.php
+++ b/resources/views/pages/public/projects/[slug]/index.blade.php
@@ -1,0 +1,20 @@
+<?php
+use function Laravel\Folio\{name, render};
+use Illuminate\View\View;
+use App\Models\Project;
+
+name('public.projects.show');
+
+render(function (View $view, string $slug) {
+    $project = Project::where('public_slug', $slug)->firstOrFail();
+    return $view->with('project', $project);
+});
+?>
+
+<x-guest-layout>
+    <x-slot name="header">
+        <h1 class="h4 mb-0">Public Tracker: {{ $project->name }}</h1>
+    </x-slot>
+
+    <livewire:public.project-kanban :project="$project" />
+</x-guest-layout>

--- a/resources/views/pages/public/projects/[slug]/index.blade.php
+++ b/resources/views/pages/public/projects/[slug]/index.blade.php
@@ -1,7 +1,8 @@
 <?php
-use function Laravel\Folio\{name, render};
 use Illuminate\View\View;
 use App\Models\Project;
+
+use function Laravel\Folio\{name, render};
 
 name('public.projects.show');
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -12,12 +12,15 @@ Route::get('/user', static function (Request $request) {
 Route::post('/webhooks/github', [GitHubWebhookController::class, 'handle'])
     ->name('webhooks.github');
 
-
 Route::prefix('v1')->name('api.v1.')->group(function () {
     // Public (throttled) ingest; optionally protect with 'ingest.key' later.
     Route::post('tickets', [V1\TicketController::class, 'store'])
         ->name('tickets.store')
         ->middleware(['ingest.key', 'throttle:ticket-ingest']);
+
+    Route::get('/public/projects/{slug}/issues', [V1\PublicProjectIssuesController::class, 'index'])
+        ->name('public.projects.issues')
+        ->middleware('throttle:60,1');
 });
 
 Route::prefix('v1')->middleware(['auth:sanctum', 'throttle:api'])->group(function (): void {


### PR DESCRIPTION
This feature introduces a public tracker for projects, including a Kanban board view that can be embedded into external websites. Key changes include enhancements to models, middleware, and APIs, alongside new database migrations to support public and embed-related attributes.

## Summary by Sourcery

Add a public project tracker with an embeddable Kanban board view, including administrative controls, public API endpoint, and CSP-enabled embed support

New Features:
- Add admin controls to enable a public tracker, set unique slug, configure counters, and whitelist embed domains
- Expose a throttled public API endpoint to fetch a project’s public issues by slug
- Implement a Livewire Kanban board component with filters, progress counters, and a blank layout for embedding
- Register embed routes and middleware to apply frame-ancestors CSP headers

Enhancements:
- Extend Issue and Project models with is_public flags, public visibility scopes, embeddability checks, and automatic cache invalidation
- Create database migrations for public tracker fields on projects and public flags on issues
- Add a security config for embed allowlist