### PR TITLE
Push to Production for Pre-Alpha Release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -108,3 +108,8 @@ ATLASSIAN_CLIENT_SECRET=
 ATLASSIAN_REDIRECT_URI=${APP_URL}/auth/atlassian/link/callback
 
 SOCIALITE_PROVIDERS=github,gitlab,gitea,discord,todoist,atlassian
+
+SELF_UPDATER_VERSION_INSTALLED=0.1.0
+SELF_UPDATER_REPO_VENDOR=crimsonstrife
+SELF_UPDATER_REPO_NAME=forge
+SELF_UPDATER_PACKAGE_FILE_NAME=regex:forge-.*\.zip

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ yarn-error.log
 forge.code-workspace
 .DS_Store
 /public/plugins/*
+/VERSION

--- a/app/Console/Commands/AppVersionCommand.php
+++ b/app/Console/Commands/AppVersionCommand.php
@@ -6,9 +6,7 @@ use Illuminate\Console\Command;
 
 class AppVersionCommand extends Command
 {
-    protected $signature = 'app:version
-        {action : read|write}
-        {--value= : Version value to write (for write action)}';
+    protected $signature = 'app:version {action : read|write} {--value= : Version value to write (for write action)}';
 
     protected $description = 'Read or write the application VERSION file';
 

--- a/app/Console/Commands/AppVersionCommand.php
+++ b/app/Console/Commands/AppVersionCommand.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class AppVersionCommand extends Command
+{
+    protected $signature = 'app:version
+        {action : read|write}
+        {--value= : Version value to write (for write action)}';
+
+    protected $description = 'Read or write the application VERSION file';
+
+    public function handle(): int
+    {
+        $path = base_path('VERSION');
+
+        if ($this->argument('action') === 'read') {
+            $this->line(is_file($path) ? trim((string) @file_get_contents($path)) : 'VERSION not found');
+            return self::SUCCESS;
+        }
+
+        if ($this->argument('action') === 'write') {
+            $value = (string) $this->option('value');
+            if ($value === '') {
+                $this->error('Please provide --value="<semver>"');
+                return self::INVALID;
+            }
+
+            file_put_contents($path, trim($value) . PHP_EOL);
+            $this->info("Wrote VERSION: {$value}");
+            return self::SUCCESS;
+        }
+
+        $this->error('Unknown action. Use read|write.');
+        return self::INVALID;
+    }
+}

--- a/app/Console/Commands/AppVersionCommand.php
+++ b/app/Console/Commands/AppVersionCommand.php
@@ -6,41 +6,71 @@ use Illuminate\Console\Command;
 
 class AppVersionCommand extends Command
 {
-    protected $signature = 'app:version {action : read|write} {--value= : Version value to write (for write action)}';
+    const SUCCESS = 0;
+    const FAILURE = 1;
+    const INVALID = 2;
 
+    protected $signature = 'app:version {action : read|write} {--value= : Version value to write (for write action)}';
     protected $description = 'Read or write the application VERSION file';
 
     public function handle(): int
     {
         $path = base_path('VERSION');
+        $action = $this->argument('action');
 
-        if ($this->argument('action') === 'read') {
-            $this->line(is_file($path) ? trim((string) @file_get_contents($path)) : 'VERSION not found');
-            return self::SUCCESS;
-            if (is_file($path)) {
-                $contents = file_get_contents($path);
-                if ($contents === false) {
-                    $this->error('Failed to read VERSION file.');
-                    return self::FAILURE;
-                }
-                $this->line(trim((string) $contents));
-            } else {
-                $this->line('VERSION not found');
-            }
+        if (!in_array($action, ['read', 'write'], true)) {
+            $this->error('Invalid action. Use "read" or "write".');
+            return self::INVALID;
+        }
 
-        if ($this->argument('action') === 'write') {
-            $value = (string) $this->option('value');
-            if ($value === '') {
-                $this->error('Please provide --value="<semver>"');
-                return self::INVALID;
-            }
+        if ($action === 'read') {
+            return $this->readVersion($path);
+        }
 
-            file_put_contents($path, trim($value) . PHP_EOL);
-            $this->info("Wrote VERSION: {$value}");
+        if ($action === 'write') {
+            return $this->writeVersion($path);
+        }
+
+        return self::INVALID;
+    }
+
+    private function readVersion(string $path): int
+    {
+        if (!is_file($path)) {
+            $this->line('VERSION not found');
             return self::SUCCESS;
         }
 
-        $this->error('Unknown action. Use read|write.');
-        return self::INVALID;
+        try {
+            $contents = file_get_contents($path);
+        } catch (\Exception $e) {
+            $this->error('Failed to read VERSION file: ' . $e->getMessage());
+            return self::FAILURE;
+        }
+
+        $this->line(trim($contents));
+        return self::SUCCESS;
+    }
+
+    private function writeVersion(string $path): int
+    {
+        $value = (string) $this->option('value');
+        if ($value === '') {
+            $this->error('Please provide --value="<semver>".');
+            return self::INVALID;
+        }
+
+        if (!preg_match('/^\d+\.\d+\.\d+$/', $value)) {
+            $this->error('Invalid version format. Use semantic versioning (e.g., 1.2.3).');
+            return self::INVALID;
+        }
+
+        if (file_put_contents($path, trim($value) . PHP_EOL) === false) {
+            $this->error('Failed to write to VERSION file.');
+            return self::FAILURE;
+        }
+
+        $this->info("Wrote VERSION: {$value}");
+        return self::SUCCESS;
     }
 }

--- a/app/Console/Commands/AppVersionCommand.php
+++ b/app/Console/Commands/AppVersionCommand.php
@@ -17,7 +17,16 @@ class AppVersionCommand extends Command
         if ($this->argument('action') === 'read') {
             $this->line(is_file($path) ? trim((string) @file_get_contents($path)) : 'VERSION not found');
             return self::SUCCESS;
-        }
+            if (is_file($path)) {
+                $contents = file_get_contents($path);
+                if ($contents === false) {
+                    $this->error('Failed to read VERSION file.');
+                    return self::FAILURE;
+                }
+                $this->line(trim((string) $contents));
+            } else {
+                $this->line('VERSION not found');
+            }
 
         if ($this->argument('action') === 'write') {
             $value = (string) $this->option('value');

--- a/app/Console/Commands/AppVersionCommand.php
+++ b/app/Console/Commands/AppVersionCommand.php
@@ -6,9 +6,9 @@ use Illuminate\Console\Command;
 
 class AppVersionCommand extends Command
 {
-    const SUCCESS = 0;
-    const FAILURE = 1;
-    const INVALID = 2;
+    public const SUCCESS = 0;
+    public const FAILURE = 1;
+    public const INVALID = 2;
 
     protected $signature = 'app:version {action : read|write} {--value= : Version value to write (for write action)}';
     protected $description = 'Read or write the application VERSION file';

--- a/app/Console/Commands/CheckForAppUpdate.php
+++ b/app/Console/Commands/CheckForAppUpdate.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\SelfUpdateService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class CheckForAppUpdate extends Command
+{
+    protected $signature = 'app:update:check';
+    protected $description = 'Check for a newer app version and log a notice if found';
+
+    public function __construct(private SelfUpdateService $updates) { parent::__construct(); }
+
+    public function handle(): int
+    {
+        $current = config('self-update.version_installed'); // or settings
+        $available = $this->updates->isUpdateAvailable($current);
+
+        if ($available) {
+            $this->info('New version available.');
+            Log::info('SelfUpdate: new version available', ['current' => $current]);
+            // TODO: Dispatch notification to admin users/Slack/email here.
+        } else {
+            $this->line('No updates found.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/CheckForAppUpdate.php
+++ b/app/Console/Commands/CheckForAppUpdate.php
@@ -15,7 +15,7 @@ class CheckForAppUpdate extends Command
     {
         parent::__construct();
     }
-
+        $current = $this->updates->currentVersion();
     public function handle(): int
     {
         $current = config('self-update.version_installed'); // or settings

--- a/app/Console/Commands/CheckForAppUpdate.php
+++ b/app/Console/Commands/CheckForAppUpdate.php
@@ -15,7 +15,6 @@ class CheckForAppUpdate extends Command
     {
         parent::__construct();
     }
-        $current = $this->updates->currentVersion();
     public function handle(): int
     {
         $current = $this->updates->currentVersion();

--- a/app/Console/Commands/CheckForAppUpdate.php
+++ b/app/Console/Commands/CheckForAppUpdate.php
@@ -11,7 +11,10 @@ class CheckForAppUpdate extends Command
     protected $signature = 'app:update:check';
     protected $description = 'Check for a newer app version and log a notice if found';
 
-    public function __construct(private SelfUpdateService $updates) { parent::__construct(); }
+    public function __construct(private SelfUpdateService $updates)
+    {
+        parent::__construct();
+    }
 
     public function handle(): int
     {

--- a/app/Console/Commands/CheckForAppUpdate.php
+++ b/app/Console/Commands/CheckForAppUpdate.php
@@ -18,7 +18,7 @@ class CheckForAppUpdate extends Command
         $current = $this->updates->currentVersion();
     public function handle(): int
     {
-        $current = config('self-update.version_installed'); // or settings
+        $current = $this->updates->currentVersion();
         $available = $this->updates->isUpdateAvailable($current);
 
         if ($available) {

--- a/app/Filament/Pages/SystemUpdates.php
+++ b/app/Filament/Pages/SystemUpdates.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Services\SelfUpdateService;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Pages\Page;
+use Filament\Support\Icons\Heroicon;
+
+class SystemUpdates extends Page
+{
+    protected static string|null|\BackedEnum $navigationIcon = Heroicon::OutlinedArrowPath;
+    protected static string|null|\UnitEnum $navigationGroup = 'Settings';
+    protected static ?string $title = 'System Updates';
+    protected string $view = 'filament.pages.system-updates';
+
+    public string $currentVersion = '0.1.0';
+    public bool $updateAvailable = false;
+
+    public function mount(SelfUpdateService $updates): void
+    {
+        $this->currentVersion  = $updates->currentVersion();
+        $this->updateAvailable = $updates->isUpdateAvailable($this->currentVersion);
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('check')
+                ->label('Check for Updates')
+                ->icon(Heroicon::ArrowPath)
+                ->color('gray')
+                ->action(function (SelfUpdateService $updates): void {
+                    $this->currentVersion  = $updates->currentVersion();
+                    $this->updateAvailable = $updates->isUpdateAvailable($this->currentVersion);
+
+                    if ($this->updateAvailable) {
+                        Notification::make()
+                            ->title('Update available.')
+                            ->success()
+                            ->send();
+                    } else {
+                        Notification::make()
+                            ->title('You are up to date.')
+                            ->color('gray')
+                            ->send();
+                    }
+                }),
+
+            Action::make('updateNow')
+                ->label('Update Now')
+                ->icon(Heroicon::CloudArrowDown)
+                ->color('primary')
+                ->requiresConfirmation()
+                ->disabled(fn (): bool => ! $this->updateAvailable)
+                ->action(function (SelfUpdateService $updates): void {
+                    $current = $updates->currentVersion();
+                    $result  = $updates->runUpdate($current);
+
+                    if (! $result['success']) {
+                        Notification::make()
+                            ->title($result['error'] ?? 'Update failed.')
+                            ->danger()
+                            ->send();
+
+                        // Refresh state after failure
+                        $this->currentVersion  = $updates->currentVersion();
+                        $this->updateAvailable = $updates->isUpdateAvailable($this->currentVersion);
+                        return;
+                    }
+
+                    // Success path
+                    $new = $result['newVersion'] ?? $updates->currentVersion();
+
+                    Notification::make()
+                        ->title("Updated successfully to {$new}.")
+                        ->success()
+                        ->send();
+
+                    $this->currentVersion  = $new;
+                    $this->updateAvailable = false;
+                }),
+        ];
+    }
+}

--- a/app/Http/Controllers/Admin/UpdateController.php
+++ b/app/Http/Controllers/Admin/UpdateController.php
@@ -8,7 +8,9 @@ use Illuminate\Http\JsonResponse;
 
 class UpdateController extends Controller
 {
-    public function __construct(private SelfUpdateService $selfUpdate) {}
+    public function __construct(private SelfUpdateService $selfUpdate)
+    {
+    }
 
     public function check(): JsonResponse
     {

--- a/app/Http/Controllers/Admin/UpdateController.php
+++ b/app/Http/Controllers/Admin/UpdateController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Services\SelfUpdateService;
+use Illuminate\Http\JsonResponse;
+
+class UpdateController extends Controller
+{
+    public function __construct(private SelfUpdateService $selfUpdate) {}
+
+    public function check(): JsonResponse
+    {
+        $current = $this->selfUpdate->currentVersion();
+
+        return response()->json([
+            'current' => $current,
+            'updateAvailable' => $this->selfUpdate->isUpdateAvailable($current),
+        ]);
+    }
+
+    public function run(): JsonResponse
+    {
+        $current = $this->selfUpdate->currentVersion();
+        $result = $this->selfUpdate->runUpdate($current);
+
+        return response()->json($result, $result['success'] ? 200 : 422);
+    }
+}

--- a/app/Services/SelfUpdateService.php
+++ b/app/Services/SelfUpdateService.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Services;
+
+use Codedge\Updater\UpdaterManager;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * @phpstan-type UpdateResult array{
+ *   success: bool,
+ *   newVersion?: string|null,
+ *   message?: string|null,
+ *   error?: string|null
+ * }
+ */
+class SelfUpdateService
+{
+    public function __construct(
+        private UpdaterManager $updater,
+        private Dispatcher $events,
+    ) {}
+
+    /**
+     * Check if a newer version than $currentVersion exists.
+     */
+    public function isUpdateAvailable(string $currentVersion): bool
+    {
+        return $this->updater->source()->isNewVersionAvailable($currentVersion);
+    }
+
+    /**
+     * Run the update. Returns a structured array result.
+     *
+     * @param string $currentVersion
+     * @param array{package_file_name?: string|null} $options
+     * @return UpdateResult
+     */
+    public function runUpdate(string $currentVersion, array $options = []): array
+    {
+        // Optionally override which asset to fetch (helps for "pick a version").
+        if (! empty($options['package_file_name'])) {
+            Config::set(
+                'self-update.repository_types.github.package_file_name',
+                $options['package_file_name']
+            );
+        }
+
+        // Basic preflight: dirs + zip extension present.
+        if (! extension_loaded('zip')) {
+            return ['success' => false, 'error' => 'The PHP zip extension is not enabled.'];
+        }
+
+        try {
+            // Maintenance mode with a simple render (optional blade view).
+            Artisan::call('down', ['--render' => 'errors::maintenance']);
+
+            // Double-check availability right before updating.
+            if (! $this->updater->source()->isNewVersionAvailable($currentVersion)) {
+                Artisan::call('up');
+                return ['success' => false, 'message' => 'Already up to date.'];
+            }
+
+            $ok = $this->updater->update(); // download + extract + mirror
+            if (! $ok) {
+                Artisan::call('up');
+                return ['success' => false, 'error' => 'Updater returned false (mirroring or extraction failed). Check storage/app/self-updater and permissions.'];
+            }
+
+            // Post-update: database & caches (adjust to your app’s needs).
+            Artisan::call('migrate', ['--force' => true]);
+            Artisan::call('optimize:clear');
+            Artisan::call('view:cache');
+            Artisan::call('config:cache');
+
+            // After a successful update:
+            $new = $this->detectNewVersion();
+            $this->persistInstalledVersion($new);
+
+            Artisan::call('up');
+
+            return [
+                'success' => true,
+                'newVersion' => $this->detectNewVersion(),
+                'message' => 'Application updated successfully.',
+            ];
+        } catch (Throwable $e) {
+            Log::error('SelfUpdate failed', [
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+
+            // Ensure app is back up even on error.
+            try { Artisan::call('up'); } catch (Throwable) {}
+
+            return ['success' => false, 'error' => $e->getMessage()];
+        }
+    }
+
+    /**
+     * Best-effort way to read the just-installed version (override as needed).
+     * - Tag name from RELEASE file, VERSION file, or your own config/Settings.
+     */
+    private function detectNewVersion(): ?string
+    {
+        // Prefer a VERSION file you write during packaging:
+        $path = base_path('VERSION');
+        if (is_file($path)) {
+            return trim((string) @file_get_contents($path)) ?: null;
+        }
+
+        // Or fall back to env/config if that’s your pattern:
+        $v = config('self-update.version_installed');
+        return is_string($v) ? $v : null;
+    }
+
+    /**
+     * Resolve the current installed version.
+     * Priority: VERSION file > SystemSettings.installed_version > config/env.
+     */
+    public function currentVersion(): string
+    {
+        $fromFile = $this->detectNewVersion();
+        if (is_string($fromFile) && $fromFile !== '') {
+            return $fromFile;
+        }
+
+        if (class_exists(\App\Settings\SystemSettings::class)) {
+            /** @var \App\Settings\SystemSettings $settings */
+            $settings = app(\App\Settings\SystemSettings::class);
+            if (is_string($settings->installed_version) && $settings->installed_version !== '') {
+                return $settings->installed_version;
+            }
+        }
+
+        $v = config('self-update.version_installed');
+        return is_string($v) && $v !== '' ? $v : '0.1.0';
+    }
+
+    /**
+     * Persist the installed version post-update (prefer Settings).
+     */
+    private function persistInstalledVersion(?string $version): void
+    {
+        if (! is_string($version) || $version === '') {
+            return;
+        }
+
+        if (class_exists(\App\Settings\SystemSettings::class)) {
+            /** @var \App\Settings\SystemSettings $settings */
+            $settings = app(\App\Settings\SystemSettings::class);
+            $settings->installed_version = $version;
+            $settings->save();
+            return;
+        }
+
+        // Optional: also mirror to config() so the app reflects it immediately.
+        config()->set('self-update.version_installed', $version);
+    }
+}

--- a/app/Services/SelfUpdateService.php
+++ b/app/Services/SelfUpdateService.php
@@ -113,7 +113,11 @@ class SelfUpdateService
         // Prefer a VERSION file you write during packaging:
         $path = base_path('VERSION');
         if (is_file($path)) {
-            return trim((string) @file_get_contents($path)) ?: null;
+            $contents = file_get_contents($path);
+            if ($contents === false) {
+                return null;
+            }
+            return trim((string) $contents) ?: null;
         }
 
         // Or fall back to env/config if that’s your pattern:

--- a/app/Services/SelfUpdateService.php
+++ b/app/Services/SelfUpdateService.php
@@ -85,7 +85,7 @@ class SelfUpdateService
 
             return [
                 'success' => true,
-                'newVersion' => $this->detectNewVersion(),
+                'newVersion' => $new,
                 'message' => 'Application updated successfully.',
             ];
         } catch (Throwable $e) {

--- a/app/Services/SelfUpdateService.php
+++ b/app/Services/SelfUpdateService.php
@@ -22,7 +22,8 @@ class SelfUpdateService
     public function __construct(
         private UpdaterManager $updater,
         private Dispatcher $events,
-    ) {}
+    ) {
+    }
 
     /**
      * Check if a newer version than $currentVersion exists.
@@ -94,7 +95,10 @@ class SelfUpdateService
             ]);
 
             // Ensure app is back up even on error.
-            try { Artisan::call('up'); } catch (Throwable) {}
+            try {
+                Artisan::call('up');
+            } catch (Throwable) {
+            }
 
             return ['success' => false, 'error' => $e->getMessage()];
         }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "ashallendesign/short-url": "^8.3",
         "blaspsoft/blasp": "^2.1",
         "calebporzio/sushi": "^2.5",
+        "codedge/laravel-selfupdater": "^3.10",
         "dedoc/scramble": "^0.12.34",
         "doctrine/dbal": "^4.3",
         "filament/filament": "^4.0",
@@ -131,7 +132,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "phpstan/extension-installer": true
         }
     },
     "minimum-stability": "stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d03b85363ce0d6a1cdac209e7a0cea5",
+    "content-hash": "164a4552a1c4a2a17a79b472e1f9a858",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -960,6 +960,79 @@
                 }
             ],
             "time": "2025-01-03T16:18:33+00:00"
+        },
+        {
+            "name": "codedge/laravel-selfupdater",
+            "version": "3.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://codeberg.org/codedge/laravel-selfupdater",
+                "reference": "021acbe86a2d4823bf19e57cbf5c1aea20c1bdd4"
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-zip": "*",
+                "guzzlehttp/guzzle": "^7.5.0",
+                "illuminate/support": "^10 || ^11.0 || ^12.0",
+                "league/uri": "~6.7 || ~6.8 || ^7.4",
+                "php": "^8.1",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.2 || ^2.0"
+            },
+            "require-dev": {
+                "dg/bypass-finals": "^1.4",
+                "mikey179/vfsstream": "^1.6",
+                "mockery/mockery": "^1.5",
+                "orchestra/testbench": "^8.1 || ^9.0 || ^10.0",
+                "phpunit/phpunit": "^9.5.26 || ^10.5 || ^11.5.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Updater": "Codedge\\Updater\\UpdaterFacade"
+                    },
+                    "providers": [
+                        "Codedge\\Updater\\UpdaterServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Codedge\\Updater\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Holger Lösken",
+                    "email": "holger.loesken@codedge.de",
+                    "homepage": "https://codedge.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Providing an auto-updating functionality for your self-hosted Laravel application.",
+            "keywords": [
+                "auto update",
+                "auto-update",
+                "laravel",
+                "laravel application",
+                "self update",
+                "self-hosted laravel application",
+                "self-update",
+                "update"
+            ],
+            "support": {
+                "issues": "https://github.com/codedge/laravel-selfupdater/issues",
+                "source": "https://github.com/codedge/laravel-selfupdater"
+            },
+            "time": "2025-02-26T12:27:31+00:00"
         },
         {
             "name": "composer/semver",
@@ -8094,6 +8167,54 @@
             "time": "2025-06-26T16:29:55+00:00"
         },
         {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
+            },
+            "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
             "name": "phpstan/phpdoc-parser",
             "version": "2.3.0",
             "source": {
@@ -8139,6 +8260,117 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
             },
             "time": "2025-08-30T15:50:23+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.28",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "578fa296a166605d97b94091f724f1257185d278"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/578fa296a166605d97b94091f724f1257185d278",
+                "reference": "578fa296a166605d97b94091f724f1257185d278",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-09-19T08:58:49+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "2.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "9a9b161baee88a5f5c58d816943cff354ff233dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/9a9b161baee88a5f5c58d816943cff354ff233dc",
+                "reference": "9a9b161baee88a5f5c58d816943cff354ff233dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpstan": "^2.1.18"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^5",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/2.0.7"
+            },
+            "time": "2025-07-13T11:31:46+00:00"
         },
         {
             "name": "pragmarx/google2fa",
@@ -16746,64 +16978,6 @@
             "time": "2022-02-21T01:04:05+00:00"
         },
         {
-            "name": "phpstan/phpstan",
-            "version": "2.1.28",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "578fa296a166605d97b94091f724f1257185d278"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/578fa296a166605d97b94091f724f1257185d278",
-                "reference": "578fa296a166605d97b94091f724f1257185d278",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.4|^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan-shim": "*"
-            },
-            "bin": [
-                "phpstan",
-                "phpstan.phar"
-            ],
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHPStan - PHP Static Analysis Tool",
-            "keywords": [
-                "dev",
-                "static analysis"
-            ],
-            "support": {
-                "docs": "https://phpstan.org/user-guide/getting-started",
-                "forum": "https://github.com/phpstan/phpstan/discussions",
-                "issues": "https://github.com/phpstan/phpstan/issues",
-                "security": "https://github.com/phpstan/phpstan/security/policy",
-                "source": "https://github.com/phpstan/phpstan-src"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/ondrejmirtes",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/phpstan",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-09-19T08:58:49+00:00"
-        },
-        {
             "name": "phpunit/php-code-coverage",
             "version": "11.0.11",
             "source": {
@@ -19324,6 +19498,6 @@
         "ext-mbstring": "*",
         "ext-zip": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/config/self-update.php
+++ b/config/self-update.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default source repository type
+    |--------------------------------------------------------------------------
+    |
+    | The default source repository type you want to pull your updates from.
+    |
+    */
+
+    'default' => env('SELF_UPDATER_SOURCE', 'github'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Version installed
+    |--------------------------------------------------------------------------
+    |
+    | Set this to the version of your software installed on your system.
+    |
+    */
+
+    'version_installed' => env('SELF_UPDATER_VERSION_INSTALLED', '0.1.0'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Repository types
+    |--------------------------------------------------------------------------
+    |
+    | A repository can be of different types, which can be specified here.
+    | Current options:
+    | - github
+    | - gitlab
+    | - http
+    |
+    */
+
+    'repository_types' => [
+        'github' => [
+            'type'                 => 'github',
+            'repository_vendor'    => env('SELF_UPDATER_REPO_VENDOR', ''),
+            'repository_name'      => env('SELF_UPDATER_REPO_NAME', ''),
+            'repository_url'       => '',
+            'download_path'        => storage_path('app/self-updater'),
+            'temp_path'            => storage_path('app/self-updater/temp'),
+            'private_access_token' => env('SELF_UPDATER_GITHUB_PRIVATE_ACCESS_TOKEN', ''),
+            'use_branch'           => env('SELF_UPDATER_USE_BRANCH', ''),
+            'package_file_name'    => env('SELF_UPDATER_PACKAGE_FILE_NAME'),
+        ],
+        'gitlab' => [
+            'base_url'             => '',
+            'type'                 => 'gitlab',
+            'repository_id'        => env('SELF_UPDATER_REPO_URL', ''),
+            'download_path'        => env('SELF_UPDATER_DOWNLOAD_PATH', '/tmp'),
+            'private_access_token' => env('SELF_UPDATER_GITLAB_PRIVATE_ACCESS_TOKEN', ''),
+        ],
+        'http' => [
+            'type'                 => 'http',
+            'repository_url'       => env('SELF_UPDATER_REPO_URL', ''),
+            'pkg_filename_format'  => env('SELF_UPDATER_PKG_FILENAME_FORMAT', 'v_VERSION_'),
+            'download_path'        => env('SELF_UPDATER_DOWNLOAD_PATH', '/tmp'),
+            'private_access_token' => env('SELF_UPDATER_HTTP_PRIVATE_ACCESS_TOKEN', ''),
+        ],
+        'gitea' => [
+            'type'                 => 'gitea',
+            'repository_vendor'    => env('SELF_UPDATER_REPO_VENDOR', ''),
+            'gitea_url'            => env('SELF_UPDATER_GITEA_URL', ''),
+            'repository_name'      => env('SELF_UPDATER_REPO_NAME', ''),
+            'download_path'        => env('SELF_UPDATER_DOWNLOAD_PATH', '/tmp'),
+            'private_access_token' => env('SELF_UPDATER_GITEA_PRIVATE_ACCESS_TOKEN', ''),
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Exclude folders from update
+    |--------------------------------------------------------------------------
+    |
+    | Specific folders which should not be updated and will be skipped during the
+    | update process.
+    |
+    | Here's already a list of good examples to skip. You may want to keep those.
+    |
+    */
+
+    'exclude_folders' => [
+        '__MACOSX',
+        'node_modules',
+        'bootstrap/cache',
+        'bower',
+        'storage/app',
+        'storage/framework',
+        'storage/logs',
+        'storage/self-update',
+        'vendor',
+        '.env',
+        'storage/*',
+        'bootstrap/cache/*',
+        'vendor/*',
+        'node_modules/*',
+        'public/storage',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Download Timeout
+    |--------------------------------------------------------------------------
+    |
+    | Specifies the duration (in seconds) for how long downloads can take
+    | until they timeout.
+    |
+    */
+
+    'download_timeout' => env('SELF_UPDATER_DOWNLOAD_TIMEOUT', 400),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Event Logging
+    |--------------------------------------------------------------------------
+    |
+    | Configure if fired events should be logged
+    |
+    */
+
+    'log_events' => env('SELF_UPDATER_LOG_EVENTS', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Notifications
+    |--------------------------------------------------------------------------
+    |
+    | Specify for which events you want to get notifications. Out of the box you can use 'mail'.
+    |
+    */
+
+    'notifications' => [
+        'notifications' => [
+            \Codedge\Updater\Notifications\Notifications\UpdateSucceeded::class => ['mail'],
+            \Codedge\Updater\Notifications\Notifications\UpdateFailed::class    => ['mail'],
+            \Codedge\Updater\Notifications\Notifications\UpdateAvailable::class => ['mail'],
+        ],
+
+        /*
+         * Here you can specify the notifiable to which the notifications should be sent. The default
+         * notifiable will use the variables specified in this config file.
+         */
+        'notifiable' => \Codedge\Updater\Notifications\Notifiable::class,
+
+        'mail' => [
+            'to' => [
+                'address' => env('SELF_UPDATER_MAILTO_ADDRESS', 'notifications@example.com'),
+                'name'    => env('SELF_UPDATER_MAILTO_NAME', ''),
+            ],
+
+            'from' => [
+                'address' => env('SELF_UPDATER_MAIL_FROM_ADDRESS', 'updater@example.com'),
+                'name'    => env('SELF_UPDATER_MAIL_FROM_NAME', 'Update'),
+            ],
+        ],
+    ],
+
+    /*
+    |---------------------------------------------------------------------------
+    | Register custom artisan commands
+    |---------------------------------------------------------------------------
+    */
+
+    'artisan_commands' => [
+        'pre_update' => [
+            //'command:signature' => [
+            //    'class' => Command class
+            //    'params' => []
+            //]
+        ],
+        'post_update' => [
+
+        ],
+    ],
+
+];

--- a/resources/views/filament/pages/system-updates.blade.php
+++ b/resources/views/filament/pages/system-updates.blade.php
@@ -1,0 +1,11 @@
+<x-filament::page>
+    <div class="fi-section rounded-xl border p-6">
+        <h2 class="text-lg font-semibold">Current Version</h2>
+        <p class="text-2xl font-bold mt-1">{{ $currentVersion }}</p>
+        @if ($updateAvailable)
+            <p class="mt-2 text-amber-600">A new update is available.</p>
+        @else
+            <p class="mt-2 text-emerald-600">You are up to date.</p>
+        @endif
+    </div>
+</x-filament::page>

--- a/resources/views/vendor/self-update/mails/update-available.blade.php
+++ b/resources/views/vendor/self-update/mails/update-available.blade.php
@@ -1,0 +1,5 @@
+Hello!
+
+The new version {{ $newVersion }} is available.
+
+Kind regards

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,21 @@
 <?php
 
+use App\Console\Commands\CheckForAppUpdate;
+use App\Console\Commands\RecalcIssueRollups;
+use App\Console\Commands\SyncRepositoryIssues;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+
+Schedule::command(CheckForAppUpdate::class)
+    ->dailyAt('09:00');
+
+Schedule::command(SyncRepositoryIssues::class)
+    ->everyFifteenMinutes();
+
+Schedule::command(RecalcIssueRollups::class)
+    ->everyFiveMinutes();

--- a/routes/console.php
+++ b/routes/console.php
@@ -5,6 +5,7 @@ use App\Console\Commands\RecalcIssueRollups;
 use App\Console\Commands\SyncRepositoryIssues;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());

--- a/routes/console.php
+++ b/routes/console.php
@@ -11,7 +11,6 @@ Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
 
-
 Schedule::command(CheckForAppUpdate::class)
     ->dailyAt('09:00');
 


### PR DESCRIPTION
## Summary by Sourcery

Enable pre-alpha production readiness by implementing a full self-update system—including configuration, services, UI, API, console commands, and scheduled background tasks—alongside necessary dependency updates

New Features:
- Add self-update functionality via codedge/laravel-selfupdater with configuration and a dedicated service
- Introduce a Filament System Updates page with actions to check for and apply updates
- Expose HTTP endpoints and console commands (app:update:check, app:version) for programmatic version management and update control
- Schedule new console jobs for daily update checks, fifteen-minute repository issue syncs, and five-minute issue rollup recalculations

Enhancements:
- Update composer dependencies to include laravel-selfupdater and phpstan extension installer