### PR TITLE
Add reporting structures and backfill support for projects

### DIFF
--- a/app/Console/Commands/ReportsBackfillCommand.php
+++ b/app/Console/Commands/ReportsBackfillCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\BuildProjectDailyReportsJob;
+use App\Models\Project;
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+
+class ReportsBackfillCommand extends Command
+{
+    protected $signature = 'reports:backfill {--days=60} {--project=*}';
+    protected $description = 'Backfill project reporting snapshots for the last N days.';
+
+    public function handle(): int
+    {
+        $days = (int) $this->option('days');
+        $projectIds = (array) $this->option('project');
+
+        $query = Project::query()->select('id');
+        if (!empty($projectIds)) {
+            $query->whereIn('id', $projectIds);
+        }
+
+        $dates = collect(range(0, $days - 1))
+            ->map(static fn (int $i): Carbon => now()->copy()->subDays($i)->startOfDay())
+            ->reverse()
+            ->values();
+
+        $query->chunkById(200, function ($projects) use ($dates): void {
+            foreach ($projects as $project) {
+                foreach ($dates as $date) {
+                    dispatch(new BuildProjectDailyReportsJob($project->id, $date))->onQueue('reports');
+                }
+            }
+        });
+
+        $this->info("Dispatched backfill for {$days} day(s).");
+        return self::SUCCESS;
+    }
+}

--- a/app/Jobs/BuildProjectDailyReportsJob.php
+++ b/app/Jobs/BuildProjectDailyReportsJob.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Issue;
+use App\Models\IssueStatus;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Throwable;
+
+class BuildProjectDailyReportsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        private readonly string $projectId,
+        private readonly Carbon $forDate
+    ) {}
+
+    /**
+     * @throws Throwable
+     */
+    public function handle(): void
+    {
+        $start = $this->forDate->copy()->startOfDay();
+        $end   = $this->forDate->copy()->endOfDay();
+
+        $issues = Issue::query()
+            ->select(['id', 'project_id', 'issue_status_id', 'created_at', 'updated_at'])
+            ->where('project_id', $this->projectId)
+            ->get();
+
+        $statusById = IssueStatus::query()
+            ->select(['id', 'name', 'is_done'])
+            ->get()
+            ->keyBy('id');
+
+        $open = 0; $wip = 0; $done = 0;
+
+        foreach ($issues as $issue) {
+            $status = $statusById[(int) $issue->issue_status_id] ?? null;
+            if ($status?->is_done) {
+                $done++;
+            } else {
+                $issue->updated_at->greaterThan($start->copy()->subDays(7)) ? $wip++ : $open++;
+            }
+        }
+
+        $throughput = Issue::query()
+            ->where('project_id', $this->projectId)
+            ->whereBetween('updated_at', [$start, $end])
+            ->whereHas('status', static function (Builder $q): void {
+                $q->where('is_done', true);
+            })
+            ->count();
+
+        $doneIssues = Issue::query()
+            ->where('project_id', $this->projectId)
+            ->whereHas('status', static fn (Builder $q) => $q->where('is_done', true))
+            ->whereDate('updated_at', '<=', $end)
+            ->select(['created_at', 'updated_at'])
+            ->get()
+            ->map(static fn (Issue $i): int => (int) $i->created_at->diffInMinutes($i->updated_at))
+            ->sort()
+            ->values();
+
+        $median = $this->percentile($doneIssues, 0.5);
+        $p75    = $this->percentile($doneIssues, 0.75);
+
+        DB::transaction(function () use ($open, $wip, $done, $throughput, $median, $p75, $start): void {
+            DB::table('report_project_daily_summaries')->upsert(
+                [[
+                    'id' => (string) Str::uuid(), // for insert only
+                    'project_id' => $this->projectId,
+                    'report_date' => $start->toDateString(),
+                    'open_count' => $open,
+                    'wip_count' => $wip,
+                    'done_count' => $done,
+                    'throughput_count' => $throughput,
+                    'median_cycle_time_minutes' => $median,
+                    'p75_cycle_time_minutes' => $p75,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]],
+                // unique-by columns (must match your unique index)
+                ['project_id', 'report_date'],
+                // columns to update on conflict (exclude 'id', 'project_id', 'report_date', 'created_at')
+                [
+                    'open_count',
+                    'wip_count',
+                    'done_count',
+                    'throughput_count',
+                    'median_cycle_time_minutes',
+                    'p75_cycle_time_minutes',
+                    'updated_at',
+                ],
+            );
+
+        });
+
+        $counts = Issue::query()
+            ->selectRaw('issue_status_id, COUNT(*) as total')
+            ->where('project_id', $this->projectId)
+            ->groupBy('issue_status_id')
+            ->pluck('total', 'issue_status_id');
+
+        $values = [];
+        foreach ($counts as $statusId => $total) {
+            $values[] = [
+                'id' => (string) Str::uuid(), // for insert only
+                'project_id' => $this->projectId,
+                'report_date' => $start->toDateString(),
+                'issue_status_id' => (int) $statusId,
+                'count' => (int) $total,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ];
+        }
+
+        DB::table('report_cfd_snapshots')->upsert(
+            $values,
+            ['project_id', 'report_date', 'issue_status_id'],
+            ['count', 'updated_at'],
+        );
+
+    }
+
+    /**
+     * @param Collection<int,int> $sortedMinutes
+     */
+    private function percentile(Collection $sortedMinutes, float $p): int
+    {
+        $n = $sortedMinutes->count();
+        if ($n === 0) {
+            return 0;
+        }
+
+        $rank = ($n - 1) * $p;
+        $low  = (int) floor($rank);
+        $high = (int) ceil($rank);
+
+        if ($low === $high) {
+            return (int) $sortedMinutes[$low];
+        }
+
+        $weight = $rank - $low;
+        return (int) round((1 - $weight) * $sortedMinutes[$low] + $weight * $sortedMinutes[$high]);
+    }
+}

