### PR TITLE
Use UUIDs for notifications and fix issue URL generation.

### DIFF
--- a/app/Listeners/Issues/SendIssueAssignedNotification.php
+++ b/app/Listeners/Issues/SendIssueAssignedNotification.php
@@ -38,7 +38,7 @@ final class SendIssueAssignedNotification implements ShouldQueue
 
         $url = Route::has('issues.show')
             ? route('issues.show', ['project' => $issue->project, 'issue' => $issue])
-            : url('projects/' . $issue->project_id . '/issues/' . $issue->getKey());
+            : url('projects/' . $issue->project_id . '/issues/' . $issue->key);
 
         $user->notify(new IssueAssigned(issue: $issue, url: $url));
     }

--- a/database/migrations/2025_09_30_131520_create_notifications_table.php
+++ b/database/migrations/2025_09_30_131520_create_notifications_table.php
@@ -12,7 +12,7 @@ return new class () extends Migration {
     {
         if (! Schema::hasTable('notifications')) {
             Schema::create('notifications', static function (Blueprint $table): void {
-                $table->id();
+                $table->uuid('id')->primary();
                 $table->string('type');
                 $table->uuidMorphs('notifiable'); // notifiable_type, notifiable_id
                 $table->text('data'); // json in text keeps sqlite compat; cast in model


### PR DESCRIPTION
Replaced the `id` column in the notifications table with a UUID to ensure consistency and scalability. Also corrected the fallback issue URL generation to use `$issue->key` instead of `$issue->getKey()`.

## Summary by Sourcery

Use UUIDs as primary keys in the notifications table and fix fallback URL construction for issue notifications.

Bug Fixes:
- Correct the fallback issue URL generation to use the issue key property instead of the deprecated method.

Enhancements:
- Migrate the notifications table primary key from an auto-increment integer to a UUID.