### PR TITLE
Refactor time_entries migration for simplicity and clarity

### DIFF
--- a/database/migrations/2025_10_03_152203_harden_time_entries.php
+++ b/database/migrations/2025_10_03_152203_harden_time_entries.php
@@ -5,83 +5,37 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-/**
- * Harden time_entries:
- * - Enforce "one running timer per user".
- * - Add helpful secondary indexes.
- *
- * MySQL/MariaDB: generated column + unique index.
- * SQLite/Postgres: partial unique index on (user_id) WHERE ended_at IS NULL.
- */
 return new class () extends Migration {
     public function up(): void
     {
         $driver = Schema::getConnection()->getDriverName();
 
-        // --- Enforce one running timer per user --------------------------------
-        if ($this->supportsPartialUnique($driver)) {
-            // SQLite / Postgres: partial unique index
-            $this->createPartialUniqueIndex(
-                table: 'time_entries',
-                index: 'time_entries_unique_running_user',
-                columns: ['user_id'],
-                where: 'ended_at IS NULL',
-                driver: $driver,
-            );
+        // Enforce "one running timer per user"
+        if (in_array($driver, ['sqlite', 'pgsql'], true)) {
+            // Partial unique index: (user_id) WHERE ended_at IS NULL
+            DB::statement('CREATE UNIQUE INDEX IF NOT EXISTS time_entries_unique_running_user ON time_entries (user_id) WHERE ended_at IS NULL');
         } else {
-            // MySQL/MariaDB: generated column + unique index
-            if (! Schema::hasColumn('time_entries', 'running_user_id')) {
-                Schema::table('time_entries', static function (Blueprint $t): void {
-                    // Match your UUID length; char(36) is typical
-                    $t->char('running_user_id', 36)
-                        ->nullable()
-                        ->storedAs("(case when `ended_at` is null then `user_id` else null end)");
-                });
+            // MySQL / MariaDB: functional unique index on expression
+            if (! $this->indexExistsMySql('time_entries', 'time_entries_unique_running_user')) {
+                DB::statement('CREATE UNIQUE INDEX `time_entries_unique_running_user` ON `time_entries` ((CASE WHEN `ended_at` IS NULL THEN `user_id` ELSE NULL END))');
             }
-            $this->ensureIndexMySql(
-                table: 'time_entries',
-                index: 'time_entries_unique_running_user',
-                creator: static function (): void {
-                    Schema::table('time_entries', static function (Blueprint $t): void {
-                        $t->unique('running_user_id', 'time_entries_unique_running_user');
-                    });
-                },
-                alsoCheck: ['time_entries_running_user_id_unique']
-            );
         }
 
-        // --- Secondary indexes --------------------------------------------------
-        $this->ensureCompositeIndex(
-            table: 'time_entries',
-            index: 'time_entries_user_ended_at',
-            columns: ['user_id', 'ended_at'],
-            driver: $driver
-        );
-
-        $this->ensureCompositeIndex(
-            table: 'time_entries',
-            index: 'time_entries_issue_started_at',
-            columns: ['issue_id', 'started_at'],
-            driver: $driver
-        );
+        // Secondary indexes (portable)
+        $this->ensureCompositeIndex('time_entries', 'time_entries_user_ended_at', ['user_id', 'ended_at'], $driver);
+        $this->ensureCompositeIndex('time_entries', 'time_entries_issue_started_at', ['issue_id', 'started_at'], $driver);
     }
 
     public function down(): void
     {
         $driver = Schema::getConnection()->getDriverName();
 
-        // Drop unique/rule for "one running timer per user"
-        if ($this->supportsPartialUnique($driver)) {
-            // SQLite / Postgres
-            $this->dropIndexRaw('time_entries_unique_running_user', $driver);
+        // Drop unique constraint for "one running timer per user"
+        if (in_array($driver, ['sqlite', 'pgsql'], true)) {
+            DB::statement('DROP INDEX IF EXISTS time_entries_unique_running_user');
         } else {
-            // MySQL/MariaDB
-            $this->dropIndexMySql('time_entries', 'time_entries_unique_running_user');
-            $this->dropIndexMySql('time_entries', 'time_entries_running_user_id_unique'); // fallback name
-            if (Schema::hasColumn('time_entries', 'running_user_id')) {
-                Schema::table('time_entries', static function (Blueprint $t): void {
-                    $t->dropColumn('running_user_id');
-                });
+            if ($this->indexExistsMySql('time_entries', 'time_entries_unique_running_user')) {
+                DB::statement('DROP INDEX `time_entries_unique_running_user` ON `time_entries`');
             }
         }
 
@@ -90,42 +44,9 @@ return new class () extends Migration {
         $this->dropIndexPortable('time_entries', 'time_entries_issue_started_at', $driver);
     }
 
-    // -------------------------------------------------------------------------
-    // Helpers
-    // -------------------------------------------------------------------------
+    // ----- helpers -----------------------------------------------------------
 
-    private function supportsPartialUnique(string $driver): bool
-    {
-        return in_array($driver, ['sqlite', 'pgsql'], true);
-    }
-
-    /**
-     * Create partial unique index (SQLite/Postgres).
-     *
-     * @param array<int,string> $columns
-     */
-    private function createPartialUniqueIndex(string $table, string $index, array $columns, string $where, string $driver): void
-    {
-        $cols = implode(', ', array_map(static fn ($c) => $driver === 'pgsql' ? "\"$c\"" : $c, $columns));
-
-        if ($driver === 'sqlite') {
-            DB::statement("CREATE UNIQUE INDEX IF NOT EXISTS {$index} ON {$table} ({$cols}) WHERE {$where}");
-            return;
-        }
-
-        if ($driver === 'pgsql') {
-            DB::statement("CREATE UNIQUE INDEX IF NOT EXISTS {$index} ON {$table} ({$cols}) WHERE {$where}");
-            return;
-        }
-
-        // Should never hit for MySQL because supportsPartialUnique()==false there.
-    }
-
-    /**
-     * Ensure composite index exists (portable).
-     *
-     * @param array<int,string> $columns
-     */
+    /** Ensure composite index exists (portable). */
     private function ensureCompositeIndex(string $table, string $index, array $columns, string $driver): void
     {
         if ($driver === 'mysql') {
@@ -137,58 +58,27 @@ return new class () extends Migration {
             return;
         }
 
-        // SQLite / Postgres: IF NOT EXISTS available
         $cols = implode(', ', array_map(static fn ($c) => $driver === 'pgsql' ? "\"$c\"" : $c, $columns));
         DB::statement("CREATE INDEX IF NOT EXISTS {$index} ON {$table} ({$cols})");
     }
 
-    private function ensureIndexMySql(string $table, string $index, callable $creator, array $alsoCheck = []): void
+    private function dropIndexPortable(string $table, string $index, string $driver): void
     {
-        if ($this->indexExistsMySql($table, $index)) {
+        if ($driver === 'mysql') {
+            if ($this->indexExistsMySql($table, $index)) {
+                Schema::table($table, static function (Blueprint $t) use ($index): void {
+                    $t->dropIndex($index);
+                });
+            }
             return;
         }
-        foreach ($alsoCheck as $alt) {
-            if ($this->indexExistsMySql($table, $alt)) {
-                return;
-            }
-        }
-        $creator(); // will add the index via Schema::table()
+
+        DB::statement("DROP INDEX IF EXISTS {$index}");
     }
 
     private function indexExistsMySql(string $table, string $index): bool
     {
         $row = DB::selectOne("SHOW INDEX FROM `{$table}` WHERE Key_name = ?", [$index]);
         return $row !== null;
-    }
-
-    private function dropIndexMySql(string $table, string $index): void
-    {
-        if ($this->indexExistsMySql($table, $index)) {
-            Schema::table($table, static function (Blueprint $t) use ($index): void {
-                $t->dropIndex($index);
-            });
-        }
-    }
-
-    private function dropIndexRaw(string $index, string $driver): void
-    {
-        if ($driver === 'sqlite') {
-            DB::statement("DROP INDEX IF EXISTS {$index}");
-            return;
-        }
-
-        if ($driver === 'pgsql') {
-            DB::statement("DROP INDEX IF EXISTS {$index}");
-            return;
-        }
-    }
-
-    private function dropIndexPortable(string $table, string $index, string $driver): void
-    {
-        if ($driver === 'mysql') {
-            $this->dropIndexMySql($table, $index);
-            return;
-        }
-        $this->dropIndexRaw($index, $driver);
     }
 };


### PR DESCRIPTION
Simplified the migration logic by removing redundant helper methods and consolidating functionality into inline operations. Ensured unique constraints and secondary indexes are created and dropped more efficiently for each database driver. This improves maintainability and reduces complexity in migration code.

## Summary by Sourcery

Refactor the time_entries migration to simplify index management by removing redundant helper methods and consolidating driver-specific index creation and drop logic into inline raw DB statements.

Enhancements:
- Inline unique index creation and dropping using raw DB statements for SQLite, Postgres, and MySQL/MariaDB drivers
- Streamline composite index setup and teardown through a single ensureCompositeIndex method
- Remove unused helper functions and consolidate migration logic for improved readability and maintainability