### PR TITLE
Feature/optional restriction registration

### DIFF
--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -4,11 +4,14 @@ namespace App\Actions\Fortify;
 
 use App\Models\Team;
 use App\Models\User;
+use App\Settings\AuthSettings;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 use Laravel\Jetstream\Jetstream;
+use Throwable;
 
 class CreateNewUser implements CreatesNewUsers
 {
@@ -18,10 +21,17 @@ class CreateNewUser implements CreatesNewUsers
      * Create a newly registered user.
      *
      * @param array<string, string> $input
-     * @throws \Throwable
+     * @throws Throwable
      */
     public function create(array $input): User
     {
+        $settings = app(AuthSettings::class);
+        if (!($settings->allowRegistration ?? true)) {
+            throw ValidationException::withMessages([
+                'email' => __('Registration is currently closed.'),
+            ]);
+        }
+
         Validator::make($input, [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],

--- a/app/Filament/Pages/Settings/ManageAuthSettings.php
+++ b/app/Filament/Pages/Settings/ManageAuthSettings.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Filament\Pages\Settings;
+
+use App\Settings\AuthSettings;
+use Filament\Forms\Components\Toggle;
+use Filament\Pages\SettingsPage;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+
+class ManageAuthSettings extends SettingsPage
+{
+    protected static string $settings = AuthSettings::class;
+
+    protected static ?string $title = 'Authentication';
+    protected static string|null|\UnitEnum $navigationGroup = 'Settings';
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedUserPlus;
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->schema([
+            Toggle::make('allowRegistration')
+                ->label('Allow self-registration')
+                ->helperText('When off, only admins can create accounts.'),
+        ]);
+    }
+}

--- a/app/Http/Middleware/EnsureRegistrationIsEnabled.php
+++ b/app/Http/Middleware/EnsureRegistrationIsEnabled.php
@@ -12,7 +12,9 @@ use Symfony\Component\HttpFoundation\Response;
  */
 readonly class EnsureRegistrationIsEnabled
 {
-    public function __construct(private AuthSettings $settings) {}
+    public function __construct(private AuthSettings $settings)
+    {
+    }
 
     public function handle(Request $request, Closure $next): Response
     {

--- a/app/Http/Middleware/EnsureRegistrationIsEnabled.php
+++ b/app/Http/Middleware/EnsureRegistrationIsEnabled.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Settings\AuthSettings;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Prevents access to the registration page when disabled.
+ */
+readonly class EnsureRegistrationIsEnabled
+{
+    public function __construct(private AuthSettings $settings) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!($this->settings->allowRegistration ?? true) && $request->routeIs('register')) {
+            return redirect()->route('login')
+                ->with('status', __('Registration is currently closed.'));
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Settings/AuthSettings.php
+++ b/app/Settings/AuthSettings.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Settings;
+
+use Spatie\LaravelSettings\Settings;
+
+/**
+ * @phpstan-type AuthSettingsShape array{allowRegistration: bool}
+ */
+class AuthSettings extends Settings
+{
+    public bool $allowRegistration;
+
+    public static function group(): string
+    {
+        return 'auth';
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\AllowPublicEmbed;
+use App\Http\Middleware\EnsureRegistrationIsEnabled;
 use App\Http\Middleware\EnsureSupportIdentity;
 use App\Http\Middleware\SetPermissionsTeamContext;
 use App\Http\Middleware\VerifyIngestKey;
@@ -23,11 +24,15 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'support.identity' => EnsureSupportIdentity::class,
             'ingest.key' => VerifyIngestKey::class,
+            'auth.registration' => EnsureRegistrationIsEnabled::class,
         ]);
         $middleware->group('api', [
             EnsureFrontendRequestsAreStateful::class,
             'throttle:api',
             SubstituteBindings::class,
+        ]);
+        $middleware->web(append: [
+            EnsureRegistrationIsEnabled::class,
         ]);
         $middleware->group('embed', [
             AllowPublicEmbed::class

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -31,9 +31,9 @@ return Application::configure(basePath: dirname(__DIR__))
             'throttle:api',
             SubstituteBindings::class,
         ]);
-        $middleware->web(append: [
-            EnsureRegistrationIsEnabled::class,
-        ]);
+        // $middleware->web(append: [
+        //     EnsureRegistrationIsEnabled::class,
+        // ]);
         $middleware->group('embed', [
             AllowPublicEmbed::class
         ]);

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "dedoc/scramble": "^0.12.34",
         "doctrine/dbal": "^4.3",
         "filament/filament": "^4.0",
-        "filament/spatie-laravel-settings-plugin": "^v4.0.19",
+        "filament/spatie-laravel-settings-plugin": "^4.0",
         "guzzlehttp/guzzle": "^7.10",
         "kalnoy/nestedset": "^6.0",
         "knuckleswtf/scribe": "^5.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2a9be949badfd9b906b55c791c57f5fc",
+    "content-hash": "b991e47a0093a6ddce669546c8ed1744",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",

--- a/database/settings/2025_09_29_111124_create_auth_settings.php
+++ b/database/settings/2025_09_29_111124_create_auth_settings.php
@@ -1,0 +1,16 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('auth.allow_registration', true);
+    }
+
+    public function down(): void
+    {
+        $this->migrator->delete('auth.allow_registration');
+    }
+};

--- a/database/settings/2025_09_29_111124_create_auth_settings.php
+++ b/database/settings/2025_09_29_111124_create_auth_settings.php
@@ -2,8 +2,7 @@
 
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
-return new class extends SettingsMigration
-{
+return new class () extends SettingsMigration {
     public function up(): void
     {
         $this->migrator->add('auth.allowRegistration', true);

--- a/database/settings/2025_09_29_111124_create_auth_settings.php
+++ b/database/settings/2025_09_29_111124_create_auth_settings.php
@@ -6,11 +6,11 @@ return new class extends SettingsMigration
 {
     public function up(): void
     {
-        $this->migrator->add('auth.allow_registration', true);
+        $this->migrator->add('auth.allowRegistration', true);
     }
 
     public function down(): void
     {
-        $this->migrator->delete('auth.allow_registration');
+        $this->migrator->delete('auth.allowRegistration');
     }
 };

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -2,7 +2,7 @@
     use App\Models\{Project, Organization, Issue, Goal};
     /** @var \App\Models\User|null $user */
     $user = auth()->user();
-    $allowReg = app(\App\Settings\AuthSettings::class)->allowRegistration ?? true
+    $allowReg = app(\App\Settings\AuthSettings::class)->allowRegistration ?? true;
 @endphp
 <nav class="navbar navbar-expand-md bg-body border-bottom" x-data>
     <div class="container mx-auto py-4">

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -2,15 +2,14 @@
     use App\Models\{Project, Organization, Issue, Goal};
     /** @var \App\Models\User|null $user */
     $user = auth()->user();
+    $allowReg = app(\App\Settings\AuthSettings::class)->allowRegistration ?? true
 @endphp
-
 <nav class="navbar navbar-expand-md bg-body border-bottom" x-data>
     <div class="container mx-auto py-4">
         <!-- Brand -->
         <a class="navbar-brand d-flex align-items-center gap-2" href="{{ $user ? route('dashboard') : url('/') }}">
             <x-application-logo />
         </a>
-
         <!-- Toggler -->
         <button class="navbar-toggler d-md-none" type="button" data-bs-toggle="collapse" data-bs-target="#appNavbar"
                 aria-controls="appNavbar" aria-expanded="false" aria-label="Toggle navigation">
@@ -239,9 +238,11 @@
                     @if (Route::has('login'))
                         <a class="btn btn-outline-secondary" href="{{ route('login') }}">{{ __('Log in') }}</a>
                     @endif
-                    @if (Route::has('register'))
-                        <a class="btn btn-primary" href="{{ route('register') }}">{{ __('Register') }}</a>
-                    @endif
+                        @if ($allowReg)
+                            @if (Route::has('register'))
+                                <a class="btn btn-primary" href="{{ route('register') }}">{{ __('Register') }}</a>
+                            @endif
+                        @endif
                 @endauth
             </div>
         </div>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -1,5 +1,6 @@
 <x-guest-layout>
 {{-- MAIN --}}
+    @php($allowReg = app(\App\Settings\AuthSettings::class)->allowRegistration ?? true)
 <x-slot class="flex-fill">
     <div class="container py-5">
         <div class="row g-4 align-items-center">
@@ -26,10 +27,12 @@
                         <a href="{{ route('login') }}" class="btn btn-dark">
                             <i class="fa-solid fa-right-to-bracket me-1"></i> Sign in
                         </a>
-                        @if (Route::has('register'))
-                            <a href="{{ route('register') }}" class="btn btn-outline-secondary">
-                                <i class="fa-regular fa-id-card me-1"></i> Create an account
-                            </a>
+                        @if ($allowReg)
+                            @if (Route::has('register'))
+                                <a href="{{ route('register') }}" class="btn btn-outline-secondary">
+                                    <i class="fa-regular fa-id-card me-1"></i> Create an account
+                                </a>
+                            @endif
                         @endif
                     </div>
                 @endauth

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Auth\GitHubAuthController;
 use App\Http\Controllers\Auth\SocialAccountLinkController;
 use App\Http\Controllers\Auth\VerifyEmailController;
+use App\Http\Middleware\EnsureRegistrationIsEnabled;
 use App\Livewire\Auth\ConfirmPassword;
 use App\Livewire\Auth\ForgotPassword;
 use App\Livewire\Auth\Login;
@@ -13,7 +14,8 @@ use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
     Route::get('login', Login::class)->name('login');
-    Route::get('register', Register::class)->name('register');
+    Route::get('register', Register::class)->name('register')
+        ->middleware(EnsureRegistrationIsEnabled::class);
     Route::get('forgot-password', ForgotPassword::class)->name('password.request');
     Route::get('reset-password/{token}', ResetPassword::class)->name('password.reset');
 });


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new allowRegistration setting to enable or disable user self-registration across the application, with configuration UI in Filament, middleware and backend enforcement, and conditional UI adjustments

New Features:
- Introduce an AuthSettings class with an allowRegistration flag and migration
- Provide a Filament settings page to toggle the allowRegistration setting

Enhancements:
- Add EnsureRegistrationIsEnabled middleware to guard and redirect registration routes when disabled
- Enforce registration restriction in the Fortify CreateNewUser action
- Conditionally hide registration links in navigation and welcome views based on allowRegistration

Build:
- Relax filament/spatie-laravel-settings-plugin version constraint to ^4.0