### PR TITLE
Feature/solo mode

### DIFF
--- a/app/Filament/Pages/Settings/ManagePersonalizationSettings.php
+++ b/app/Filament/Pages/Settings/ManagePersonalizationSettings.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Filament\Pages\Settings;
+
+use App\Settings\AuthSettings;
+use App\Settings\PersonalizationSettings;
+use Filament\Forms\Components\Toggle;
+use Filament\Pages\SettingsPage;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+
+class ManagePersonalizationSettings extends SettingsPage
+{
+    protected static string $settings = PersonalizationSettings::class;
+
+    protected static ?string $title = 'Personalization Settings';
+    protected static string|null|\UnitEnum $navigationGroup = 'Settings';
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedPaintBrush;
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema->schema([
+            Toggle::make('solo_mode_default')
+                ->label('Enable Solo-Developer Mode')
+                ->helperText('When on, enables and prioritizes features to help Solo developers.'),
+            Toggle::make('streamer_mode')
+                ->label('Enable Streamer Mode')
+                ->helperText('When on, enables features useful for OBS or streaming embeds'),
+        ]);
+    }
+}

--- a/app/Livewire/Issues/FocusTimer.php
+++ b/app/Livewire/Issues/FocusTimer.php
@@ -67,6 +67,14 @@ final class FocusTimer extends Component
 
     public function start(): void
     {
+        // Authorization check
+        $this->authorize('view', $this->issue);
+
+        // Prevent duplicate running timers for this user and issue
+        if ($this->runningEntry !== null) {
+            // Optionally, you could throw an exception or show a message
+            return;
+        }
         $entry = new TimeEntry([
             'issue_id' => $this->issue->id,
             'user_id' => Auth::id(),

--- a/app/Livewire/Issues/FocusTimer.php
+++ b/app/Livewire/Issues/FocusTimer.php
@@ -180,4 +180,3 @@ final class FocusTimer extends Component
         return max(0, $now - $start);
     }
 }
-

--- a/app/Livewire/Issues/FocusTimer.php
+++ b/app/Livewire/Issues/FocusTimer.php
@@ -90,7 +90,7 @@ final class FocusTimer extends Component
         $this->elapsedSeconds = 0;
 
         $settings = app(PersonalizationSettings::class);
-        if (property_exists($settings, 'in_progress_status_id') && ! empty($settings->in_progress_status_id) && (int)$this->issue->issue_status_id !== (int)$settings->in_progress_status_id) {
+        if (!empty($settings->in_progress_status_id) && (int)$this->issue->issue_status_id !== (int)$settings->in_progress_status_id) {
             $this->issue->issue_status_id = (int)$settings->in_progress_status_id;
             $this->issue->save();
         }

--- a/app/Livewire/Issues/FocusTimer.php
+++ b/app/Livewire/Issues/FocusTimer.php
@@ -117,7 +117,7 @@ final class FocusTimer extends Component
         // Persist a Note snapshot from the timer notes
         if ($this->saveNoteOnStop && trim((string)$this->runningNotes) !== '') {
             Note::query()->create([
-                'user_id' => (string) auth()->id(),
+                'user_id' => Auth::id(),
                 'issue_id' => $this->issue->id,
                 'title' => 'Work log',
                 'body' => $this->runningNotes,

--- a/app/Livewire/Issues/FocusTimer.php
+++ b/app/Livewire/Issues/FocusTimer.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Issues;
 
 use App\Models\Issue;
+use App\Models\Note;
 use App\Models\TimeEntry;
 use App\Settings\PersonalizationSettings;
 use Illuminate\Auth\Access\AuthorizationException;
@@ -29,6 +30,8 @@ final class FocusTimer extends Component
     public string $focusUrl = '';
     public string $publicUrl = '';
     public string $runningNotes = '';
+
+    public bool $saveNoteOnStop = true;
 
     /**
      * @throws AuthorizationException
@@ -102,6 +105,18 @@ final class FocusTimer extends Component
         }
 
         $this->runningEntry->finalizeNow();
+
+        // Persist a Note snapshot from the timer notes
+        if ($this->saveNoteOnStop && trim((string)$this->runningNotes) !== '') {
+            Note::query()->create([
+                'user_id' => (string) auth()->id(),
+                'issue_id' => $this->issue->id,
+                'title' => 'Work log',
+                'body' => $this->runningNotes,
+                'tags' => null,
+            ]);
+        }
+
         $this->isRunning = false;
         $this->elapsedSeconds = (int) $this->runningEntry->duration_seconds;
         $this->runningEntry = null;

--- a/app/Livewire/Issues/FocusTimer.php
+++ b/app/Livewire/Issues/FocusTimer.php
@@ -4,6 +4,7 @@ namespace App\Livewire\Issues;
 
 use App\Models\Issue;
 use App\Models\TimeEntry;
+use App\Settings\PersonalizationSettings;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -63,13 +64,6 @@ final class FocusTimer extends Component
 
     public function start(): void
     {
-        $this->authorize('update', $this->issue);
-
-        if ($this->hasAnyRunningTimer(Auth::id())) {
-            $this->dispatch('banner-message', type: 'warning', message: 'You already have a running timer. Stop it first.');
-            return;
-        }
-
         $entry = new TimeEntry([
             'issue_id' => $this->issue->id,
             'user_id' => Auth::id(),
@@ -78,12 +72,18 @@ final class FocusTimer extends Component
             'duration_seconds' => 0,
             'notes' => $this->runningNotes ?: null,
         ]);
-
         $entry->save();
 
         $this->runningEntry = $entry;
         $this->isRunning = true;
         $this->elapsedSeconds = 0;
+
+        $settings = app(PersonalizationSettings::class);
+        if (property_exists($settings, 'in_progress_status_id') && ! empty($settings->in_progress_status_id) && (int)$this->issue->issue_status_id !== (int)$settings->in_progress_status_id) {
+            $this->issue->issue_status_id = (int)$settings->in_progress_status_id;
+            $this->issue->save();
+        }
+
         $this->dispatch('timer-started');
     }
 

--- a/app/Livewire/Issues/FocusTimer.php
+++ b/app/Livewire/Issues/FocusTimer.php
@@ -68,7 +68,7 @@ final class FocusTimer extends Component
     public function start(): void
     {
         // Authorization check
-        $this->authorize('view', $this->issue);
+        $this->authorize('update', $this->issue);
 
         // Prevent duplicate running timers for this user and issue
         if ($this->runningEntry !== null) {

--- a/app/Livewire/Issues/IssueNotesPanel.php
+++ b/app/Livewire/Issues/IssueNotesPanel.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Livewire\Issues;
+
+use App\Models\Issue;
+use App\Models\Note;
+use App\Services\Issues\IssueDefaultsResolver;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+
+/**
+ * Manage notes attached to a specific Issue.
+ */
+final class IssueNotesPanel extends Component
+{
+    public Issue $issue;
+
+    /** @var Collection<int, Note> */
+    public $notes;
+
+    #[Validate('nullable|string|max:255')]
+    public ?string $newTitle = null;
+
+    #[Validate('nullable|string|max:10000')]
+    public ?string $newBody = null;
+
+    public ?string $editingId = null;
+
+    public string $editingTitle = '';
+    public string $editingBody = '';
+
+    public function mount(Issue $issue): void
+    {
+        $this->issue = $issue;
+        $this->refresh();
+    }
+
+    public function render(): View
+    {
+        return view('livewire.issues.issue-notes-panel');
+    }
+
+    public function refresh(): void
+    {
+        $this->notes = Note::query()
+            ->where('issue_id', $this->issue->id)
+            ->latest('created_at')
+            ->get(['id','user_id','title','body','created_at']);
+    }
+
+    public function add(): void
+    {
+        $this->validate();
+        Note::query()->create([
+            'user_id' => Auth::id(),
+            'issue_id' => $this->issue->id,
+            'title' => $this->newTitle ?: null,
+            'body' => $this->newBody ?: null,
+            'tags' => null,
+        ]);
+
+        $this->reset(['newTitle','newBody']);
+        $this->refresh();
+    }
+
+    public function edit(string $id): void
+    {
+        /** @var Note|null $n */
+        $n = Note::query()->where('issue_id', $this->issue->id)->whereKey($id)->first();
+        if ($n === null) {
+            return;
+        }
+
+        $this->editingId = $n->id;
+        $this->editingTitle = (string)($n->title ?? '');
+        $this->editingBody = (string)($n->body ?? '');
+    }
+
+    public function save(): void
+    {
+        if ($this->editingId === null) {
+            return;
+        }
+
+        /** @var Note|null $n */
+        $n = Note::query()->where('issue_id', $this->issue->id)->whereKey($this->editingId)->first();
+        if ($n === null) {
+            return;
+        }
+
+        // Author or anyone who can update the issue
+        if ($n->user_id !== (string) Auth::id()) {
+            $this->authorize('update', $this->issue);
+        }
+
+        $n->title = trim($this->editingTitle) !== '' ? $this->editingTitle : null;
+        $n->body = trim($this->editingBody) !== '' ? $this->editingBody : null;
+        $n->save();
+
+        $this->editingId = null;
+        $this->editingTitle = '';
+        $this->editingBody = '';
+        $this->refresh();
+    }
+
+    public function cancel(): void
+    {
+        $this->editingId = null;
+        $this->editingTitle = '';
+        $this->editingBody = '';
+    }
+
+    public function delete(string $id): void
+    {
+        /** @var Note|null $n */
+        $n = Note::query()->where('issue_id', $this->issue->id)->whereKey($id)->first();
+        if ($n === null) {
+            return;
+        }
+
+        if ($n->user_id !== (string) Auth::id()) {
+            $this->authorize('update', $this->issue);
+        }
+
+        $n->delete();
+        $this->refresh();
+    }
+
+    public function convertToIssue(string $id): void
+    {
+        /** @var Note|null $n */
+        $n = Note::query()->where('issue_id', $this->issue->id)->whereKey($id)->first();
+        if ($n === null) {
+            return;
+        }
+
+        $this->authorize('create', [Issue::class, $this->issue->project]);
+
+        $summary = $n->title ?: 'New Issue';
+        $defaults = IssueDefaultsResolver::for($this->issue->project);
+
+        $new = Issue::query()->create([
+            'project_id'        => $this->issue->project_id,
+            'issue_type_id'     => $defaults->typeId(),
+            'issue_status_id'   => $defaults->statusId(),
+            'issue_priority_id' => $defaults->priorityId(),
+            'summary'           => $summary,
+            'description'       => $n->body,
+            'assignee_id'       => Auth::id(),
+        ]);
+
+        $n->issue_id = $new->id; // link note to the newly created issue
+        $n->save();
+
+        $this->dispatch('banner-message', type: 'success', message: 'Issue created from note.');
+        $this->refresh();
+    }
+}

--- a/app/Livewire/Issues/IssueQuickTimer.php
+++ b/app/Livewire/Issues/IssueQuickTimer.php
@@ -34,8 +34,7 @@ final class IssueQuickTimer extends Component
         TimeEntry::query()
             ->where('user_id', Auth::id())
             ->whereNull('ended_at')
-            ->get()
-            ->each(static fn (TimeEntry $t) => $t->finalizeNow());
+            ->update(['ended_at' => now()]);
 
         $entry = TimeEntry::query()->create([
             'issue_id' => $this->issueId,

--- a/app/Livewire/Issues/IssueQuickTimer.php
+++ b/app/Livewire/Issues/IssueQuickTimer.php
@@ -50,7 +50,12 @@ final class IssueQuickTimer extends Component
         if (isset($settings->in_progress_status_id) && ! empty($settings->in_progress_status_id)) {
             /** @var Issue|null $issue */
             $issue = Issue::query()->find($this->issueId);
-            if ($issue && (int)$issue->issue_status_id !== (int)$settings->in_progress_status_id) {
+            if (
+                $issue &&
+                $issue->issue_status_id !== null &&
+                $settings->in_progress_status_id !== null &&
+                (int)$issue->issue_status_id !== (int)$settings->in_progress_status_id
+            ) {
                 $issue->issue_status_id = (int)$settings->in_progress_status_id;
                 $issue->save();
             }

--- a/app/Livewire/Issues/IssueQuickTimer.php
+++ b/app/Livewire/Issues/IssueQuickTimer.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Livewire\Issues;
+
+use App\Models\Issue;
+use App\Models\TimeEntry;
+use App\Settings\PersonalizationSettings;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+final class IssueQuickTimer extends Component
+{
+    public string $issueId;
+
+    public bool $isRunning = false;
+    public ?string $runningEntryId = null;
+
+    public function mount(string $issueId): void
+    {
+        $this->issueId = $issueId;
+        $this->refreshRunning();
+    }
+
+    public function render(): View
+    {
+        return view('livewire.issues.issue-quick-timer');
+    }
+
+    public function start(): void
+    {
+        // Stop any other running entry for this user (single-timer rule)
+        TimeEntry::query()
+            ->where('user_id', Auth::id())
+            ->whereNull('ended_at')
+            ->get()
+            ->each(static fn (TimeEntry $t) => $t->finalizeNow());
+
+        $entry = TimeEntry::query()->create([
+            'issue_id' => $this->issueId,
+            'user_id' => Auth::id(),
+            'started_at' => now(),
+            'source' => 'timer',
+            'duration_seconds' => 0,
+            'notes' => null,
+        ]);
+
+        // push issue to "In Progress" on start (same behavior as FocusTimer)
+        $settings = app(PersonalizationSettings::class);
+        if (isset($settings->in_progress_status_id) && ! empty($settings->in_progress_status_id)) {
+            /** @var Issue|null $issue */
+            $issue = Issue::query()->find($this->issueId);
+            if ($issue && (int)$issue->issue_status_id !== (int)$settings->in_progress_status_id) {
+                $issue->issue_status_id = (int)$settings->in_progress_status_id;
+                $issue->save();
+            }
+        }
+
+        $this->runningEntryId = $entry->id;
+        $this->isRunning = true;
+
+        $this->dispatch('timer-started');
+    }
+
+    public function stop(): void
+    {
+        if (! $this->isRunning || $this->runningEntryId === null) {
+            return;
+        }
+
+        $entry = TimeEntry::query()->whereKey($this->runningEntryId)->first();
+        if ($entry && $entry->ended_at === null) {
+            $entry->finalizeNow();
+        }
+
+        $this->runningEntryId = null;
+        $this->isRunning = false;
+
+        $this->dispatch('timer-stopped');
+    }
+
+    private function refreshRunning(): void
+    {
+        $running = TimeEntry::query()
+            ->forUser((string) Auth::id())
+            ->forIssue($this->issueId)
+            ->running()
+            ->latest('started_at')
+            ->first();
+
+        $this->isRunning = $running !== null;
+        $this->runningEntryId = $running?->id;
+    }
+
+    #[On('timer-started')]
+    #[On('timer-stopped')]
+    public function _refreshOnGlobalTimerEvent(): void
+    {
+        $this->refreshRunning();
+    }
+}

--- a/app/Livewire/Issues/NextToggle.php
+++ b/app/Livewire/Issues/NextToggle.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Livewire\Issues;
+
+use App\Models\Issue;
+use Illuminate\Contracts\View\View;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+final class NextToggle extends Component
+{
+    use AuthorizesRequests;
+
+    public string $issueId;
+    public bool $isNext = false;
+
+    public function mount(string $issueId, bool $isNext): void
+    {
+        $this->issueId = $issueId;
+        $this->isNext = $isNext;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.issues.next-toggle');
+    }
+
+    public function toggle(): void
+    {
+        /** @var Issue|null $issue */
+        $issue = Issue::query()->find($this->issueId);
+        if (! $issue) {
+            return;
+        }
+
+        $this->authorize('update', $issue);
+
+        $issue->is_next = ! $issue->is_next;
+        $issue->save();
+
+        $this->isNext = $issue->is_next;
+        $this->dispatch('issue-updated', id: $issue->id);
+    }
+
+    // keep in sync if other UI updates this row
+    #[On('issue-updated')]
+    public function refreshIfMatch(string $id): void
+    {
+        if ($id !== $this->issueId) {
+            return;
+        }
+        $this->isNext = (bool) Issue::query()->whereKey($id)->value('is_next');
+    }
+}

--- a/app/Livewire/Notes/QuickCapture.php
+++ b/app/Livewire/Notes/QuickCapture.php
@@ -46,7 +46,9 @@ final class QuickCapture extends Component
             }
         }
     }
-    /** List of selectable projects when no fixed project is passed. */
+    /**
+     * List of selectable projects when no fixed project is passed.
+     */
     #[Computed]
     public function projectOptions(): Collection
     {

--- a/app/Livewire/Notes/QuickCapture.php
+++ b/app/Livewire/Notes/QuickCapture.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace App\Livewire\Notes;
+
+use App\Models\Issue;
+use App\Models\Note;
+use App\Models\Project;
+use App\Services\Issues\IssueDefaultsResolver;
+use Illuminate\Contracts\View\View;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Validate;
+use Livewire\Component;
+
+/**
+ * Quick scratchpad for capturing Notes and converting them to Issues.
+ * - If $projectId is provided, "Convert to Issue" targets that project automatically.
+ * - Otherwise, user can pick a project from a dropdown shown in the view.
+ */
+final class QuickCapture extends Component
+{
+    use AuthorizesRequests;
+
+    public ?string $projectId = null;
+    public ?string $selectedProjectId = null;
+
+    #[Validate('nullable|string|max:255')]
+    public ?string $title = null;
+
+    #[Validate('nullable|string|max:10000')]
+    public ?string $body = null;
+
+    public function mount(?string $projectId = null): void
+    {
+        $this->projectId = $projectId;
+        $this->selectedProjectId = $projectId;
+
+        // Solo-friendly: if no project was passed and there’s only one project, preselect it
+        if ($this->projectId === null) {
+            /** @var Collection<int,string> $ids */
+            $ids = Project::query()->orderBy('name')->limit(2)->pluck('id');
+            if ($ids->count() === 1) {
+                $this->selectedProjectId = (string) $ids->first();
+            }
+        }
+    }
+    /** List of selectable projects when no fixed project is passed. */
+    #[Computed]
+    public function projectOptions(): Collection
+    {
+        return $this->projectId
+            ? collect()
+            : Project::query()->orderBy('name')->get(['id', 'name']);
+    }
+
+    public function render(): View
+    {
+        return view('livewire.notes.quick-capture', [
+            'recent' => Note::query()
+                ->where('user_id', Auth::id())
+                ->with(['issue:id,project_id,key,summary'])
+                ->latest()
+                ->limit(5)
+                ->get(['id','issue_id','title','created_at']),
+        ]);
+    }
+
+    public function save(): void
+    {
+        $this->validate();
+
+        Note::query()->create([
+            'user_id' => Auth::id(),
+            'issue_id' => null,
+            'title' => $this->title ?: null,
+            'body' => $this->body ?: null,
+            'tags' => null,
+        ]);
+
+        $this->resetFields();
+        $this->dispatch('note-saved');
+    }
+
+    public function convertToIssue(): void
+    {
+        $this->validate();
+
+        $targetProjectId = $this->projectId ?: $this->selectedProjectId;
+        if (! $targetProjectId) {
+            $this->dispatch('banner-message', type: 'warning', message: 'Choose a project first.');
+            return;
+        }
+
+        /** @var Project $project */
+        $project = Project::query()->findOrFail($targetProjectId);
+        $this->authorize('create', [Issue::class, $project]);
+
+        $defaults = IssueDefaultsResolver::for($project);
+
+        $issue = Issue::query()->create([
+            'project_id'        => $project->id,
+            'issue_type_id'     => $defaults->typeId(),
+            'issue_status_id'   => $defaults->statusId(),
+            'issue_priority_id' => $defaults->priorityId(),
+            'summary'           => $this->title ?: 'New issue',
+            'description'       => $this->body ?: null,
+            'assignee_id'       => Auth::id(),
+        ]);
+
+        Note::query()->create([
+            'user_id'  => Auth::id(),
+            'issue_id' => $issue->id,
+            'title'    => $this->title ?: 'Converted note',
+            'body'     => $this->body ?: null,
+            'tags'     => null,
+        ]);
+
+        $this->resetFields();
+        $this->dispatch('issue-created', id: $issue->id);
+    }
+
+    private function resetFields(): void
+    {
+        $this->reset(['title','body']);
+    }
+}

--- a/app/Livewire/Today/TodayPanel.php
+++ b/app/Livewire/Today/TodayPanel.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Livewire\Today;
+
+use App\Models\Issue;
+use App\Models\TimeEntry;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+/**
+ * Solo dashboard showing current running timer and on-deck issues for the user.
+ */
+final class TodayPanel extends Component
+{
+    #[On('timer-started')]
+    #[On('timer-stopped')]
+    public function refresh(): void
+    {
+        // No-op; event hooks force re-render.
+    }
+
+    public function render(): View
+    {
+        $userId = (string) Auth::id();
+
+        $running = TimeEntry::query()
+            ->where('user_id', $userId)
+            ->whereNull('ended_at')
+            ->with(['issue:id,summary,project_id,key,issue_status_id', 'issue.status:id,name,color,is_done'])
+            ->latest('started_at')
+            ->first();
+
+        $onDeck = Issue::query()
+            ->select(['id','summary','project_id','issue_status_id','updated_at'])
+            ->where('assignee_id', $userId)
+            ->whereRelation('status', 'is_done', false)
+            ->with(['status:id,name,color', 'project:id,key'])
+            ->latest('updated_at')
+            ->limit(15)
+            ->get();
+
+        return view('livewire.today.today-panel', [
+            'running' => $running,
+            'onDeck'  => $onDeck,
+        ]);
+    }
+}

--- a/app/Livewire/Today/TodayPanel.php
+++ b/app/Livewire/Today/TodayPanel.php
@@ -32,9 +32,22 @@ final class TodayPanel extends Component
             ->latest('started_at')
             ->first();
 
-        $onDeck = Issue::query()
-            ->select(['id','summary','project_id','issue_status_id','updated_at'])
+        // Pinned “Next”
+        $pinned = Issue::query()
+            ->select(['id','summary','project_id','issue_status_id','updated_at','is_next'])
             ->where('assignee_id', $userId)
+            ->where('is_next', true)
+            ->whereRelation('status', 'is_done', false)
+            ->with(['status:id,name,color', 'project:id,key'])
+            ->latest('updated_at')
+            ->limit(10)
+            ->get();
+
+        // On Deck (not pinned)
+        $onDeck = Issue::query()
+            ->select(['id','summary','project_id','issue_status_id','updated_at','is_next'])
+            ->where('assignee_id', $userId)
+            ->where('is_next', false)
             ->whereRelation('status', 'is_done', false)
             ->with(['status:id,name,color', 'project:id,key'])
             ->latest('updated_at')
@@ -44,6 +57,7 @@ final class TodayPanel extends Component
         return view('livewire.today.today-panel', [
             'running' => $running,
             'onDeck'  => $onDeck,
+            'pinned'  => $pinned,
         ]);
     }
 }

--- a/app/Models/Issue.php
+++ b/app/Models/Issue.php
@@ -71,6 +71,7 @@ class Issue extends BaseModel implements HasMedia
         'due_at'    => 'immutable_datetime',
         'closed_at' => 'immutable_datetime',
         'is_public' => 'bool',
+        'is_next' => 'bool',
     ];
 
     public static function boot(): void

--- a/app/Models/Issue.php
+++ b/app/Models/Issue.php
@@ -247,6 +247,11 @@ class Issue extends BaseModel implements HasMedia
         return $this->belongsToMany(Ticket::class, 'ticket_issue_links');
     }
 
+    public function notes(): HasMany
+    {
+        return $this->hasMany(Note::class);
+    }
+
     /**
      * Quick helper: does this issue come from (at least one) support ticket?
      */

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Traits\IsPermissible;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
 
 /**
@@ -19,6 +20,7 @@ class Note extends BaseModel
 {
     use HasUuids;
     use IsPermissible;
+    use SoftDeletes;
 
     protected $keyType = 'string';
     public $incrementing = false;

--- a/app/Models/Note.php
+++ b/app/Models/Note.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use App\Traits\IsPermissible;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string|null $issue_id
+ * @property string|null $title
+ * @property string|null $body
+ * @property array|null $tags
+ */
+class Note extends BaseModel
+{
+    use HasUuids;
+    use IsPermissible;
+
+    protected $keyType = 'string';
+    public $incrementing = false;
+
+    protected $fillable = ['user_id', 'issue_id', 'title', 'body', 'tags'];
+
+    protected $casts = [
+        'tags' => 'array',
+    ];
+
+    public static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(static function ($model) {
+            $model->id = Str::uuid();
+        });
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function issue(): BelongsTo
+    {
+        return $this->belongsTo(Issue::class);
+    }
+}

--- a/app/Models/TimeEntry.php
+++ b/app/Models/TimeEntry.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Traits\HasExternalId;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
@@ -93,4 +94,23 @@ final class TimeEntry extends Model
         $this->save();
     }
 
+    public function scopeForIssue(Builder $q, string $issueId): Builder
+    {
+        return $q->where('issue_id', $issueId);
+    }
+
+    public function scopeForUser(Builder $q, string $userId): Builder
+    {
+        return $q->where('user_id', $userId);
+    }
+
+    public function scopeRunning(Builder $q): Builder
+    {
+        return $q->whereNull('ended_at');
+    }
+
+    public function getIsRunningAttribute(): bool
+    {
+        return $this->ended_at === null;
+    }
 }

--- a/app/Observers/IssueObserver.php
+++ b/app/Observers/IssueObserver.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
+use Laravel\Pennant\Feature;
 use RuntimeException;
 use Throwable;
 
@@ -51,6 +52,10 @@ class IssueObserver
                 // Assign
                 $issue->number = $next;
                 $issue->key = sprintf('%s-%d', strtoupper($project->key), $next);
+
+                if (empty($issue->assignee_id) && Feature::active('solo-mode') && Auth::check()) {
+                    $issue->assignee_id = Auth::id();
+                }
 
                 // Bump counter
                 $project->next_issue_number = $next;

--- a/app/Providers/SoloModeServiceProvider.php
+++ b/app/Providers/SoloModeServiceProvider.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Providers;
+
+use App\Settings\PersonalizationSettings;
+use Illuminate\Support\ServiceProvider;
+use Laravel\Pennant\Feature;
+
+class SoloModeServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Feature::define('solo-mode', static function (): bool {
+            /** @var PersonalizationSettings $settings */
+            $settings = app(PersonalizationSettings::class);
+
+            return $settings->solo_mode_default === true;
+        });
+    }
+}

