### PR TITLE
Feature/reporting v2

### DIFF
--- a/app/Console/Commands/ReportsComputeMetricsCommand.php
+++ b/app/Console/Commands/ReportsComputeMetricsCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\ComputeIssueMetricsJob;
+use App\Models\Issue;
+use Illuminate\Console\Command;
+
+final class ReportsComputeMetricsCommand extends Command
+{
+    protected $signature = 'reports:compute-metrics {--project=*} {--only-open} {--chunk=500}';
+    protected $description = 'Compute or refresh issue metrics (cycle/lead/age)';
+
+    public function handle(): int
+    {
+        $chunk = (int) $this->option('chunk');
+        $projects = (array) $this->option('project');
+        $onlyOpen = (bool) $this->option('only-open');
+
+        $q = Issue::query()->select(['id','project_id','issue_status_id']);
+
+        if (!empty($projects)) {
+            $q->whereIn('project_id', $projects);
+        }
+
+        if ($onlyOpen) {
+            $q->whereHas('status', static fn ($s) => $s->where('is_done', false));
+        }
+
+        $count = 0;
+        $q->chunkById($chunk, function ($issues) use (&$count): void {
+            foreach ($issues as $issue) {
+                dispatch(new ComputeIssueMetricsJob($issue->id))->onQueue('reports');
+                $count++;
+            }
+        });
+
+        $this->info("Dispatched {$count} metric job(s).");
+        return self::SUCCESS;
+    }
+}

--- a/app/Filament/Pages/Reports/ProjectAnalytics.php
+++ b/app/Filament/Pages/Reports/ProjectAnalytics.php
@@ -5,9 +5,11 @@ namespace App\Filament\Pages\Reports;
 use App\Filament\Widgets\AssigneeWorkloadTable;
 use App\Filament\Widgets\CumulativeFlowChart;
 use App\Filament\Widgets\CycleTimeHistogram;
+use App\Filament\Widgets\LeadTimeStats;
 use App\Filament\Widgets\ProjectHealthStats;
 use App\Filament\Widgets\SprintBurndown;
 use App\Filament\Widgets\ThroughputTrend;
+use App\Filament\Widgets\WipAgingTable;
 use App\Models\Project;
 use Illuminate\Support\Facades\DB;
 use Filament\Actions;
@@ -94,12 +96,12 @@ final class ProjectAnalytics extends Page
 
     protected function getHeaderWidgets(): array
     {
-        return [ ProjectHealthStats::class ];
+        return [ ProjectHealthStats::class, LeadTimeStats::class ];
     }
 
     protected function getFooterWidgets(): array
     {
-        return [CumulativeFlowChart::class, ThroughputTrend::class, AssigneeWorkloadTable::class, SprintBurndown::class, CycleTimeHistogram::class ];
+        return [CumulativeFlowChart::class, ThroughputTrend::class, AssigneeWorkloadTable::class, SprintBurndown::class, CycleTimeHistogram::class, WipAgingTable::class];
     }
 
     public function getHeaderWidgetsColumns(): int|array
@@ -111,12 +113,14 @@ final class ProjectAnalytics extends Page
     {
         return [
             ProjectHealthStats::class    => ['projectId' => $this->projectId, 'dateFrom' => $this->dateFrom, 'dateTo' => $this->dateTo],
+                LeadTimeStats::class      => ['projectId' => $this->projectId, 'dateFrom' => $this->dateFrom, 'dateTo' => $this->dateTo],
             CumulativeFlowChart::class   => ['projectId' => $this->projectId, 'dateFrom' => $this->dateFrom, 'dateTo' => $this->dateTo],
             ThroughputTrend::class       => ['projectId' => $this->projectId, 'dateFrom' => $this->dateFrom, 'dateTo' => $this->dateTo],
             AssigneeWorkloadTable::class => ['projectId' => $this->projectId],
             SprintBurndown::class        => ['projectId' => $this->projectId],
             CycleTimeHistogram::class    => ['projectId' => $this->projectId, 'dateFrom' => $this->dateFrom, 'dateTo' => $this->dateTo],
-        ];
+            WipAgingTable::class => ['projectId' => $this->projectId],
+        ] + parent::getWidgetData();
     }
 
     public function hasReportData(): bool

