### PR TITLE
Add attachments relationship to Issue model

### DIFF
--- a/app/Models/Issue.php
+++ b/app/Models/Issue.php
@@ -20,6 +20,7 @@ use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\Tags\HasTags;
 
 class Issue extends BaseModel implements HasMedia
@@ -182,6 +183,11 @@ class Issue extends BaseModel implements HasMedia
     public function comments(): MorphMany
     {
         return $this->morphMany(Comment::class, 'commentable')->orderBy('created_at');
+    }
+
+    public function attachments(): MorphMany
+    {
+        return $this->morphMany(Media::class, 'model');
     }
 
     public function sprint(): BelongsTo


### PR DESCRIPTION
Introduced a new `attachments` method in the `Issue` model to define a polymorphic relationship with the `Media` class. This enables managing associated media files for issues more effectively. Updated necessary imports to support the new functionality. Acts as an alias for SpatieMedia.  Hotfix for issue introduced in previous version.

## Summary by Sourcery

Add an attachments method to the Issue model to alias and manage related media files via a polymorphic Spatie Media relationship.

New Features:
- Add attachments polymorphic relationship to Issue model for Media

Enhancements:
- Import Spatie Media model in Issue model