--- a/app/Jobs/BuildProjectDailyReportsJob.php
+++ b/app/Jobs/BuildProjectDailyReportsJob.php
@@ -18,12 +18,16 @@ use Throwable;
 
 class BuildProjectDailyReportsJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
 
     public function __construct(
         private readonly string $projectId,
         private readonly Carbon $forDate
-    ) {}
+    ) {
+    }
 
     /**
      * @throws Throwable
@@ -43,7 +47,9 @@ class BuildProjectDailyReportsJob implements ShouldQueue
             ->get()
             ->keyBy('id');
 
-        $open = 0; $wip = 0; $done = 0;
+        $open = 0;
+        $wip = 0;
+        $done = 0;
 
         foreach ($issues as $issue) {
             $status = $statusById[(int) $issue->issue_status_id] ?? null;

--- a/app/Jobs/BuildProjectDailyReportsJob.php
+++ b/app/Jobs/BuildProjectDailyReportsJob.php
@@ -53,7 +53,15 @@ class BuildProjectDailyReportsJob implements ShouldQueue
 
         foreach ($issues as $issue) {
             $status = $statusById[(int) $issue->issue_status_id] ?? null;
-            if ($status?->is_done) {
+            if ($status === null) {
+                \Log::warning('Issue status not found', [
+                    'issue_id' => $issue->id,
+                    'issue_status_id' => $issue->issue_status_id,
+                ]);
+                // Optionally, skip counting this issue
+                continue;
+            }
+            if ($status->is_done) {
                 $done++;
             } else {
                 $issue->updated_at->greaterThan($start->copy()->subDays(7)) ? $wip++ : $open++;

--- a/app/Models/IssueStatusEvent.php
+++ b/app/Models/IssueStatusEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+/**
+ * @property string $id
+ * @property string $issue_id
+ * @property int|null $from_status_id
+ * @property int $to_status_id
+ * @property string|null $changed_by_id
+ * @property Carbon $changed_at
+ */
+class IssueStatusEvent extends Model
+{
+    use HasUuids;
+
+    protected $table = 'issue_status_events';
+    protected $keyType = 'string';
+    public $incrementing = false;
+
+    protected $fillable = [
+        'issue_id',
+        'from_status_id',
+        'to_status_id',
+        'changed_by_id',
+        'changed_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'changed_at' => 'datetime',
+        ];
+    }
+
+    public static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(static function ($model) {
+            $model->id = Str::uuid();
+        });
+    }
+
+    public function issue(): BelongsTo
+    {
+        return $this->belongsTo(Issue::class);
+    }
+}