--- a/app/Filament/Pages/Reports/ProjectAnalytics.php
+++ b/app/Filament/Pages/Reports/ProjectAnalytics.php
@@ -4,6 +4,7 @@ namespace App\Filament\Pages\Reports;
 
 use App\Filament\Widgets\AssigneeWorkloadTable;
 use App\Filament\Widgets\CumulativeFlowChart;
+use App\Filament\Widgets\CycleTimeHistogram;
 use App\Filament\Widgets\ProjectHealthStats;
 use App\Filament\Widgets\SprintBurndown;
 use App\Filament\Widgets\ThroughputTrend;
@@ -98,7 +99,7 @@ final class ProjectAnalytics extends Page
 
     protected function getFooterWidgets(): array
     {
-        return [CumulativeFlowChart::class, ThroughputTrend::class, AssigneeWorkloadTable::class, SprintBurndown::class];
+        return [CumulativeFlowChart::class, ThroughputTrend::class, AssigneeWorkloadTable::class, SprintBurndown::class, CycleTimeHistogram::class ];
     }
 
     public function getHeaderWidgetsColumns(): int|array
@@ -114,6 +115,7 @@ final class ProjectAnalytics extends Page
             ThroughputTrend::class       => ['projectId' => $this->projectId, 'dateFrom' => $this->dateFrom, 'dateTo' => $this->dateTo],
             AssigneeWorkloadTable::class => ['projectId' => $this->projectId],
             SprintBurndown::class        => ['projectId' => $this->projectId],
+            CycleTimeHistogram::class    => ['projectId' => $this->projectId, 'dateFrom' => $this->dateFrom, 'dateTo' => $this->dateTo],
         ];
     }
 

--- a/app/Filament/Widgets/CycleTimeHistogram.php
+++ b/app/Filament/Widgets/CycleTimeHistogram.php
@@ -32,8 +32,12 @@ class CycleTimeHistogram extends ChartWidget
                 ->where('project_id', $this->projectId)
                 ->whereNotNull('first_done_at');
 
-            if ($this->dateFrom) { $q->whereDate('first_done_at', '>=', $this->dateFrom); }
-            if ($this->dateTo)   { $q->whereDate('first_done_at', '<=', $this->dateTo); }
+            if ($this->dateFrom) {
+                $q->whereDate('first_done_at', '>=', $this->dateFrom);
+            }
+            if ($this->dateTo) {
+                $q->whereDate('first_done_at', '<=', $this->dateTo);
+            }
 
             $mins = $q->pluck('cycle_time_min')->map(fn ($v) => (int) $v);
 
@@ -57,7 +61,10 @@ class CycleTimeHistogram extends ChartWidget
 
             foreach ($mins as $m) {
                 foreach ($buckets as $i => $b) {
-                    if ($m <= $b['max']) { $data[$i]++; break; }
+                    if ($m <= $b['max']) {
+                        $data[$i]++;
+                        break;
+                    }
                 }
             }
 

--- a/app/Filament/Widgets/CycleTimeHistogram.php
+++ b/app/Filament/Widgets/CycleTimeHistogram.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use Filament\Widgets\ChartWidget;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+class CycleTimeHistogram extends ChartWidget
+{
+    protected ?string $heading = 'Cycle Time Histogram';
+
+    public ?string $projectId = null;
+    public ?string $dateFrom = null;
+    public ?string $dateTo = null;
+
+    protected function getType(): string
+    {
+        return 'bar';
+    }
+
+    protected function getData(): array
+    {
+        if (blank($this->projectId)) {
+            return ['labels' => [], 'datasets' => []];
+        }
+
+        $cacheKey = sprintf('reports:cth:%s:%s:%s', $this->projectId, $this->dateFrom, $this->dateTo);
+
+        return Cache::remember($cacheKey, 300, function (): array {
+            $q = DB::table('issue_metrics')
+                ->where('project_id', $this->projectId)
+                ->whereNotNull('first_done_at');
+
+            if ($this->dateFrom) { $q->whereDate('first_done_at', '>=', $this->dateFrom); }
+            if ($this->dateTo)   { $q->whereDate('first_done_at', '<=', $this->dateTo); }
+
+            $mins = $q->pluck('cycle_time_min')->map(fn ($v) => (int) $v);
+
+            if ($mins->isEmpty()) {
+                return ['labels' => [], 'datasets' => []];
+            }
+
+            // buckets in minutes
+            $buckets = [
+                ['label' => '≤ 1d',   'max' => 1 * 24 * 60],
+                ['label' => '1–2d',   'max' => 2 * 24 * 60],
+                ['label' => '2–3d',   'max' => 3 * 24 * 60],
+                ['label' => '3–7d',   'max' => 7 * 24 * 60],
+                ['label' => '7–14d',  'max' => 14 * 24 * 60],
+                ['label' => '14–30d', 'max' => 30 * 24 * 60],
+                ['label' => '> 30d',  'max' => PHP_INT_MAX],
+            ];
+
+            $labels = array_column($buckets, 'label');
+            $data   = array_fill(0, count($buckets), 0);
+
+            foreach ($mins as $m) {
+                foreach ($buckets as $i => $b) {
+                    if ($m <= $b['max']) { $data[$i]++; break; }
+                }
+            }
+
+            return ['labels' => $labels, 'datasets' => [[ 'label' => 'Issues', 'data' => $data ]]];
+        });
+    }
+}

