### PR TITLE
Minor fixes

### DIFF
--- a/app/Console/Commands/SyncRepositoryIssues.php
+++ b/app/Console/Commands/SyncRepositoryIssues.php
@@ -65,7 +65,13 @@ final class SyncRepositoryIssues extends Command
         // Stream results to keep memory usage low.
         foreach (ProjectRepository::query()->with($with)->whereHas('repository')->cursor() as $link) {
             /** @var ProjectRepository $link */
-            $ok = $this->syncLink($link);
+            try {
+                $ok = $this->syncLink($link);
+            } catch (\Throwable $e) {
+                $failures++;
+                $this->error("Failed to sync link (ID: {$link->id}): " . $e->getMessage());
+                continue;
+            }
             if (!$ok) {
                 $failures++;
             }

--- a/app/Console/Commands/SyncRepositoryIssues.php
+++ b/app/Console/Commands/SyncRepositoryIssues.php
@@ -8,18 +8,11 @@ use App\Models\ProjectRepository;
 use App\Models\Repository;
 use Illuminate\Console\Command;
 
-/**
- * Trigger an initial import/sync of issues from an external repository into a project.
- *
- * Usage examples:
- *  php artisan repo:sync --link=2c4b1e0a-...-d5f9
- *  php artisan repo:sync --project=b46445... --provider=github --owner=helicalgames --name=One-Mans-Poison
- *  php artisan repo:sync --project=FORGE --provider=github --owner=helicalgames --name=forge --queue
- */
 final class SyncRepositoryIssues extends Command
 {
     /** @var string */
     protected $signature = 'repo:sync
+        {--all : Sync all projects that have a linked external repository}
         {--link= : ProjectRepository (link) UUID}
         {--project= : Project ID or key/slug}
         {--provider=github : Provider slug (github|gitlab|gitea)}
@@ -28,17 +21,76 @@ final class SyncRepositoryIssues extends Command
         {--queue : Dispatch to queue instead of running inline}';
 
     /** @var string */
-    protected $description = 'Import/sync issues from a connected repository into a project.';
+    protected $description = 'Import/sync issues from connected repositories into one project or all projects.';
 
     public function handle(): int
     {
+        if ($this->option('all')) {
+            return $this->handleAll();
+        }
+
         $link = $this->resolveLink();
 
         if (!$link) {
-            $this->error('Could not resolve a project-repository link. Provide --link OR all of --project --provider --owner --name.');
+            $this->error('Could not resolve a project-repository link. Provide --link OR all of --project --provider --owner --name, or use --all.');
             return self::INVALID;
         }
 
+        $ok = $this->syncLink($link);
+
+        return $ok ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * Sync all linked repositories across all projects.
+     */
+    private function handleAll(): int
+    {
+        $with = ['project', 'repository', 'repository.statusMappings'];
+
+        $total = ProjectRepository::query()
+            ->whereHas('repository')
+            ->count();
+
+        if ($total === 0) {
+            $this->warn('No project-repository links found.');
+            return self::SUCCESS;
+        }
+
+        $this->info("Syncing all linked repositories ({$total})…");
+        $this->newLine();
+
+        $failures = 0;
+
+        // Stream results to keep memory usage low.
+        foreach (ProjectRepository::query()->with($with)->whereHas('repository')->cursor() as $link) {
+            /** @var ProjectRepository $link */
+            $ok = $this->syncLink($link);
+            if (!$ok) {
+                $failures++;
+            }
+            $this->newLine();
+        }
+
+        if ($this->option('queue')) {
+            $this->info("Dispatched {$total} job(s) to the queue.");
+            return self::SUCCESS;
+        }
+
+        if ($failures > 0) {
+            $this->error("Completed with {$failures} failure(s).");
+            return self::FAILURE;
+        }
+
+        $this->info('All syncs completed successfully.');
+        return self::SUCCESS;
+    }
+
+    /**
+     * Perform a sync for a single link, queued or inline.
+     */
+    private function syncLink(ProjectRepository $link): bool
+    {
         $this->line(sprintf(
             '<info>Syncing</info> %s/%s (%s) <comment>→</comment> Project %s',
             $link->repository->owner,
@@ -50,13 +102,12 @@ final class SyncRepositoryIssues extends Command
         if ($this->option('queue')) {
             InitialImportRepositoryIssues::dispatch($link->id);
             $this->info('Dispatched to queue.');
-            return self::SUCCESS;
+            return true;
         }
 
         $this->warn('Running sync inline (no queue)…');
         \Bus::dispatchSync(new InitialImportRepositoryIssues($link->id));
 
-        // Reload to show outcome
         $link->refresh();
 
         $this->line('Started:  ' . ($link->initial_import_started_at?->toDateTimeString() ?? '—'));
@@ -66,15 +117,15 @@ final class SyncRepositoryIssues extends Command
         if ($link->last_sync_error) {
             $this->newLine();
             $this->error('Error: ' . $link->last_sync_error);
-            return self::FAILURE;
+            return false;
         }
 
         $this->info('Sync complete.');
-        return self::SUCCESS;
+        return true;
     }
 
     /**
-     * Resolve the ProjectRepository link by:
+     * Resolve a single ProjectRepository link by:
      * 1) --link (UUID), or
      * 2) --project + --provider + --owner + --name
      */

--- a/app/Observers/IssueObserver.php
+++ b/app/Observers/IssueObserver.php
@@ -136,13 +136,19 @@ class IssueObserver
         }
 
         if ($issue->wasChanged('issue_status_id')) {
-            IssueStatusEvent::query()->create([
-                'issue_id'       => $issue->getKey(),
-                'from_status_id' => $issue->getOriginal('issue_status_id') !== null ? (int) $issue->getOriginal('issue_status_id') : null,
-                'to_status_id'   => (int) $issue->issue_status_id,
-                'changed_by_id'  => Auth::id(),
-                'changed_at'     => now(),
-            ]);
+            IssueStatusEvent::query()->updateOrCreate(
+                [
+                    'issue_id'      => (string) $issue->getKey(),
+                    'to_status_id'  => (int) $issue->issue_status_id,
+                    'changed_at'    => now(),
+                ],
+                [
+                    'from_status_id' => $issue->getOriginal('issue_status_id') !== null
+                        ? (int) $issue->getOriginal('issue_status_id')
+                        : null,
+                    'changed_by_id'  => Auth::id(),
+                ],
+            );
         }
     }
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -21,7 +21,7 @@ Artisan::command('inspire', function () {
 Schedule::command(CheckForAppUpdate::class)
     ->dailyAt('09:00');
 
-Schedule::command(SyncRepositoryIssues::class)
+Schedule::command(SyncRepositoryIssues::class, ['--all'])
     ->everyFifteenMinutes();
 
 Schedule::command(RecalcIssueRollups::class)
@@ -39,7 +39,7 @@ Schedule::call(static function (): void {
         ->select('id')
         ->chunkById(200, static function ($projects) use ($yesterday): void {
             foreach ($projects as $p) {
-                dispatch(new BuildProjectDailyReportsJob($p->id, $yesterday))->onQueue('reports');
+                dispatch(new BuildProjectDailyReportsJob($p->id, $yesterday));
             }
         });
 })->dailyAt('01:15');
@@ -50,7 +50,7 @@ Schedule::call(static function (): void {
         ->select(['id', 'project_id'])
         ->chunkById(200, static function ($sprints) use ($yesterday): void {
             foreach ($sprints as $s) {
-                dispatch(new BuildSprintDailyReportsJob($s->project_id, $s->id, $yesterday))->onQueue('reports');
+                dispatch(new BuildSprintDailyReportsJob($s->project_id, $s->id, $yesterday));
             }
         });
 })->dailyAt('01:25');


### PR DESCRIPTION
## Summary by Sourcery

Add batch syncing capability to the repo:sync command and streamline event creation and scheduling

New Features:
- Add --all option to repo:sync command to sync all linked external repositories in one run

Enhancements:
- Refactor SyncRepositoryIssues to use a streaming cursor, boolean-based syncLink method, and improved exit codes
- Update console scheduler to run repo:sync with --all and dispatch report jobs without explicit queue specification
- Use updateOrCreate for IssueStatusEvent in IssueObserver to avoid duplicate status events