--- a/app/Services/Issues/IssueDefaultsResolver.php
+++ b/app/Services/Issues/IssueDefaultsResolver.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Services\Issues;
+
+use App\Models\IssuePriority;
+use App\Models\IssueStatus;
+use App\Models\IssueType;
+use App\Models\Project;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+/**
+ * Resolves default IDs for new Issues, per project if possible.
+ */
+final class IssueDefaultsResolver
+{
+    public function __construct(private Project $project) {}
+
+    public static function for(Project $project): self
+    {
+        return new self($project);
+    }
+
+    public function typeId(): string
+    {
+        // Prefer a common "task" type; otherwise first alphabetically.
+        $id = IssueType::query()->where('key', 'task')->value('id')
+            ?? IssueType::query()->orderBy('name')->value('id');
+
+        if (! $id) {
+            throw new RuntimeException('No Issue Types are configured.');
+        }
+
+        return (string) $id;
+    }
+
+    public function statusId(): ?string
+    {
+        // Try a project-enabled, non-done status first
+        $q = IssueStatus::query()
+            ->whereIn('id', DB::table('project_issue_statuses')
+                ->select('issue_status_id')
+                ->where('project_id', $this->project->id))
+            ->where('is_done', false);
+
+        $id = $q->orderBy('name')->value('id')
+            ?? IssueStatus::query()->where('is_done', false)->orderBy('name')->value('id')
+            ?? IssueStatus::query()->orderBy('name')->value('id'); // last resort
+
+        return $id ? (string) $id : null;
+    }
+
+    public function priorityId(): ?string
+    {
+        // Pick the first by name as a stable default (e.g., "Medium")
+        $id = IssuePriority::query()->orderBy('name')->value('id');
+
+        return $id ? (string) $id : null;
+    }
+}