--- a/app/Models/IssueStatusEvent.php
+++ b/app/Models/IssueStatusEvent.php
@@ -44,7 +44,9 @@ class IssueStatusEvent extends Model
         parent::boot();
 
         static::creating(static function ($model) {
-            $model->id = Str::uuid();
+            if (empty($model->id)) {
+                $model->id = Str::uuid();
+            }
         });
     }
 

--- a/app/Observers/IssueObserver.php
+++ b/app/Observers/IssueObserver.php
@@ -7,11 +7,13 @@ use App\Domain\Issues\IssueRollupService;
 use App\Jobs\RecalculateIssueRollups;
 use App\Models\Goal;
 use App\Models\Issue;
+use App\Models\IssueStatusEvent;
 use App\Models\Project;
 use App\Models\User;
 use App\Notifications\IssueAssigned;
 use App\Services\GoalProgressService;
 use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
@@ -131,6 +133,16 @@ class IssueObserver
                     actorId: auth()->id() ? (string) auth()->id() : null,
                 ));
             }
+        }
+
+        if ($issue->wasChanged('issue_status_id')) {
+            IssueStatusEvent::query()->create([
+                'issue_id'       => $issue->getKey(),
+                'from_status_id' => (int) $issue->getOriginal('issue_status_id'),
+                'to_status_id'   => (int) $issue->issue_status_id,
+                'changed_by_id'  => Auth::id(),
+                'changed_at'     => now(),
+            ]);
         }
     }
 

