### PR TITLE
Added Error Log viewer to Admin panel

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -29,8 +29,6 @@ use Laravel\Jetstream\Jetstream;
 
 class AdminPanelProvider extends PanelProvider
 {
-
-
     public function panel(Panel $panel): Panel
     {
         return $panel

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use AchyutN\FilamentLogViewer\FilamentLogViewer;
 use App\Filament\Pages\ConnectorsAndSyncSettings;
 use App\Listeners\SwitchTeam;
 use Filament\Events\TenantSet;
@@ -13,6 +14,7 @@ use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
+use Filament\Support\Icons\Heroicon;
 use Filament\Widgets\AccountWidget;
 use Filament\Widgets\FilamentInfoWidget;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
@@ -63,6 +65,19 @@ class AdminPanelProvider extends PanelProvider
             ])
             ->authMiddleware([
                 Authenticate::class,
-            ]);
+            ])
+            ->plugins([
+                FilamentLogViewer::make()
+                    ->navigationGroup('System')
+                    ->authorize(function () {
+                        $user = auth()->user();
+                        return $user
+                            && (
+                                $user->can('view.system-logs') ||
+                                $user->can('is-super-admin') ||
+                                $user->can('is-admin')
+                            );
+                    }),
+        ]);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "ext-libxml": "*",
         "ext-mbstring": "*",
         "ext-zip": "*",
+        "achyutn/filament-log-viewer": "^1.4",
         "ashallendesign/short-url": "^8.3",
         "blaspsoft/blasp": "^3.0",
         "calebporzio/sushi": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,86 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b991e47a0093a6ddce669546c8ed1744",
+    "content-hash": "cb823411ecc25d39afeabf2eb0cfc797",
     "packages": [
+        {
+            "name": "achyutn/filament-log-viewer",
+            "version": "v1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/achyutkneupane/filament-log-viewer.git",
+                "reference": "016fcd25dd520aa07132d149b627e621d3490e06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/achyutkneupane/filament-log-viewer/zipball/016fcd25dd520aa07132d149b627e621d3490e06",
+                "reference": "016fcd25dd520aa07132d149b627e621d3490e06",
+                "shasum": ""
+            },
+            "require": {
+                "filament/filament": "^4.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.23",
+                "orchestra/testbench": "^10.4",
+                "pestphp/pest": "^3.8",
+                "pestphp/pest-plugin-laravel": "^3.2",
+                "pestphp/pest-plugin-livewire": "^3.0",
+                "rector/rector": "^2.1"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "AchyutN\\FilamentLogViewer\\LogViewerProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "AchyutN\\FilamentLogViewer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Achyut Neupane",
+                    "email": "achyutkneupane@gmail.com",
+                    "homepage": "https://achyut.com.np",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "A Filament package to view and manage Laravel logs.",
+            "keywords": [
+                "Viewer",
+                "filament",
+                "laravel",
+                "log"
+            ],
+            "support": {
+                "issues": "https://github.com/achyutkneupane/filament-log-viewer/issues",
+                "source": "https://github.com/achyutkneupane/filament-log-viewer/tree/v1.4.2"
+            },
+            "funding": [
+                {
+                    "url": "https://www.buymeacoffee.com/achyutn",
+                    "type": "buy_me_a_coffee"
+                },
+                {
+                    "url": "https://github.com/achyutkneupane",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/Achyut",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-09-27T17:25:24+00:00"
+        },
         {
             "name": "anourvalar/eloquent-serialize",
             "version": "1.3.4",


### PR DESCRIPTION
## Summary by Sourcery

Register the FilamentLogViewer plugin in the Admin panel provider with permission checks and add it as a project dependency.

New Features:
- Add an error log viewer plugin to the admin panel under the 'System' navigation group with role-based access control.

Build:
- Require the achyutn/filament-log-viewer package in composer.