--- a/app/Filament/Widgets/LeadTimeStats.php
+++ b/app/Filament/Widgets/LeadTimeStats.php
@@ -30,8 +30,12 @@ class LeadTimeStats extends BaseWidget
                 ->where('project_id', $this->projectId)
                 ->whereNotNull('first_done_at');
 
-            if ($this->dateFrom) { $q->whereDate('first_done_at', '>=', $this->dateFrom); }
-            if ($this->dateTo)   { $q->whereDate('first_done_at', '<=', $this->dateTo); }
+            if ($this->dateFrom) {
+                $q->whereDate('first_done_at', '>=', $this->dateFrom);
+            }
+            if ($this->dateTo) {
+                $q->whereDate('first_done_at', '<=', $this->dateTo);
+            }
 
             /** @var Collection<int,int> $mins */
             $mins = $q->orderBy('lead_time_min')->pluck('lead_time_min')->map(fn ($v) => (int) $v)->values();
@@ -54,11 +58,15 @@ class LeadTimeStats extends BaseWidget
     private function percentile(\Illuminate\Support\Collection $sorted, float $p): int
     {
         $n = $sorted->count();
-        if ($n === 0) { return 0; }
+        if ($n === 0) {
+            return 0;
+        }
         $rank = ($n - 1) * $p;
         $low  = (int) floor($rank);
         $high = (int) ceil($rank);
-        if ($low === $high) { return (int) $sorted[$low]; }
+        if ($low === $high) {
+            return (int) $sorted[$low];
+        }
         $w = $rank - $low;
         return (int) round((1 - $w) * (int) $sorted[$low] + $w * (int) $sorted[$high]);
     }

--- a/app/Filament/Widgets/LeadTimeStats.php
+++ b/app/Filament/Widgets/LeadTimeStats.php
@@ -71,10 +71,21 @@ class LeadTimeStats extends BaseWidget
         return (int) round((1 - $w) * (int) $sorted[$low] + $w * (int) $sorted[$high]);
     }
 
-    private function fmt(int $mins): string
+        private function fmt(int $mins): string
     {
         $d = intdiv($mins, 1440);
         $h = intdiv($mins % 1440, 60);
-        return $d > 0 ? "{$d}d {$h}h" : "{$h}h";
+        $m = $mins % 60;
+        if ($d > 0) {
+            return $m > 0
+                ? "{$d}d {$h}h {$m}m"
+                : "{$d}d {$h}h";
+        } elseif ($h > 0) {
+            return $m > 0
+                ? "{$h}h {$m}m"
+                : "{$h}h";
+        } else {
+            return "{$m}m";
+        }
     }
 }

--- a/app/Filament/Widgets/LeadTimeStats.php
+++ b/app/Filament/Widgets/LeadTimeStats.php
@@ -71,7 +71,7 @@ class LeadTimeStats extends BaseWidget
         return (int) round((1 - $w) * (int) $sorted[$low] + $w * (int) $sorted[$high]);
     }
 
