### PR TITLE
Implement FilamentUser interface in User model

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,8 @@ namespace App\Models;
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use App\Traits\HasPermissionSets;
 use Database\Factories\UserFactory;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -19,7 +21,7 @@ use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasPermissions;
 use Spatie\Permission\Traits\HasRoles;
 
-class User extends Authenticatable
+class User extends Authenticatable implements FilamentUser
 {
     use HasApiTokens;
     use HasPermissionSets;
@@ -101,5 +103,13 @@ class User extends Authenticatable
     public function socialAccounts(): HasMany
     {
         return $this->hasMany(SocialAccount::class);
+    }
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return $this->hasAnyPermission(
+            ['is-super-admin', 'filament.access', 'is-admin', 'is-panel-user', 'admin.panel.access'],
+            filament()->getAuthGuard()
+        );
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
             "dependencies": {
                 "@awesome.me/webawesome": "^3.0.0-beta.6",
                 "@popperjs/core": "^2.11.8",
-                "@rollup/rollup-linux-x64-gnu": "^4.52.3",
                 "@tailwindcss/vite": "^4.1.11",
                 "autoprefixer": "^10.4.20",
                 "axios": "^1.12.2",


### PR DESCRIPTION
Updated the User model to implement the FilamentUser interface and added the required `canAccessPanel` method for panel access control. Also removed an unused dependency `@rollup/rollup-linux-x64-gnu` from `package-lock.json`.

## Summary by Sourcery

Implement FilamentUser interface in the User model for panel access control and remove an unused dependency from the lockfile

New Features:
- Implement FilamentUser interface and add canAccessPanel method to enforce Filament panel permissions

Build:
- Remove unused @rollup/rollup-linux-x64-gnu dependency from package-lock.json