--- a/app/Providers/ModelObserverServiceProvider.php
+++ b/app/Providers/ModelObserverServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Issue;
+use App\Observers\IssueObserver;
+use Illuminate\Support\ServiceProvider;
+
+class ModelObserverServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        //
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        Issue::observe(IssueObserver::class);
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -12,6 +12,7 @@ return [
     App\Providers\HealthServiceProvider::class,
     App\Providers\HorizonServiceProvider::class,
     App\Providers\JetstreamServiceProvider::class,
+    App\Providers\ModelObserverServiceProvider::class,
     App\Providers\RepositoryServiceProvider::class,
     App\Providers\TelescopeServiceProvider::class,
     App\Providers\VoltServiceProvider::class,

--- a/database/migrations/2025_10_02_182444_create_issue_status_events_table.php
+++ b/database/migrations/2025_10_02_182444_create_issue_status_events_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class () extends Migration {
     public function up(): void
     {
         Schema::create('issue_status_events', static function (Blueprint $t): void {

--- a/database/migrations/2025_10_02_182444_create_issue_status_events_table.php
+++ b/database/migrations/2025_10_02_182444_create_issue_status_events_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('issue_status_events', static function (Blueprint $t): void {
+            $t->uuid('id')->primary();
+            $t->foreignUuid('issue_id')->index();
+            $t->foreignId('from_status_id')->nullable()->index();
+            $t->foreignId('to_status_id')->index();
+            $t->foreignUuid('changed_by_id')->nullable()->index();
+            $t->timestamp('changed_at')->index();
+            $t->timestamps();
+
+            $t->unique(['issue_id', 'to_status_id', 'changed_at'], 'uniq_issue_to_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('issue_status_events');
+    }
+};

--- a/database/migrations/2025_10_02_182532_create_report_project_daily_summaries_table.php
+++ b/database/migrations/2025_10_02_182532_create_report_project_daily_summaries_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('report_project_daily_summaries', static function (Blueprint $t): void {
+            $t->uuid('id')->primary();
+            $t->foreignUuid('project_id')->index();
+            $t->date('report_date')->index();
+
+            $t->unsignedInteger('open_count')->default(0);
+            $t->unsignedInteger('wip_count')->default(0);
+            $t->unsignedInteger('done_count')->default(0);
+            $t->unsignedInteger('throughput_count')->default(0);
+
+            $t->unsignedInteger('median_cycle_time_minutes')->default(0);
+            $t->unsignedInteger('p75_cycle_time_minutes')->default(0);
+
+            $t->timestamps();
+            $t->unique(['project_id', 'report_date'], 'uniq_project_date');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('report_project_daily_summaries');
+    }
+};

--- a/database/migrations/2025_10_02_182532_create_report_project_daily_summaries_table.php
+++ b/database/migrations/2025_10_02_182532_create_report_project_daily_summaries_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class () extends Migration {
     public function up(): void
     {
         Schema::create('report_project_daily_summaries', static function (Blueprint $t): void {

--- a/database/migrations/2025_10_02_182630_create_report_cfd_snapshots_table.php
+++ b/database/migrations/2025_10_02_182630_create_report_cfd_snapshots_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class () extends Migration {
     public function up(): void
     {
         Schema::create('report_cfd_snapshots', static function (Blueprint $t): void {

--- a/database/migrations/2025_10_02_182630_create_report_cfd_snapshots_table.php
+++ b/database/migrations/2025_10_02_182630_create_report_cfd_snapshots_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('report_cfd_snapshots', static function (Blueprint $t): void {
+            $t->uuid('id')->primary();
+            $t->foreignUuid('project_id')->index();
+            $t->date('report_date')->index();
+            $t->foreignId('issue_status_id')->index();
+            $t->unsignedInteger('count')->default(0);
+            $t->timestamps();
+
+            $t->unique(['project_id', 'report_date', 'issue_status_id'], 'uniq_project_date_status');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('report_cfd_snapshots');
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,7 +4,10 @@ use App\Console\Commands\CheckForAppUpdate;
 use App\Console\Commands\RecalcIssueRollups;
 use App\Console\Commands\ReverbHealthCheck;
 use App\Console\Commands\SyncRepositoryIssues;
+use App\Jobs\BuildProjectDailyReportsJob;
+use App\Models\Project;
 use Illuminate\Foundation\Inspiring;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
 use Spatie\Health\Commands\RunHealthChecksCommand;
@@ -27,3 +30,14 @@ Schedule::command(ReverbHealthCheck::class)
 
 Schedule::command(RunHealthChecksCommand::class)
     ->everyMinute();
+
+Schedule::call(static function (): void {
+    $yesterday = Carbon::yesterday();
+    Project::query()
+        ->select('id')
+        ->chunkById(200, static function ($projects) use ($yesterday): void {
+            foreach ($projects as $p) {
+                dispatch(new BuildProjectDailyReportsJob($p->id, $yesterday))->onQueue('reports');
+            }
+        });
+})->dailyAt('01:15');


### PR DESCRIPTION
Introduced migrations, models, and jobs to support daily project reporting and cumulative flow snapshots. Added a command for backfilling historical reports and integrated it into scheduling. Updated the IssueObserver to log status change events and ensure consistent tracking.

## Summary by Sourcery

Add support for daily project reporting and historical backfill by introducing new migrations, models, jobs, and commands, integrate scheduling, and track issue status transitions.

New Features:
- Create report_project_daily_summaries and report_cfd_snapshots tables with models to store daily project metrics and CFD snapshots
- Implement BuildProjectDailyReportsJob to calculate and upsert daily open, WIP, done counts, throughput, and cycle time percentiles
- Add reports:backfill command to dispatch historical BuildProjectDailyReportsJob runs for a configurable number of days and projects
- Schedule daily dispatch of BuildProjectDailyReportsJob at 01:15 via the console scheduler
- Introduce IssueStatusEvent model and update IssueObserver to record issue status change events
- Register IssueObserver through a new ModelObserverServiceProvider for automatic observation