-        private function fmt(int $mins): string
+    private function fmt(int $mins): string
     {
         $d = intdiv($mins, 1440);
         $h = intdiv($mins % 1440, 60);

--- a/app/Filament/Widgets/LeadTimeStats.php
+++ b/app/Filament/Widgets/LeadTimeStats.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use Filament\Widgets\StatsOverviewWidget as BaseWidget;
+use Filament\Widgets\StatsOverviewWidget\Stat;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+class LeadTimeStats extends BaseWidget
+{
+    protected ?string $heading = 'Lead Time (Created → Done)';
+
+    public ?string $projectId = null;
+    public ?string $dateFrom = null;
+    public ?string $dateTo = null;
+
+    protected function getStats(): array
+    {
+        if (blank($this->projectId)) {
+            return [ Stat::make('P50', '0m'), Stat::make('P75', '0m'), Stat::make('P90', '0m') ];
+        }
+
+        $key = sprintf('reports:leadp:%s:%s:%s', $this->projectId, $this->dateFrom, $this->dateTo);
+
+        /** @var array{p50:int,p75:int,p90:int} $p */
+        $p = Cache::remember($key, 300, function (): array {
+            $q = DB::table('issue_metrics')
+                ->where('project_id', $this->projectId)
+                ->whereNotNull('first_done_at');
+
+            if ($this->dateFrom) { $q->whereDate('first_done_at', '>=', $this->dateFrom); }
+            if ($this->dateTo)   { $q->whereDate('first_done_at', '<=', $this->dateTo); }
+
+            /** @var Collection<int,int> $mins */
+            $mins = $q->orderBy('lead_time_min')->pluck('lead_time_min')->map(fn ($v) => (int) $v)->values();
+
+            return [
+                'p50' => $this->percentile($mins, 0.50),
+                'p75' => $this->percentile($mins, 0.75),
+                'p90' => $this->percentile($mins, 0.90),
+            ];
+        });
+
+        return [
+            Stat::make('P50', $this->fmt($p['p50'])),
+            Stat::make('P75', $this->fmt($p['p75'])),
+            Stat::make('P90', $this->fmt($p['p90'])),
+        ];
+    }
+
+    /** @param Collection<int,int> $sorted */
+    private function percentile(\Illuminate\Support\Collection $sorted, float $p): int
+    {
+        $n = $sorted->count();
+        if ($n === 0) { return 0; }
+        $rank = ($n - 1) * $p;
+        $low  = (int) floor($rank);
+        $high = (int) ceil($rank);
+        if ($low === $high) { return (int) $sorted[$low]; }
+        $w = $rank - $low;
+        return (int) round((1 - $w) * (int) $sorted[$low] + $w * (int) $sorted[$high]);
+    }
+
+    private function fmt(int $mins): string
+    {
+        $d = intdiv($mins, 1440);
+        $h = intdiv($mins % 1440, 60);
+        return $d > 0 ? "{$d}d {$h}h" : "{$h}h";
+    }
+}

--- a/app/Filament/Widgets/ProjectHealthStats.php
+++ b/app/Filament/Widgets/ProjectHealthStats.php
@@ -32,8 +32,12 @@ class ProjectHealthStats extends BaseWidget
             ->where('project_id', $this->projectId)
             ->whereNotNull('first_done_at');
 
-        if ($this->dateFrom) { $mq->whereDate('first_done_at', '>=', $this->dateFrom); }
-        if ($this->dateTo)   { $mq->whereDate('first_done_at', '<=', $this->dateTo); }
+        if ($this->dateFrom) {
+            $mq->whereDate('first_done_at', '>=', $this->dateFrom);
+        }
+        if ($this->dateTo) {
+            $mq->whereDate('first_done_at', '<=', $this->dateTo);
+        }
 
         // MySQL-friendly median: order + offset
         $median = (int) (optional(

--- a/app/Filament/Widgets/ProjectHealthStats.php
+++ b/app/Filament/Widgets/ProjectHealthStats.php
@@ -9,26 +9,45 @@ use Illuminate\Support\Facades\DB;
 class ProjectHealthStats extends BaseWidget
 {
     protected ?string $heading = 'Project Health';
+
     public ?string $projectId = null;
+    public ?string $dateFrom = null;
+    public ?string $dateTo = null;
 
     protected function getStats(): array
     {
+        // Latest daily summary for Open/WIP/Done/Throughput
         $row = DB::table('report_project_daily_summaries')
             ->where('project_id', $this->projectId)
             ->orderByDesc('report_date')
             ->first();
 
-        $open    = (int) ($row?->open_count ?? 0);
-        $wip     = (int) ($row?->wip_count ?? 0);
-        $done    = (int) ($row?->done_count ?? 0);
-        $tp      = (int) ($row?->throughput_count ?? 0);
-        $median  = (int) ($row?->median_cycle_time_minutes ?? 0);
+        $open   = (int) ($row->open_count ?? 0);
+        $wip    = (int) ($row->wip_count ?? 0);
+        $done   = (int) ($row->done_count ?? 0);
+        $tp24h  = (int) ($row->throughput_count ?? 0);
+
+        // True cycle-time median over selected range using issue_metrics
+        $mq = DB::table('issue_metrics')
+            ->where('project_id', $this->projectId)
+            ->whereNotNull('first_done_at');
+
+        if ($this->dateFrom) { $mq->whereDate('first_done_at', '>=', $this->dateFrom); }
+        if ($this->dateTo)   { $mq->whereDate('first_done_at', '<=', $this->dateTo); }
+
+        // MySQL-friendly median: order + offset
+        $median = (int) (optional(
+            $mq->orderBy('cycle_time_min')
+                ->skip(max(0, (int) floor(max(0, $mq->count() - 1) / 2)))
+                ->take(1)
+                ->first(['cycle_time_min'])
+        )->cycle_time_min ?? 0);
 
         return [
             Stat::make('Open', (string) $open),
             Stat::make('WIP', (string) $wip),
             Stat::make('Done', (string) $done),
-            Stat::make('Throughput (24h)', (string) $tp),
+            Stat::make('Throughput (24h)', (string) $tp24h),
             Stat::make('Median Cycle (m)', (string) $median),
         ];
     }

--- a/app/Filament/Widgets/ProjectHealthStats.php
+++ b/app/Filament/Widgets/ProjectHealthStats.php
@@ -39,13 +39,29 @@ class ProjectHealthStats extends BaseWidget
             $mq->whereDate('first_done_at', '<=', $this->dateTo);
         }
 
-        // MySQL-friendly median: order + offset
-        $median = (int) (optional(
-            $mq->orderBy('cycle_time_min')
-                ->skip(max(0, (int) floor(max(0, $mq->count() - 1) / 2)))
+        // True median: average two middle values if even, or take the middle if odd
+        $count = $mq->count();
+        if ($count === 0) {
+            $median = 0;
+        } elseif ($count % 2 === 1) {
+            // Odd: take the middle value
+            $medianRow = $mq->orderBy('cycle_time_min')
+                ->skip(floor($count / 2))
                 ->take(1)
-                ->first(['cycle_time_min'])
-        )->cycle_time_min ?? 0);
+                ->first(['cycle_time_min']);
+            $median = (int) ($medianRow?->cycle_time_min ?? 0);
+        } else {
+            // Even: average the two middle values
+            $middleRows = $mq->orderBy('cycle_time_min')
+                ->skip($count / 2 - 1)
+                ->take(2)
+                ->get(['cycle_time_min']);
+            if ($middleRows->count() === 2) {
+                $median = (int) round(($middleRows[0]->cycle_time_min + $middleRows[1]->cycle_time_min) / 2);
+            } else {
+                $median = (int) ($middleRows[0]->cycle_time_min ?? 0);
+            }
+        }
 
         return [
             Stat::make('Open', (string) $open),

--- a/app/Filament/Widgets/ProjectHealthStats.php
+++ b/app/Filament/Widgets/ProjectHealthStats.php
@@ -22,10 +22,10 @@ class ProjectHealthStats extends BaseWidget
             ->orderByDesc('report_date')
             ->first();
 
-        $open   = (int) ($row->open_count ?? 0);
-        $wip    = (int) ($row->wip_count ?? 0);
-        $done   = (int) ($row->done_count ?? 0);
-        $tp24h  = (int) ($row->throughput_count ?? 0);
+        $open   = (int) ($row?->open_count ?? 0);
+        $wip    = (int) ($row?->wip_count ?? 0);
+        $done   = (int) ($row?->done_count ?? 0);
+        $tp24h  = (int) ($row?->throughput_count ?? 0);
 
         // True cycle-time median over selected range using issue_metrics
         $mq = DB::table('issue_metrics')

--- a/app/Filament/Widgets/WipAgingTable.php
+++ b/app/Filament/Widgets/WipAgingTable.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Models\Issue;
+use Filament\Tables;
+use Filament\Widgets\TableWidget as BaseWidget;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+class WipAgingTable extends BaseWidget
+{
+    protected static ?string $heading = 'WIP Aging';
+    public ?string $projectId = null;
+
+    protected function getTableQuery(): Builder|Relation|null
+    {
+        if ($this->projectId === null) {
+            return Issue::query()->whereRaw('0 = 1');
+        }
+
+        return Issue::query()
+            ->select([
+                'issues.id', 'issues.key', 'issues.title', 'issues.assignee_id',
+                'issues.issue_status_id', 'issue_statuses.name as status_name',
+                'issue_metrics.age_min',
+            ])
+            ->join('issue_statuses', 'issue_statuses.id', '=', 'issues.issue_status_id')
+            ->join('issue_metrics', 'issue_metrics.issue_id', '=', 'issues.id')
+            ->where('issues.project_id', $this->projectId)
+            ->where('issue_statuses.is_done', false)
+            ->orderByDesc('issue_metrics.age_min');
+    }
+
+    protected function getTableColumns(): array
+    {
+        return [
+            Tables\Columns\TextColumn::make('key')->label('Key')->searchable(),
+            Tables\Columns\TextColumn::make('title')->label('Title')->limit(60)->searchable(),
+            Tables\Columns\TextColumn::make('status_name')->label('Status'),
+            Tables\Columns\TextColumn::make('assignee_id')
+                ->label('Assignee')
+                ->formatStateUsing(static function ($id): string {
+                    $u = \App\Models\User::query()->select(['id','name'])->find($id);
+                    return $u?->name ?? 'Unassigned';
+                }),
+            Tables\Columns\TextColumn::make('age_min')
+                ->label('Age')
+                ->formatStateUsing(static function (int $mins): string {
+                    $d = intdiv($mins, 1440);
+                    $h = intdiv($mins % 1440, 60);
+                    return $d > 0 ? "{$d}d {$h}h" : "{$h}h";
+                }),
+        ];
+    }
+}

--- a/app/Jobs/ComputeIssueMetricsJob.php
+++ b/app/Jobs/ComputeIssueMetricsJob.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Issue;
+use App\Models\IssueMetric;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Collection as ECollection;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final class ComputeIssueMetricsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public readonly string $issueId
+    ) {}
+
+    public function handle(): void
+    {
+        /** @var Issue|null $issue */
+        $issue = Issue::query()
+            ->select(['id','project_id','issue_status_id','created_at'])
+            ->find($this->issueId);
+
+        if ($issue === null) {
+            return;
+        }
+
+        // status events are written by IssueObserver
+        /** @var ECollection<int,object> $events */
+        $events = DB::table('issue_status_events')
+            ->where('issue_id', $issue->id)
+            ->orderBy('changed_at')
+            ->get(['to_status_id','changed_at']);
+
+        $firstStartedAt = $events->first()?->changed_at ? Carbon::parse($events->first()->changed_at) : null;
+
+        $firstDoneAt = null;
+        if ($events->isNotEmpty()) {
+            // first time it entered a "done" status
+            $doneStatusIds = DB::table('issue_statuses')->where('is_done', true)->pluck('id')->all();
+            $firstDoneAt = $events->firstWhere(fn ($e) => in_array((int) $e->to_status_id, $doneStatusIds, true))
+                ? Carbon::parse($events->firstWhere(fn ($e) => in_array((int) $e->to_status_id, $doneStatusIds, true))->changed_at)
+                : null;
+        }
+
+        $now = now();
+        $isDone = (bool)DB::table('issue_statuses')->where('id', $issue->issue_status_id)->value('is_done');
+
+        $leadMin  = $firstDoneAt ? (int) $issue->created_at->diffInMinutes($firstDoneAt) : 0;
+        $cycleMin = match (true) {
+            $firstStartedAt && $firstDoneAt => (int) $firstStartedAt->diffInMinutes($firstDoneAt),
+            $firstStartedAt && !$firstDoneAt => (int) $firstStartedAt->diffInMinutes($now),
+            default => 0,
+        };
+        $ageMin   = $isDone ? 0 : (int) $issue->created_at->diffInMinutes($now);
+
+        IssueMetric::query()->updateOrCreate(
+            ['issue_id' => $issue->id],
+            [
+                'project_id'        => $issue->project_id,
+                'first_started_at'  => $firstStartedAt,
+                'first_done_at'     => $firstDoneAt,
+                'lead_time_min'     => $leadMin,
+                'cycle_time_min'    => $cycleMin,
+                'age_min'           => $ageMin,
+                'current_status_id' => (int) $issue->issue_status_id,
+                'is_done'           => $isDone,
+            ]
+        );
+    }
+}

--- a/app/Jobs/ComputeIssueMetricsJob.php
+++ b/app/Jobs/ComputeIssueMetricsJob.php
@@ -49,9 +49,8 @@ final class ComputeIssueMetricsJob implements ShouldQueue
             $firstDoneAt = $firstDoneEvent
                 ? Carbon::parse($firstDoneEvent->changed_at)
             // first time it entered a "done" status
-            $doneStatusIds = DB::table('issue_statuses')->where('is_done', true)->pluck('id')->all();
-            $firstDoneAt = $events->firstWhere(fn ($e) => in_array((int) $e->to_status_id, $doneStatusIds, true))
-                ? Carbon::parse($events->firstWhere(fn ($e) => in_array((int) $e->to_status_id, $doneStatusIds, true))->changed_at)
+            $doneEvent = $events->firstWhere(fn ($e) => in_array((int) $e->to_status_id, $doneStatusIds, true));
+            $firstDoneAt = $doneEvent ? Carbon::parse($doneEvent->changed_at) : null;
                 : null;
         }
 

--- a/app/Jobs/ComputeIssueMetricsJob.php
+++ b/app/Jobs/ComputeIssueMetricsJob.php
@@ -15,11 +15,15 @@ use Illuminate\Support\Facades\DB;
 
 final class ComputeIssueMetricsJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
 
     public function __construct(
         public readonly string $issueId
-    ) {}
+    ) {
+    }
 
     public function handle(): void
     {

--- a/app/Jobs/ComputeIssueMetricsJob.php
+++ b/app/Jobs/ComputeIssueMetricsJob.php
@@ -45,8 +45,9 @@ final class ComputeIssueMetricsJob implements ShouldQueue
 
         $firstStartedAt = $events->first()?->changed_at ? Carbon::parse($events->first()->changed_at) : null;
 
-        $firstDoneAt = null;
-        if ($events->isNotEmpty()) {
+            $firstDoneEvent = $events->firstWhere(fn ($e) => in_array((int) $e->to_status_id, $doneStatusIds, true));
+            $firstDoneAt = $firstDoneEvent
+                ? Carbon::parse($firstDoneEvent->changed_at)
             // first time it entered a "done" status
             $doneStatusIds = DB::table('issue_statuses')->where('is_done', true)->pluck('id')->all();
             $firstDoneAt = $events->firstWhere(fn ($e) => in_array((int) $e->to_status_id, $doneStatusIds, true))

--- a/app/Jobs/RefreshOpenIssueAgesJob.php
+++ b/app/Jobs/RefreshOpenIssueAgesJob.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+
+final class RefreshOpenIssueAgesJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(private readonly string $projectId) {}
+
+    public function handle(): void
+    {
+        // Keep age_min, current_status_id, and is_done fresh for non-done issues.
+        DB::update(<<<'SQL'
+            UPDATE issue_metrics m
+            JOIN issues i           ON i.id = m.issue_id
+            JOIN issue_statuses s   ON s.id = i.issue_status_id
+            SET
+                m.age_min = TIMESTAMPDIFF(MINUTE, i.created_at, NOW()),
+                m.current_status_id = i.issue_status_id,
+                m.is_done = s.is_done,
+                m.updated_at = NOW()
+            WHERE m.project_id = ? AND s.is_done = 0
+        SQL, [$this->projectId]);
+    }
+}

--- a/app/Jobs/RefreshOpenIssueAgesJob.php
+++ b/app/Jobs/RefreshOpenIssueAgesJob.php
@@ -11,9 +11,14 @@ use Illuminate\Support\Facades\DB;
 
 final class RefreshOpenIssueAgesJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
 
-    public function __construct(private readonly string $projectId) {}
+    public function __construct(private readonly string $projectId)
+    {
+    }
 
     public function handle(): void
     {

--- a/app/Models/IssueMetric.php
+++ b/app/Models/IssueMetric.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+/**
+ * @property string $issue_id
+ * @property string $project_id
+ * @property Carbon|null $first_started_at
+ * @property Carbon|null $first_done_at
+ * @property int $lead_time_min
+ * @property int $cycle_time_min
+ * @property int $age_min
+ * @property int|null $current_status_id
+ * @property bool $is_done
+ */
+class IssueMetric extends Model
+{
+    use HasUuids;
+
+    protected $table = 'issue_metrics';
+    protected $primaryKey = 'issue_id';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected function casts(): array
+    {
+        return [
+            'first_started_at' => 'datetime',
+            'first_done_at' => 'datetime',
+            'is_done' => 'bool',
+        ];
+    }
+
+    protected $fillable = [
+        'issue_id','project_id',
+        'first_started_at','first_done_at',
+        'lead_time_min','cycle_time_min','age_min',
+        'current_status_id','is_done',
+    ];
+
+    public static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(static function ($model) {
+            $model->id = Str::uuid();
+        });
+    }
+}

--- a/app/Observers/IssueObserver.php
+++ b/app/Observers/IssueObserver.php
@@ -4,6 +4,7 @@ namespace App\Observers;
 
 use App\Domain\Issues\Events\IssueAssigneeChanged;
 use App\Domain\Issues\IssueRollupService;
+use App\Jobs\ComputeIssueMetricsJob;
 use App\Jobs\RecalculateIssueRollups;
 use App\Models\Goal;
 use App\Models\Issue;
@@ -149,6 +150,8 @@ class IssueObserver
                     'changed_by_id'  => Auth::id(),
                 ],
             );