--- a/app/Services/Issues/IssueDefaultsResolver.php
+++ b/app/Services/Issues/IssueDefaultsResolver.php
@@ -14,7 +14,9 @@ use RuntimeException;
  */
 final class IssueDefaultsResolver
 {
-    public function __construct(private Project $project) {}
+    public function __construct(private Project $project)
+    {
+    }
 
     public static function for(Project $project): self
     {

--- a/app/Settings/PersonalizationSettings.php
+++ b/app/Settings/PersonalizationSettings.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Settings;
+
+use Spatie\LaravelSettings\Settings;
+
+/**
+ * @property bool $solo_mode_default
+ * @property bool $streamer_mode
+ * @property ?int $in_progress_status_id
+ */
+final class PersonalizationSettings extends Settings
+{
+    public bool $solo_mode_default = true;
+    public bool $streamer_mode = false;
+    public ?int $in_progress_status_id = null;
+
+    public static function group(): string
+    {
+        return 'personalization';
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -14,6 +14,7 @@ return [
     App\Providers\JetstreamServiceProvider::class,
     App\Providers\ModelObserverServiceProvider::class,
     App\Providers\RepositoryServiceProvider::class,
+    App\Providers\SoloModeServiceProvider::class,
     App\Providers\TelescopeServiceProvider::class,
     App\Providers\VoltServiceProvider::class,
     SocialiteProviders\Manager\ServiceProvider::class,

--- a/database/migrations/2025_10_03_150437_create_notes_table.php
+++ b/database/migrations/2025_10_03_150437_create_notes_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('notes', static function (Blueprint $t): void {
+            $t->uuid('id')->primary();
+            $t->foreignUuid('user_id')->constrained('users');
+            $t->foreignUuid('issue_id')->nullable()->constrained('issues');
+            $t->string('title')->nullable();
+            $t->text('body')->nullable();
+            $t->json('tags')->nullable();
+            $t->timestamps();
+
+            $t->index(['user_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('notes');
+    }
+};

--- a/database/migrations/2025_10_03_150437_create_notes_table.php
+++ b/database/migrations/2025_10_03_150437_create_notes_table.php
@@ -16,7 +16,6 @@ return new class extends Migration
             $t->text('body')->nullable();
             $t->json('tags')->nullable();
             $t->timestamps();
-
             $t->index(['user_id', 'created_at']);
         });
     }

--- a/database/migrations/2025_10_03_150437_create_notes_table.php
+++ b/database/migrations/2025_10_03_150437_create_notes_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::create('notes', static function (Blueprint $t): void {

--- a/database/migrations/2025_10_03_152203_harden_time_entries.php
+++ b/database/migrations/2025_10_03_152203_harden_time_entries.php
@@ -5,8 +5,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         // Add generated column if missing (used to enforce "one running timer per user")

--- a/database/migrations/2025_10_03_152203_harden_time_entries.php
+++ b/database/migrations/2025_10_03_152203_harden_time_entries.php
@@ -1,0 +1,99 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Add generated column if missing (used to enforce "one running timer per user")
+        if (! Schema::hasColumn('time_entries', 'running_user_id')) {
+            Schema::table('time_entries', static function (Blueprint $t): void {
+                // STORED keeps this indexable across MySQL/MariaDB variants.
+                $t->char('running_user_id', 36)
+                    ->nullable()
+                    ->storedAs('IF(ended_at IS NULL, user_id, NULL)');
+            });
+        }
+
+        // Create/ensure indexes (only if they don't already exist)
+        $this->ensureIndex('time_entries', 'time_entries_unique_running_user', static function () {
+            Schema::table('time_entries', static function (Blueprint $t): void {
+                $t->unique('running_user_id', 'time_entries_unique_running_user');
+            });
+        }, ['time_entries_running_user_id_unique']);
+
+        $this->ensureIndex('time_entries', 'time_entries_user_ended_at', static function () {
+            Schema::table('time_entries', static function (Blueprint $t): void {
+                $t->index(['user_id', 'ended_at'], 'time_entries_user_ended_at');
+            });
+        });
+
+        $this->ensureIndex('time_entries', 'time_entries_issue_started_at', static function () {
+            Schema::table('time_entries', static function (Blueprint $t): void {
+                $t->index(['issue_id', 'started_at'], 'time_entries_issue_started_at');
+            });
+        });
+    }
+
+    public function down(): void
+    {
+        // Drop indexes if present
+        $this->dropIndexIfExists('time_entries', 'time_entries_unique_running_user');
+        $this->dropIndexIfExists('time_entries', 'time_entries_running_user_id_unique'); // fallback name
+        $this->dropIndexIfExists('time_entries', 'time_entries_user_ended_at');
+        $this->dropIndexIfExists('time_entries', 'time_entries_issue_started_at');
+
+        // Drop column if present
+        if (Schema::hasColumn('time_entries', 'running_user_id')) {
+            Schema::table('time_entries', static function (Blueprint $t): void {
+                $t->dropColumn('running_user_id');
+            });
+        }
+    }
+
+    // --- helpers -------------------------------------------------------------
+
+    /** Ensure an index exists; if not, run the creator callback. */
+    private function ensureIndex(string $table, string $indexName, callable $creator, array $alsoCheck = []): void
+    {
+        if ($this->indexExists($table, $indexName)) {
+            return;
+        }
+
+        // Check any alternate names that may already exist
+        foreach ($alsoCheck as $alt) {
+            if ($this->indexExists($table, $alt)) {
+                return;
+            }
+        }
+
+        $creator();
+    }
+
+    /** Drop an index if it exists (safe across environments). */
+    private function dropIndexIfExists(string $table, string $indexName): void
+    {
+        if ($this->indexExists($table, $indexName)) {
+            Schema::table($table, static function (Blueprint $t) use ($indexName): void {
+                $t->dropIndex($indexName);
+            });
+        }
+    }
+
+    /** Check information_schema for an index by name. */
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $db = DB::getDatabaseName();
+
+        $row = DB::selectOne(
+            'SELECT 1 FROM information_schema.statistics WHERE table_schema = ? AND table_name = ? AND index_name = ? LIMIT 1',
+            [$db, $table, $indexName]
+        );
+
+        return $row !== null;
+    }
+};

--- a/database/migrations/2025_10_03_165304_add_soft_deletes_to_notes_table.php
+++ b/database/migrations/2025_10_03_165304_add_soft_deletes_to_notes_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2025_10_03_165304_add_soft_deletes_to_notes_table.php
+++ b/database/migrations/2025_10_03_165304_add_soft_deletes_to_notes_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('notes', static function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('notes', static function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2025_10_03_181235_add_is_next_to_issues.php
+++ b/database/migrations/2025_10_03_181235_add_is_next_to_issues.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('issues', static function (Blueprint $t): void {

--- a/database/migrations/2025_10_03_181235_add_is_next_to_issues.php
+++ b/database/migrations/2025_10_03_181235_add_is_next_to_issues.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('issues', static function (Blueprint $t): void {
+            $t->boolean('is_next')->default(false)->after('estimate_minutes');
+            $t->index(['project_id', 'is_next', 'updated_at'], 'issues_project_next_updated');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('issues', static function (Blueprint $t): void {
+            $t->dropIndex('issues_project_next_updated');
+            $t->dropColumn('is_next');
+        });
+    }
+};

--- a/database/settings/2025_10_03_000001_personalization_settings.php
+++ b/database/settings/2025_10_03_000001_personalization_settings.php
@@ -3,8 +3,7 @@
 use App\Settings\PersonalizationSettings;
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
-return new class extends SettingsMigration
-{
+return new class () extends SettingsMigration {
     public function up(): void
     {
         $this->migrator->add('personalization.solo_mode_default', true);

--- a/database/settings/2025_10_03_000001_personalization_settings.php
+++ b/database/settings/2025_10_03_000001_personalization_settings.php
@@ -1,0 +1,21 @@
+<?php
+
+use App\Settings\PersonalizationSettings;
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('personalization.solo_mode_default', true);
+        $this->migrator->add('personalization.streamer_mode', false);
+        $this->migrator->add('personalization.in_progress_status_id', null);
+    }
+
+    public function down(): void
+    {
+        $this->migrator->delete('personalization.solo_mode_default');
+        $this->migrator->delete('personalization.streamer_mode');
+        $this->migrator->delete('personalization.in_progress_status_id');
+    }
+};

--- a/resources/views/livewire/issues/focus-timer.blade.php
+++ b/resources/views/livewire/issues/focus-timer.blade.php
@@ -27,6 +27,13 @@
             <wa-textarea class="form-control" wire:model.debounce.750ms="runningNotes" rows="3" placeholder="What are you focusing on?" x-bind:disabled="!isRunning"></wa-textarea>
             <div class="form-text">Notes save automatically while the timer runs.</div>
         </div>
+
+        <div class="form-check mt-2">
+            <input class="form-check-input" type="checkbox" id="saveNoteOnStop" wire:model="saveNoteOnStop" :disabled="!isRunning">
+            <label class="form-check-label small" for="saveNoteOnStop">
+                Save these notes as an Issue note when I stop
+            </label>
+        </div>
     </div>
 </div>
 <script>

--- a/resources/views/livewire/issues/issue-notes-panel.blade.php
+++ b/resources/views/livewire/issues/issue-notes-panel.blade.php
@@ -1,0 +1,45 @@
+<div class="card shadow-sm">
+    <div class="card-body">
+        <h4 class="h6 mb-3">Notes</h4>
+
+        <div class="mb-3">
+            <input type="text" class="form-control mb-2" placeholder="Title (optional)" wire:model.defer="newTitle">
+            <textarea class="form-control" rows="3" placeholder="Write a quick note…" wire:model.defer="newBody"></textarea>
+            <div class="mt-2">
+                <button type="button" class="btn btn-primary btn-sm" wire:click="add">Add Note</button>
+            </div>
+        </div>
+
+        <ul class="list-unstyled mb-0">
+            @forelse($notes as $n)
+                <li class="border rounded p-2 mb-2">
+                    @if($editingId === $n->id)
+                        <input type="text" class="form-control mb-2" wire:model.defer="editingTitle">
+                        <textarea class="form-control mb-2" rows="3" wire:model.defer="editingBody"></textarea>
+                        <div class="d-flex gap-2">
+                            <button class="btn btn-primary btn-sm" wire:click="save">Save</button>
+                            <button class="btn btn-outline-secondary btn-sm" wire:click="cancel">Cancel</button>
+                        </div>
+                    @else
+                        <div class="d-flex justify-content-between align-items-start">
+                            <div class="me-2">
+                                <div class="fw-semibold">{{ $n->title ?? 'Untitled' }}</div>
+                                @if($n->body)
+                                    <div class="small text-body">{{ $n->body }}</div>
+                                @endif
+                                <div class="small text-body-secondary mt-1">{{ $n->created_at?->diffForHumans() }}</div>
+                            </div>
+                            <div class="d-flex gap-2">
+                                <button class="btn btn-outline-secondary btn-sm" wire:click="edit('{{ $n->id }}')">Edit</button>
+                                <button class="btn btn-outline-primary btn-sm" wire:click="convertToIssue('{{ $n->id }}')">Convert</button>
+                                <button class="btn btn-outline-danger btn-sm" wire:click="delete('{{ $n->id }}')">Delete</button>
+                            </div>
+                        </div>
+                    @endif
+                </li>
+            @empty
+                <li class="text-body-secondary small">No notes yet.</li>
+            @endforelse
+        </ul>
+    </div>
+</div>

--- a/resources/views/livewire/issues/issue-quick-timer.blade.php
+++ b/resources/views/livewire/issues/issue-quick-timer.blade.php
@@ -1,0 +1,7 @@
+<div class="d-inline-flex gap-2">
+    @if ($isRunning)
+        <button type="button" class="btn btn-warning btn-sm" wire:click="stop">Stop</button>
+    @else
+        <button type="button" class="btn btn-primary btn-sm" wire:click="start">Start</button>
+    @endif
+</div>

--- a/resources/views/livewire/issues/next-toggle.blade.php
+++ b/resources/views/livewire/issues/next-toggle.blade.php
@@ -1,0 +1,11 @@
+<button type="button"
+        class="btn btn-sm {{ $isNext ? 'btn-warning' : 'btn-outline-secondary' }}"
+        title="{{ $isNext ? 'Unpin from Next' : 'Pin to Next' }}"
+        wire:click="toggle">
+    {{-- simple star icon using wa-icon; fallback to ★/☆ --}}
+    @if(function_exists('wa_icon'))
+        <wa-icon family="{{ $isNext ? 'solid' : 'outline' }}" name="{{ $isNext ? 'star' : 'star' }}"></wa-icon>
+    @else
+        {!! $isNext ? '★' : '☆' !!}
+    @endif
+</button>

--- a/resources/views/livewire/issues/next-toggle.blade.php
+++ b/resources/views/livewire/issues/next-toggle.blade.php
@@ -4,7 +4,7 @@
         wire:click="toggle">
     {{-- simple star icon using wa-icon; fallback to ★/☆ --}}
     @if(function_exists('wa_icon'))
-        <wa-icon family="{{ $isNext ? 'solid' : 'outline' }}" name="{{ $isNext ? 'star' : 'star' }}"></wa-icon>
+        <wa-icon family="{{ $isNext ? 'solid' : 'outline' }}" name="star"></wa-icon>
     @else
         {!! $isNext ? '★' : '☆' !!}
     @endif

--- a/resources/views/livewire/notes/quick-capture.blade.php
+++ b/resources/views/livewire/notes/quick-capture.blade.php
@@ -1,0 +1,73 @@
+<div x-data="quickCapture()" x-init="init($root)" class="card shadow-sm">
+    <div class="card-header d-flex align-items-center justify-content-between">
+        <strong>Quick Capture</strong>
+        <small class="text-body-secondary">Press ⌘/Ctrl + K</small>
+    </div>
+
+    <div class="card-body">
+        @if($this->projectOptions->isNotEmpty())
+            <div class="mb-2">
+                <label class="form-label">Project (for Convert to Issue)</label>
+                <select class="form-select" wire:model="selectedProjectId">
+                    <option value="">— Choose a project —</option>
+                    @foreach($this->projectOptions as $p)
+                        <option value="{{ $p->id }}">{{ $p->name }}</option>
+                    @endforeach
+                </select>
+            </div>
+        @endif
+
+        <div class="mb-2">
+            <input type="text" class="form-control" placeholder="Title (optional)" wire:model.defer="title">
+        </div>
+
+        <div class="mb-2">
+            <textarea class="form-control" rows="4" placeholder="Write a quick note…" wire:model.defer="body"></textarea>
+        </div>
+
+        <div class="d-flex gap-2">
+            <button type="button" class="btn btn-primary btn-sm" wire:click="save">Save Note</button>
+            <button type="button" class="btn btn-outline-secondary btn-sm" wire:click="convertToIssue">
+                Convert to Issue
+            </button>
+        </div>
+    </div>
+
+    @if($recent->isNotEmpty())
+        <div class="list-group list-group-flush">
+            @foreach($recent as $n)
+                <div class="list-group-item small d-flex justify-content-between align-items-center">
+                    <span class="text-truncate" style="max-width: 28rem;">
+                        {{ $n->title ?? 'Untitled note' }}
+                    </span>
+                    @if ($n->issue)
+                        <a class="text-decoration-none"
+                           href="{{ route('issues.show', ['project' => $n->issue->project_id, 'issue' => $n->issue]) }}">
+                            View issue ({{ $n->issue->key }})
+                        </a>
+                    @endif
+                </div>
+            @endforeach
+        </div>
+    @endif
+</div>
+
+@push('scripts')
+<script>
+    document.addEventListener('alpine:init', () => {
+          Alpine.data('quickCapture', () => ({
+                root: null,
+                init(root) {
+                  this.root = root; // DOM root of THIS Livewire component instance
+                  window.addEventListener('keydown', (e) => {
+                        if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+                              e.preventDefault();
+                              const ta = this.root.querySelector('textarea');
+                              if (ta) ta.focus();
+                            }
+                      });
+                },
+          }));
+        });
+</script>
+@endpush

--- a/resources/views/livewire/today/today-panel.blade.php
+++ b/resources/views/livewire/today/today-panel.blade.php
@@ -1,0 +1,67 @@
+<div class="d-grid gap-3">
+
+    {{-- Running timer --}}
+    <div class="card shadow-sm">
+        <div class="card-body d-flex align-items-center justify-content-between">
+            <div class="me-3">
+                <div class="text-body-secondary small mb-1">Now working on</div>
+                @if($running)
+                    <div class="fw-semibold">
+                        <a class="text-decoration-none"
+                           href="{{ route('issues.show', ['project' => $running->issue->project_id, 'issue' => $running->issue]) }}">
+                            {{ $running->issue->summary }}
+                        </a>
+                        <span class="badge ms-2"
+                              style="background-color: {{ $running->issue->status?->color ?? 'transparent' }}20;">
+                              {{ $running->issue->status?->name }}
+                        </span>
+                    </div>
+                    <div class="small text-body-secondary mt-1">
+                        Started {{ $running->started_at?->diffForHumans() }}
+                    </div>
+                @else
+                    <div class="text-body-secondary">No active timer.</div>
+                @endif
+            </div>
+            @if($running)
+                <div>
+                    <a class="btn btn-outline-primary btn-sm"
+                       href="{{ route('issues.focus', ['project' => $running->issue->project_id, 'issue' => $running->issue]) }}">
+                        Open focus
+                    </a>
+                </div>
+            @endif
+        </div>
+    </div>
+
+    {{-- On Deck list with inline Start/Stop --}}
+    <div class="card shadow-sm">
+        <div class="card-header d-flex align-items-center justify-content-between">
+            <h3 class="h6 mb-0">On Deck</h3>
+            <small class="text-body-secondary">{{ $onDeck->count() }} items</small>
+        </div>
+
+        <div class="list-group list-group-flush">
+            @forelse ($onDeck as $i)
+                <div class="list-group-item d-flex justify-content-between align-items-center gap-3">
+                    <div class="flex-grow-1">
+                        <a class="text-decoration-none fw-semibold"
+                           href="{{ route('issues.show', ['project' => $i->project_id, 'issue' => $i->id]) }}">
+                            {{ $i->summary }}
+                        </a>
+                        <span class="badge ms-2"
+                              style="background-color: {{ $i->status?->color ?? 'transparent' }}20;">
+                              {{ $i->status?->name }}
+                        </span>
+                        <div class="small text-body-secondary">Updated {{ $i->updated_at?->diffForHumans() }}</div>
+                    </div>
+                    <div class="flex-shrink-0">
+                        <livewire:issues.issue-quick-timer :issue-id="$i->id" :wire:key="'qt-today-'.$i->id" />
+                    </div>
+                </div>
+            @empty
+                <div class="list-group-item text-body-secondary small">Nothing assigned yet.</div>
+            @endforelse
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/today/today-panel.blade.php
+++ b/resources/views/livewire/today/today-panel.blade.php
@@ -13,7 +13,7 @@
                         </a>
                         <span class="badge ms-2"
                               style="background-color: {{ $running->issue->status?->color ?? 'transparent' }}20;">
-                              {{ $running->issue->status?->name }}
+                            {{ $running->issue->status?->name }}
                         </span>
                     </div>
                     <div class="small text-body-secondary mt-1">
@@ -24,17 +24,49 @@
                 @endif
             </div>
             @if($running)
-                <div>
-                    <a class="btn btn-outline-primary btn-sm"
-                       href="{{ route('issues.focus', ['project' => $running->issue->project_id, 'issue' => $running->issue]) }}">
-                        Open focus
-                    </a>
-                </div>
+                <a class="btn btn-outline-primary btn-sm"
+                   href="{{ route('issues.focus', ['project' => $running->issue->project_id, 'issue' => $running->issue]) }}">
+                    Open focus
+                </a>
             @endif
         </div>
     </div>
 
-    {{-- On Deck list with inline Start/Stop --}}
+    {{-- Next (pinned) --}}
+    @if($pinned->isNotEmpty())
+        <div class="card shadow-sm">
+            <div class="card-header d-flex align-items-center justify-content-between">
+                <h3 class="h6 mb-0">Next</h3>
+                <small class="text-body-secondary">{{ $pinned->count() }} pinned</small>
+            </div>
+
+            <div class="list-group list-group-flush">
+                @foreach ($pinned as $i)
+                    <div class="list-group-item d-flex justify-content-between align-items-center gap-3">
+                        <div class="flex-grow-1">
+                            <a class="text-decoration-none fw-semibold"
+                               href="{{ route('issues.show', ['project' => $i->project_id, 'issue' => $i->id]) }}">
+                                {{ $i->summary }}
+                            </a>
+                            <span class="badge ms-2"
+                                  style="background-color: {{ $i->status?->color ?? 'transparent' }}20;">
+                                {{ $i->status?->name }}
+                            </span>
+                            <div class="small text-body-secondary">Updated {{ $i->updated_at?->diffForHumans() }}</div>
+                        </div>
+                        <div class="d-inline-flex gap-2 flex-shrink-0">
+                            {{-- Start/Stop timer --}}
+                            <livewire:issues.issue-quick-timer :issue-id="$i->id" :wire:key="'qt-next-'.$i->id" />
+                            {{-- Unpin/Pin --}}
+                            <livewire:issues.next-toggle :issue-id="$i->id" :is-next="$i->is_next" :wire:key="'next-next-'.$i->id" />
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </div>
+    @endif
+
+    {{-- On Deck (not pinned) --}}
     <div class="card shadow-sm">
         <div class="card-header d-flex align-items-center justify-content-between">
             <h3 class="h6 mb-0">On Deck</h3>
@@ -51,12 +83,13 @@
                         </a>
                         <span class="badge ms-2"
                               style="background-color: {{ $i->status?->color ?? 'transparent' }}20;">
-                              {{ $i->status?->name }}
+                            {{ $i->status?->name }}
                         </span>
                         <div class="small text-body-secondary">Updated {{ $i->updated_at?->diffForHumans() }}</div>
                     </div>
-                    <div class="flex-shrink-0">
-                        <livewire:issues.issue-quick-timer :issue-id="$i->id" :wire:key="'qt-today-'.$i->id" />
+                    <div class="d-inline-flex gap-2 flex-shrink-0">
+                        <livewire:issues.issue-quick-timer :issue-id="$i->id" :wire:key="'qt-deck-'.$i->id" />
+                        <livewire:issues.next-toggle :issue-id="$i->id" :is-next="$i->is_next" :wire:key="'next-deck-'.$i->id" />
                     </div>
                 </div>
             @empty

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -7,7 +7,7 @@
 <nav class="navbar navbar-expand-md bg-body border-bottom" x-data>
     <div class="container mx-auto py-4">
         <!-- Brand -->
-        <a class="navbar-brand d-flex align-items-center gap-2" href="{{ $user ? route('dashboard') : url('/') }}">
+        <a class="navbar-brand d-flex align-items-center gap-2" href="{{ url('/') }}">
             <x-application-logo />
         </a>
         <!-- Toggler -->

--- a/resources/views/pages/notes/index.blade.php
+++ b/resources/views/pages/notes/index.blade.php
@@ -1,0 +1,18 @@
+<?php
+
+use function Laravel\Folio\{name, middleware};
+
+name('notes.index');
+middleware(['auth','verified']);
+?>
+<x-app-layout>
+    <x-slot name="header"><h1 class="h4 mb-0">Notes</h1></x-slot>
+    <div class="container py-3">
+        <div class="row g-3">
+            <div class="col-12 col-xl-6">
+                {{-- No project passed → shows project picker for Convert --}}
+                <livewire:notes.quick-capture />
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/pages/projects/[project]/issues/[issue].blade.php
+++ b/resources/views/pages/projects/[project]/issues/[issue].blade.php
@@ -303,6 +303,7 @@ render(function (View $view, Project $project, Issue $issue) {
                             @endforelse
                         </ul>
                     </div>
+                    <livewire:issues.issue-quick-timer :issue-id="$issue->id" :wire:key="'qt-show-'.$issue->id" />
                 @endcan
             @can('update', $issue)
                     <a href="{{ route('issues.edit', ['project'=>$project, 'issue'=>$issue]) }}"

--- a/resources/views/pages/projects/[project]/issues/[issue].blade.php
+++ b/resources/views/pages/projects/[project]/issues/[issue].blade.php
@@ -435,6 +435,7 @@ render(function (View $view, Project $project, Issue $issue) {
                                             <wa-tab panel="subissues">Sub-issues</wa-tab>
                                             <wa-tab panel="activity">Activity</wa-tab>
                                             <wa-tab panel="time">Time</wa-tab>
+                                            <wa-tab panel="notes">Notes</wa-tab>
                                         </div>
                                     </div>
 
@@ -627,6 +628,11 @@ render(function (View $view, Project $project, Issue $issue) {
                                             <livewire:issues.focus-timer :issue="$issue"/>
                                         </div>
                                         <livewire:issues.time-entries-panel :issue="$issue"/>
+                                    </wa-tab-panel>
+
+                                    <!-- Notes panel -->
+                                    <wa-tab-panel name="notes">
+                                        <livewire:issues.issue-notes-panel :issue="$issue" />
                                     </wa-tab-panel>
                                 </wa-tab-group>
 

--- a/resources/views/pages/projects/[project]/issues/[issue].blade.php
+++ b/resources/views/pages/projects/[project]/issues/[issue].blade.php
@@ -304,6 +304,7 @@ render(function (View $view, Project $project, Issue $issue) {
                         </ul>
                     </div>
                     <livewire:issues.issue-quick-timer :issue-id="$issue->id" :wire:key="'qt-show-'.$issue->id" />
+                    <livewire:issues.next-toggle :issue-id="$issue->id" :is-next="$issue->is_next" :wire:key="'next-'.$issue->id" />
                 @endcan
             @can('update', $issue)
                     <a href="{{ route('issues.edit', ['project'=>$project, 'issue'=>$issue]) }}"

--- a/resources/views/pages/projects/[project]/issues/[issue]/focus.blade.php
+++ b/resources/views/pages/projects/[project]/issues/[issue]/focus.blade.php
@@ -1,20 +1,17 @@
 <?php
 
 use App\Models\Issue;
-use App\Models\Project;
-use Illuminate\Contracts\View\View;
+use Illuminate\View\View;
 use function Laravel\Folio\{name, middleware, render};
 
 name('issues.focus');
-middleware(['auth', 'verified']);
+middleware(['auth','verified']);
 
-render(function (View $view, Project $project, Issue $issue): void {
-    //
+render(function (View $view, Issue $issue) {
+    $view->with('issue', $issue->loadMissing('project'));
 });
-
 ?>
 <x-app-layout>
-    <div class="p-4">
-        <livewire:issues.focus-timer :issue="$issue" />
-    </div>
+    <x-slot name="header"><h1 class="h5 mb-0">Focus: {{ $issue->summary }}</h1></x-slot>
+    <div class="container py-3"><livewire:issues.focus-timer :issue="$issue"/></div>
 </x-app-layout>

--- a/resources/views/pages/projects/[project]/issues/[issue]/focus.blade.php
+++ b/resources/views/pages/projects/[project]/issues/[issue]/focus.blade.php
@@ -2,6 +2,7 @@
 
 use App\Models\Issue;
 use Illuminate\View\View;
+
 use function Laravel\Folio\{name, middleware, render};
 
 name('issues.focus');

--- a/resources/views/pages/projects/[project]/issues/[issue]/focus/public.blade.php
+++ b/resources/views/pages/projects/[project]/issues/[issue]/focus/public.blade.php
@@ -1,188 +1,22 @@
 <?php
 
 use App\Models\Issue;
-use App\Models\Project;
-use App\Models\TimeEntry;
-use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
-use function Laravel\Folio\{name, middleware, render};
+use Illuminate\Support\Facades\URL;
+use Illuminate\View\View;
+use function Laravel\Folio\{name, render};
 
 name('issues.focus.public');
-// No auth – signed link required
-middleware(['signed']);
 
-render(function (View $view, Request $request, Project $project, Issue $issue): void {
-    $running = TimeEntry::query()
-        ->where('issue_id', $issue->id)
-        ->whereNull('ended_at')
-        ->latest('started_at')
-        ->first();
-
-    $startedAt = $running?->started_at?->getTimestamp();
-    $isRunning = $running !== null;
-
-    $payload = [
-        'is_running' => $isRunning,
-        'started_at' => $startedAt,
-        'server_now' => now()->getTimestamp(),
-    ];
-
-    if ($request->wantsJson() || $request->boolean('json')) {
-        echo response()->json($payload)->send();
-        exit;
-    }
-
-    $view->with(array_merge([
-        'transparent' => false,
-        'compact' => false,
-        'pollMs' => 5000,
-    ], [
-        'isRunning' => $isRunning,
-        'startedAt' => $startedAt,
-    ]));
+render(function (View $view, Request $request, Issue $issue) {
+    abort_unless(URL::hasValidSignature($request), 403);
+    $view->with('issue', $issue->loadMissing('project'));
 });
 ?>
-@php
-    // Safe defaults in case the page is parsed before render() binds data
-    $transparent = $transparent ?? false;
-    $compact = $compact ?? false;
-    $pollMs = $pollMs ?? 5000;
-    $isRunning = $isRunning ?? false;
-    $startedAt = $startedAt ?? null;
-@endphp
-    <!doctype html>
-<html lang="en">
-<head>
-    <meta charset="utf-8"/>
-    <title>Focus Timer</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1"/>
-    <style>
-        html, body {
-            margin: 0;
-            padding: 0;
-        }
-
-        body {
-            font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
-            background: {{ $transparent ? 'transparent' : '#0b1020' }};
-            color: #fff;
-        }
-
-        .wrap {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            min-height: 100vh;
-        }
-
-        .timer {
-            font-weight: 700;
-            letter-spacing: .02em;
-            {{ $compact ? 'font-size: 32px; padding: 6px 10px; border-radius: 10px;' : 'font-size: 48px; padding: 10px 16px; border-radius: 14px;' }}
-   background: {{ $transparent ? 'transparent' : 'rgba(255,255,255,.08)' }};
-            border: {{ $transparent ? 'none' : '1px solid rgba(255,255,255,.15)' }};
-            backdrop-filter: blur(8px);
-        }
-
-        .paused {
-            opacity: .7
-        }
-
-        .badge {
-            font-size: 12px;
-            margin-left: 10px;
-            opacity: .8
-        }
-    </style>
-</head>
-<body>
-<div class="wrap">
-    <div class="timer" id="t">
-        <span id="time">00:00:00</span>
-        <span id="state" class="badge"></span>
-    </div>
-</div>
-
-<script>
-    (function () {
-        const startedAt = @json(($isRunning && $startedAt) ? (int) $startedAt : null, JSON_THROW_ON_ERROR);
-        const pollMs = @json((int) $pollMs, JSON_THROW_ON_ERROR);
-        let isRunning = @json((bool) $isRunning, JSON_THROW_ON_ERROR);
-        let seconds = 0;
-
-        const elTime = document.getElementById('time');
-        const elState = document.getElementById('state');
-        const elTimer = document.getElementById('t');
-
-        function fmt(total) {
-            total = Math.max(0, Math.floor(Number(total) || 0));
-            const h = String(Math.floor(total / 3600)).padStart(2, '0');
-            const m = String(Math.floor((total % 3600) / 60)).padStart(2, '0');
-            const s = String(Math.floor(total % 60)).padStart(2, '0');
-            return `${h}:${m}:${s}`;
-        }
-
-        function setState(run) {
-            isRunning = !!run;
-            elState.textContent = isRunning ? 'LIVE' : 'PAUSED';
-            elTimer.classList.toggle('paused', !isRunning);
-        }
-
-        // Seed
-        if (startedAt) {
-            seconds = Math.max(0, Math.floor(Date.now() / 1000) - startedAt);
-            setState(true);
-            elTime.textContent = fmt(seconds);
-        } else {
-            setState(false);
-            elTime.textContent = fmt(0);
-        }
-
-        // Local tick
-        setInterval(() => {
-            if (isRunning) {
-                seconds += 1;
-                elTime.textContent = fmt(seconds);
-            }
-        }, 1000);
-
-        // Poll server for authoritative state
-        async function poll() {
-            try {
-                const url = new URL(window.location.href);
-                url.searchParams.set('json', '1');
-                const res = await fetch(url.toString(), {headers: {'Accept': 'application/json'}, cache: 'no-store'});
-                const data = await res.json();
-
-                const running = !!data.is_running;
-                if (running) {
-                    const now = Math.floor(Date.now() / 1000);
-                    const serverStart = Number(data.started_at || 0);
-                    const serverNow = Number(data.server_now || now);
-                    const serverElapsed = Math.max(0, serverNow - serverStart);
-
-                    // If server is ahead, jump forward; if behind, ignore to avoid flicker
-                    if (serverElapsed > seconds) {
-                        seconds = serverElapsed;
-                        elTime.textContent = fmt(seconds);
-                    }
-                } else {
-                    seconds = 0;
-                    elTime.textContent = fmt(0);
-                }
-
-                if (running !== isRunning) {
-                    setState(running);
-                }
-            } catch (_) {
-                /* ignore network hiccups */
-            } finally {
-                setTimeout(poll, pollMs);
-            }
-        }
-
-        setTimeout(poll, pollMs);
-    })();
-</script>
-</body>
-</html>
+    <!doctype html><html lang="en"><head>
+    <meta charset="utf-8"><title>Focus</title>
+    @vite(['resources/js/app.js','resources/css/app.css']) @livewireStyles
+</head><body class="bg-body p-3">
+<div class="container"><livewire:issues.focus-timer :issue="$issue"/></div>
+@livewireScripts
+</body></html>

--- a/resources/views/pages/projects/[project]/issues/[issue]/focus/public.blade.php
+++ b/resources/views/pages/projects/[project]/issues/[issue]/focus/public.blade.php
@@ -4,6 +4,7 @@ use App\Models\Issue;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\URL;
 use Illuminate\View\View;
+
 use function Laravel\Folio\{name, render};
 
 name('issues.focus.public');

--- a/resources/views/pages/projects/[project]/issues/index.blade.php
+++ b/resources/views/pages/projects/[project]/issues/index.blade.php
@@ -103,6 +103,9 @@ render(function (View $view, Project $project, Request $request) {
         ->when($request->filled('priority'), function ($q) use ($request) {
             $q->whereRelation('priority', 'id', (string)$request->string('priority'));
         })
+        ->when($request->boolean('next'), function ($q) {
+            $q->where('is_next', true);
+        })
         ->when($request->boolean('assigned_to_me'), function ($q) {
             $q->where('assignee_id', auth()->id());
         })
@@ -303,6 +306,11 @@ render(function (View $view, Project $project, Request $request) {
                     @endforeach
                 </select>
 
+                <div class="form-check">
+                    <input class="form-check-input" type="checkbox" name="next" value="1" id="next" @checked(request('next'))>
+                    <label class="form-check-label" for="next">Only “Next”</label>
+                </div>
+
                 <div class="form-check ms-2">
                     <input class="form-check-input" type="checkbox" name="assigned_to_me" value="1"
                            id="me" @checked(request('assigned_to_me'))>
@@ -470,6 +478,9 @@ render(function (View $view, Project $project, Request $request) {
                                     </div>
                                     <span class="ms-2 align-middle">
                                         <livewire:issues.issue-quick-timer :issue-id="$issue->id" :wire:key="'qt-row-'.$issue->id" />
+                                    </span>
+                                    <span class="ms-2 align-middle">
+                                        <livewire:issues.next-toggle :issue-id="$issue->id" :is-next="$issue->is_next" :wire:key="'next-row-'.$issue->id" />
                                     </span>
                                 @endcan
                             </td>

--- a/resources/views/pages/projects/[project]/issues/index.blade.php
+++ b/resources/views/pages/projects/[project]/issues/index.blade.php
@@ -468,6 +468,9 @@ render(function (View $view, Project $project, Request $request) {
                                             @endforelse
                                         </ul>
                                     </div>
+                                    <span class="ms-2 align-middle">
+                                        <livewire:issues.issue-quick-timer :issue-id="$issue->id" :wire:key="'qt-row-'.$issue->id" />
+                                    </span>
                                 @endcan
                             </td>
                         </tr>

--- a/resources/views/pages/stream/now-public.blade.php
+++ b/resources/views/pages/stream/now-public.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\TimeEntry;
+use App\Settings\PersonalizationSettings;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\URL;
 
@@ -11,7 +12,23 @@ name('stream.now.public');
 render(function (Request $request) {
     abort_unless(URL::hasValidSignature($request), 403);
 
-    $userId = (string) $request->string('user');
+    $userId = (string)$request->string('user');
+
+    /** @var PersonalizationSettings $prefs */
+    $prefs = app(PersonalizationSettings::class);
+
+    $enabled = false;
+    if (method_exists($prefs, 'forUser')) {
+        /** @var PersonalizationSettings $owner */
+        $owner = $prefs::forUser($userId);
+        $enabled = (bool)($owner->streamer_mode ?? false);
+    } else {
+        $enabled = (bool)($prefs->streamer_mode ?? false);
+    }
+
+    abort_unless($enabled, 404);
+
+    $userId = (string)$request->string('user');
 
     $running = TimeEntry::query()
         ->where('user_id', $userId)
@@ -21,18 +38,18 @@ render(function (Request $request) {
         ->first();
 
     $payload = $running ? [
-        'user_id'         => $userId,
-        'issue_id'        => (string) $running->issue_id,
-        'issue_key'       => $running->issue?->key,
-        'issue_summary'   => $running->issue?->summary,
-        'project_id'      => $running->issue?->project_id,
-        'project_key'     => $running->issue?->project?->key,
-        'started_at'      => optional($running->started_at)?->toIso8601String(),
+        'user_id' => $userId,
+        'issue_id' => (string)$running->issue_id,
+        'issue_key' => $running->issue?->key,
+        'issue_summary' => $running->issue?->summary,
+        'project_id' => $running->issue?->project_id,
+        'project_key' => $running->issue?->project?->key,
+        'started_at' => optional($running->started_at)?->toIso8601String(),
         'elapsed_seconds' => max(0, now()->getTimestamp() - $running->started_at->getTimestamp()),
-        'issue_url'       => $running->issue
+        'issue_url' => $running->issue
             ? route('issues.show', ['project' => $running->issue->project_id, 'issue' => $running->issue])
             : null,
-        'updated_at'      => now()->toIso8601String(),
+        'updated_at' => now()->toIso8601String(),
     ] : null;
 
     return response()

--- a/resources/views/pages/stream/now-public.blade.php
+++ b/resources/views/pages/stream/now-public.blade.php
@@ -28,8 +28,6 @@ render(function (Request $request) {
 
     abort_unless($enabled, 404);
 
-    $userId = (string)$request->string('user');
-
     $running = TimeEntry::query()
         ->where('user_id', $userId)
         ->whereNull('ended_at')

--- a/resources/views/pages/stream/now-public.blade.php
+++ b/resources/views/pages/stream/now-public.blade.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\TimeEntry;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\URL;
+
+use function Laravel\Folio\{name, render};
+
+name('stream.now.public');
+
+render(function (Request $request) {
+    abort_unless(URL::hasValidSignature($request), 403);
+
+    $userId = (string) $request->string('user');
+
+    $running = TimeEntry::query()
+        ->where('user_id', $userId)
+        ->whereNull('ended_at')
+        ->with(['issue:id,summary,project_id,key', 'issue.project:id,key'])
+        ->latest('started_at')
+        ->first();
+
+    $payload = $running ? [
+        'user_id'         => $userId,
+        'issue_id'        => (string) $running->issue_id,
+        'issue_key'       => $running->issue?->key,
+        'issue_summary'   => $running->issue?->summary,
+        'project_id'      => $running->issue?->project_id,
+        'project_key'     => $running->issue?->project?->key,
+        'started_at'      => optional($running->started_at)?->toIso8601String(),
+        'elapsed_seconds' => max(0, now()->getTimestamp() - $running->started_at->getTimestamp()),
+        'issue_url'       => $running->issue
+            ? route('issues.show', ['project' => $running->issue->project_id, 'issue' => $running->issue])
+            : null,
+        'updated_at'      => now()->toIso8601String(),
+    ] : null;
+
+    return response()
+        ->json(['running' => $payload])
+        ->header('Cache-Control', 'no-store, max-age=0');
+});

--- a/resources/views/pages/stream/now.blade.php
+++ b/resources/views/pages/stream/now.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\TimeEntry;
+use App\Settings\PersonalizationSettings;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 
@@ -10,7 +11,14 @@ name('stream.now');
 middleware(['auth', 'verified']);
 
 render(function (Request $request) {
-    $userId = (string) Auth::id();
+    /** @var PersonalizationSettings $prefs */
+    $prefs = app(PersonalizationSettings::class);
+
+    if (!(bool)($prefs->streamer_mode ?? false)) {
+        abort(404);
+    }
+
+    $userId = (string)Auth::id();
 
     $running = TimeEntry::query()
         ->where('user_id', $userId)
@@ -20,18 +28,18 @@ render(function (Request $request) {
         ->first();
 
     $payload = $running ? [
-        'user_id'         => $userId,
-        'issue_id'        => (string) $running->issue_id,
-        'issue_key'       => $running->issue?->key,
-        'issue_summary'   => $running->issue?->summary,
-        'project_id'      => $running->issue?->project_id,
-        'project_key'     => $running->issue?->project?->key,
-        'started_at'      => optional($running->started_at)?->toIso8601String(),
+        'user_id' => $userId,
+        'issue_id' => (string)$running->issue_id,
+        'issue_key' => $running->issue?->key,
+        'issue_summary' => $running->issue?->summary,
+        'project_id' => $running->issue?->project_id,
+        'project_key' => $running->issue?->project?->key,
+        'started_at' => optional($running->started_at)?->toIso8601String(),
         'elapsed_seconds' => max(0, now()->getTimestamp() - $running->started_at->getTimestamp()),
-        'issue_url'       => $running->issue
+        'issue_url' => $running->issue
             ? route('issues.show', ['project' => $running->issue->project_id, 'issue' => $running->issue])
             : null,
-        'updated_at'      => now()->toIso8601String(),
+        'updated_at' => now()->toIso8601String(),
     ] : null;
 
     return response()

--- a/resources/views/pages/stream/now.blade.php
+++ b/resources/views/pages/stream/now.blade.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\TimeEntry;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+use function Laravel\Folio\{name, middleware, render};
+
+name('stream.now');
+middleware(['auth', 'verified']);
+
+render(function (Request $request) {
+    $userId = (string) Auth::id();
+
+    $running = TimeEntry::query()
+        ->where('user_id', $userId)
+        ->whereNull('ended_at')
+        ->with(['issue:id,summary,project_id,key', 'issue.project:id,key'])
+        ->latest('started_at')
+        ->first();
+
+    $payload = $running ? [
+        'user_id'         => $userId,
+        'issue_id'        => (string) $running->issue_id,
+        'issue_key'       => $running->issue?->key,
+        'issue_summary'   => $running->issue?->summary,
+        'project_id'      => $running->issue?->project_id,
+        'project_key'     => $running->issue?->project?->key,
+        'started_at'      => optional($running->started_at)?->toIso8601String(),
+        'elapsed_seconds' => max(0, now()->getTimestamp() - $running->started_at->getTimestamp()),
+        'issue_url'       => $running->issue
+            ? route('issues.show', ['project' => $running->issue->project_id, 'issue' => $running->issue])
+            : null,
+        'updated_at'      => now()->toIso8601String(),
+    ] : null;
+
+    return response()
+        ->json(['running' => $payload])
+        ->header('Cache-Control', 'no-store, max-age=0');
+});

--- a/resources/views/pages/stream/overlay.blade.php
+++ b/resources/views/pages/stream/overlay.blade.php
@@ -1,0 +1,103 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use function Laravel\Folio\{name, render};
+
+name('stream.overlay');
+
+render(function (Request $request) {
+    // If ?url is missing, default to the authenticated JSON when logged in.
+    $jsonUrl = (string) $request->string('url', '');
+    if ($jsonUrl === '' && Auth::check()) {
+        $jsonUrl = route('stream.now');
+    }
+
+    view()->share('jsonUrl', $jsonUrl);
+});
+?>
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Now Working On</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>
+        html,body{background:transparent;margin:0}
+        body{font:16px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif}
+        .wrap{padding:.5rem .75rem; background: rgba(0,0,0,.66); color:#fff; border-radius:.5rem;
+            display:inline-flex; gap:.5rem; align-items:center; max-width:95vw}
+        .key{opacity:.85; font-family: ui-monospace, Menlo, Consolas, monospace; white-space:nowrap}
+        .summary{white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:70vw}
+        .time{opacity:.85}
+        .warn{background:#fff3cd;color:#664d03;border:1px solid #ffecb5;border-radius:.5rem;padding:.5rem .75rem;margin:.5rem}
+    </style>
+</head>
+<body>
+<div class="wrap" id="box">
+    <span class="key" id="key">—</span>
+    <span class="summary" id="summary">Loading…</span>
+    <span class="time" id="elapsed"></span>
+</div>
+
+<div id="warning" class="warn" style="display:none">
+    Missing <code>?url=</code> param. While logged in, this page will default to your auth feed.
+    For public/OBS, open the overlay with:
+    <code>{{ route('stream.overlay') }}?url={{ urlencode(URL::signedRoute('stream.now.public', ['user' => auth()->id()])) }}</code>
+</div>
+
+<script>
+    const url = @json($jsonUrl);
+    let startedAt = null;
+
+    const fmt = s => {
+        s = Math.max(0, Math.floor(Number(s)||0));
+        const h = String(Math.floor(s/3600)).padStart(2,'0');
+        const m = String(Math.floor((s%3600)/60)).padStart(2,'0');
+        const a = String(s%60).padStart(2,'0');
+        return `${h}:${m}:${a}`;
+    };
+
+    if (!url) {
+        // Friendly inline guidance, no exception/500s.
+        document.getElementById('key').textContent = '';
+        document.getElementById('summary').textContent = 'Add ?url=… to use this overlay.';
+        document.getElementById('elapsed').textContent = '';
+        const w = document.getElementById('warning');
+        if (w) w.style.display = 'block';
+    } else {
+        async function poll() {
+            try {
+                const r = await fetch(url, {cache:'no-store'});
+                const j = await r.json();
+                const run = j?.running;
+                if (!run) {
+                    document.getElementById('key').textContent = '—';
+                    document.getElementById('summary').textContent = 'No active timer';
+                    document.getElementById('elapsed').textContent = '';
+                    startedAt = null;
+                    return;
+                }
+                document.getElementById('key').textContent = run.issue_key || '';
+                document.getElementById('summary').textContent = run.issue_summary || '';
+                const serverElapsed = Number(run.elapsed_seconds || 0);
+                startedAt = Date.now()/1000 - serverElapsed;
+                document.getElementById('elapsed').textContent = fmt(serverElapsed);
+            } catch (e) {
+                // Keep overlay resilient during hiccups
+            }
+        }
+
+        // Smooth local tick
+        setInterval(() => {
+            if (startedAt != null) {
+                const now = Date.now()/1000;
+                document.getElementById('elapsed').textContent = fmt(now - startedAt);
+            }
+        }, 1000);
+
+        poll(); setInterval(poll, 5000);
+    }
+</script>
+</body>
+</html>

--- a/resources/views/pages/stream/overlay.blade.php
+++ b/resources/views/pages/stream/overlay.blade.php
@@ -31,7 +31,7 @@ render(function (Request $request) {
     <style>
         html, body {
             background: transparent;
-            margin: 0
+            margin: 0;
         }
 
         body {

--- a/resources/views/pages/stream/overlay.blade.php
+++ b/resources/views/pages/stream/overlay.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Settings\PersonalizationSettings;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use function Laravel\Folio\{name, render};
@@ -7,30 +8,71 @@ use function Laravel\Folio\{name, render};
 name('stream.overlay');
 
 render(function (Request $request) {
-    // If ?url is missing, default to the authenticated JSON when logged in.
-    $jsonUrl = (string) $request->string('url', '');
+    $jsonUrl = (string)$request->string('url', '');
+
     if ($jsonUrl === '' && Auth::check()) {
-        $jsonUrl = route('stream.now');
+        /** @var PersonalizationSettings $prefs */
+        $prefs = app(PersonalizationSettings::class);
+        if ((bool)($prefs->streamer_mode ?? false)) {
+            $jsonUrl = route('stream.now');
+        }
     }
 
     view()->share('jsonUrl', $jsonUrl);
 });
 ?>
-<!doctype html>
+    <!doctype html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
     <title>Now Working On</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <style>
-        html,body{background:transparent;margin:0}
-        body{font:16px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif}
-        .wrap{padding:.5rem .75rem; background: rgba(0,0,0,.66); color:#fff; border-radius:.5rem;
-            display:inline-flex; gap:.5rem; align-items:center; max-width:95vw}
-        .key{opacity:.85; font-family: ui-monospace, Menlo, Consolas, monospace; white-space:nowrap}
-        .summary{white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:70vw}
-        .time{opacity:.85}
-        .warn{background:#fff3cd;color:#664d03;border:1px solid #ffecb5;border-radius:.5rem;padding:.5rem .75rem;margin:.5rem}
+        html, body {
+            background: transparent;
+            margin: 0
+        }
+
+        body {
+            font: 16px/1.4 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif
+        }
+
+        .wrap {
+            padding: .5rem .75rem;
+            background: rgba(0, 0, 0, .66);
+            color: #fff;
+            border-radius: .5rem;
+            display: inline-flex;
+            gap: .5rem;
+            align-items: center;
+            max-width: 95vw
+        }
+
+        .key {
+            opacity: .85;
+            font-family: ui-monospace, Menlo, Consolas, monospace;
+            white-space: nowrap
+        }
+
+        .summary {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 70vw
+        }
+
+        .time {
+            opacity: .85
+        }
+
+        .warn {
+            background: #fff3cd;
+            color: #664d03;
+            border: 1px solid #ffecb5;
+            border-radius: .5rem;
+            padding: .5rem .75rem;
+            margin: .5rem
+        }
     </style>
 </head>
 <body>
@@ -43,7 +85,8 @@ render(function (Request $request) {
 <div id="warning" class="warn" style="display:none">
     Missing <code>?url=</code> param. While logged in, this page will default to your auth feed.
     For public/OBS, open the overlay with:
-    <code>{{ route('stream.overlay') }}?url={{ urlencode(URL::signedRoute('stream.now.public', ['user' => auth()->id()])) }}</code>
+    <code>{{ route('stream.overlay') }}
+        ?url={{ urlencode(URL::signedRoute('stream.now.public', ['user' => auth()->id()])) }}</code>
 </div>
 
 <script>
@@ -51,10 +94,10 @@ render(function (Request $request) {
     let startedAt = null;
 
     const fmt = s => {
-        s = Math.max(0, Math.floor(Number(s)||0));
-        const h = String(Math.floor(s/3600)).padStart(2,'0');
-        const m = String(Math.floor((s%3600)/60)).padStart(2,'0');
-        const a = String(s%60).padStart(2,'0');
+        s = Math.max(0, Math.floor(Number(s) || 0));
+        const h = String(Math.floor(s / 3600)).padStart(2, '0');
+        const m = String(Math.floor((s % 3600) / 60)).padStart(2, '0');
+        const a = String(s % 60).padStart(2, '0');
         return `${h}:${m}:${a}`;
     };
 
@@ -68,7 +111,7 @@ render(function (Request $request) {
     } else {
         async function poll() {
             try {
-                const r = await fetch(url, {cache:'no-store'});
+                const r = await fetch(url, {cache: 'no-store'});
                 const j = await r.json();
                 const run = j?.running;
                 if (!run) {
@@ -81,7 +124,7 @@ render(function (Request $request) {
                 document.getElementById('key').textContent = run.issue_key || '';
                 document.getElementById('summary').textContent = run.issue_summary || '';
                 const serverElapsed = Number(run.elapsed_seconds || 0);
-                startedAt = Date.now()/1000 - serverElapsed;
+                startedAt = Date.now() / 1000 - serverElapsed;
                 document.getElementById('elapsed').textContent = fmt(serverElapsed);
             } catch (e) {
                 // Keep overlay resilient during hiccups
@@ -91,12 +134,13 @@ render(function (Request $request) {
         // Smooth local tick
         setInterval(() => {
             if (startedAt != null) {
-                const now = Date.now()/1000;
+                const now = Date.now() / 1000;
                 document.getElementById('elapsed').textContent = fmt(now - startedAt);
             }
         }, 1000);
 
-        poll(); setInterval(poll, 5000);
+        poll();
+        setInterval(poll, 5000);
     }
 </script>
 </body>

--- a/resources/views/pages/stream/overlay.blade.php
+++ b/resources/views/pages/stream/overlay.blade.php
@@ -3,6 +3,7 @@
 use App\Settings\PersonalizationSettings;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+
 use function Laravel\Folio\{name, render};
 
 name('stream.overlay');

--- a/resources/views/pages/today.blade.php
+++ b/resources/views/pages/today.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\View\View;
+
 use function Laravel\Folio\{name, middleware};
 
 name('today.index');

--- a/resources/views/pages/today.blade.php
+++ b/resources/views/pages/today.blade.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\View\View;
+use function Laravel\Folio\{name, middleware};
+
+name('today.index');
+middleware(['auth', 'verified']);
+
+?>
+<x-app-layout>
+    <x-slot name="header">
+        <h1 class="h4 mb-0">Today</h1>
+    </x-slot>
+
+    <div class="container py-3">
+        <div class="row g-3">
+            <div class="col-12 col-xl-8">
+                <livewire:today.today-panel />
+            </div>
+            <div class="col-12 col-xl-4">
+                <livewire:notes.quick-capture />
+            </div>
+        </div>
+    </div>
+</x-app-layout>

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -18,6 +18,9 @@
                         <a href="{{ route('dashboard') }}" class="btn btn-dark">
                             <i class="fa-solid fa-house me-1"></i> Go to Dashboard
                         </a>
+                        <a href="{{ route('today.index') }}" class="btn btn-outline-secondary">
+                            <i class="fa-solid fa-calendar-day me-1"></i> Today's Work
+                        </a>
                         <a href="{{ route('projects.index') }}" class="btn btn-outline-secondary">
                             <i class="fa-solid fa-diagram-project me-1"></i> Browse Projects
                         </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 
 Route::get('/', static function () {
     if (!auth()->check()) {
-        return view('welcome');// Send non-logged-in users to the welcome page
+        return view('welcome'); // Send non-logged-in users to the welcome page
     }
 
     if (Feature::active('solo-mode')) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,8 +17,17 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
-Route::get('/', function () {
-    return view('welcome');
+Route::get('/', static function () {
+    if (!auth()->check()) {
+        return view('welcome');// Send non-logged-in users to the welcome page
+    }
+
+    if (Feature::active('solo-mode')) {
+        return redirect()->route('today.index');
+    }
+
+    // Team-focused fallback: e.g., projects list/board
+    return redirect()->route('dashboard');
 });
 
 Route::middleware(['auth'])->group(function () {


### PR DESCRIPTION
## Summary by Sourcery

Implement solo-developer mode with personalization settings and extensive UI enhancements: introduce a Today dashboard, note capture and management panels, issue pinning, streamer overlay, and refactor timer components and database schema to support these features.

New Features:
- Enable solo-developer mode via personalization settings and a feature flag
- Add a solo-focused "Today" dashboard showing the current timer, pinned Next issues, and on-deck items
- Introduce a Quick Capture panel for user notes with conversion to issues
- Add a Notes panel on issue pages to add, edit, delete, and convert notes to new issues
- Add a "Next" pin toggle for issues with UI controls and an index filter
- Provide a streaming overlay and public "now" endpoint for OBS/streamer mode

Enhancements:
- Refactor focus timer and quick timer UIs into Livewire components and simplify blade pages
- Automatically set issues to in-progress status on timer start based on personalization settings
- Harden the time_entries table with a generated column and unique/index constraints to enforce one running timer per user
- Add query scopes and an isRunning attribute to the TimeEntry model
- Redirect root route to solo or team dashboards based on mode and auth

Chores:
- Add migrations for notes table (with soft deletes), is_next flag on issues, time_entries constraints, and initial personalization settings