+
+            dispatch(new ComputeIssueMetricsJob($issue->getKey()));
         }
     }
 

--- a/database/migrations/2025_10_03_124720_create_issue_metrics_table.php
+++ b/database/migrations/2025_10_03_124720_create_issue_metrics_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class () extends Migration {
     public function up(): void
     {
         Schema::create('issue_metrics', static function (Blueprint $t): void {

--- a/database/migrations/2025_10_03_124720_create_issue_metrics_table.php
+++ b/database/migrations/2025_10_03_124720_create_issue_metrics_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('issue_metrics', static function (Blueprint $t): void {
+            $t->uuid('issue_id')->primary();              // one row per issue
+            $t->foreignUuid('project_id')->index();
+
+            $t->timestamp('first_started_at')->nullable()->index();
+            $t->timestamp('first_done_at')->nullable()->index();
+
+            $t->unsignedInteger('lead_time_min')->default(0);   // created_at -> first_done_at
+            $t->unsignedInteger('cycle_time_min')->default(0);  // first_started_at -> first_done_at (or now if not done)
+            $t->unsignedInteger('age_min')->default(0);         // created_at -> now if not done
+
+            $t->unsignedBigInteger('current_status_id')->nullable()->index();
+            $t->boolean('is_done')->default(false)->index();
+
+            $t->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('issue_metrics');
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -6,6 +6,7 @@ use App\Console\Commands\ReverbHealthCheck;
 use App\Console\Commands\SyncRepositoryIssues;
 use App\Jobs\BuildProjectDailyReportsJob;
 use App\Jobs\BuildSprintDailyReportsJob;
+use App\Jobs\RefreshOpenIssueAgesJob;
 use App\Models\Project;
 use App\Models\Sprint;
 use Illuminate\Foundation\Inspiring;
@@ -54,3 +55,11 @@ Schedule::call(static function (): void {
             }
         });
 })->dailyAt('01:25');
+
+Schedule::call(static function (): void {
+    Project::query()->select('id')->chunkById(200, static function ($projects): void {
+        foreach ($projects as $p) {
+            dispatch(new RefreshOpenIssueAgesJob($p->id));
+        }
+    });
+})->dailyAt('01:40');


### PR DESCRIPTION
## Summary by Sourcery

Enable advanced reporting by capturing and storing per-issue time metrics, computing them via queued jobs and CLI commands, and surfacing lead time percentiles, cycle time histograms, and WIP aging in the Filament analytics dashboard with date-range support.

New Features:
- Persist per-issue metrics (lead time, cycle time, age) in a new issue_metrics table and compute them via background jobs (ComputeIssueMetricsJob) and a CLI command (reports:compute-metrics)
- Add a daily scheduled job (RefreshOpenIssueAgesJob) to refresh ages of open issues
- Introduce new Filament dashboard widgets—LeadTimeStats, CycleTimeHistogram, and WipAgingTable—and integrate them into the ProjectAnalytics page

Enhancements:
- Extend ProjectHealthStats to support date range filters and compute true median cycle time from issue_metrics

Chores:
- Add IssueMetric Eloquent model with UUID primary key and migration for issue_metrics table
- Hook into IssueObserver to dispatch metric computation on status updates and schedule nightly metric refresh