### PR TITLE
Implement per-record sharing with access level hierarchy

### DIFF
--- a/app/Console/Commands/MakeUserCommand.php
+++ b/app/Console/Commands/MakeUserCommand.php
@@ -17,7 +17,7 @@ class MakeUserCommand extends Command
         $email = $this->ask('What is the user\'s email?');
         $password = $this->secret('What is the user\'s password?');
 
-        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
             $this->error('Invalid email address.');
             return;
         }

--- a/app/Console/Commands/MakeUserCommand.php
+++ b/app/Console/Commands/MakeUserCommand.php
@@ -17,8 +17,15 @@ class MakeUserCommand extends Command
         $email = $this->ask('What is the user\'s email?');
         $password = $this->secret('What is the user\'s password?');
 
+        // Validate email format
         if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
             $this->error('Invalid email address.');
+            return;
+        }
+
+        // Check if the user already exists
+        if (User::where('email', $email)->exists()) {
+            $this->error('A user with this email address already exists.');
             return;
         }
 

--- a/app/Console/Commands/MakeUserCommand.php
+++ b/app/Console/Commands/MakeUserCommand.php
@@ -17,13 +17,22 @@ class MakeUserCommand extends Command
         $email = $this->ask('What is the user\'s email?');
         $password = $this->secret('What is the user\'s password?');
 
-        User::create([
-            'name' => $name,
-            'email' => $email,
-            'password' => Hash::make($password),
-            'email_verified_at' => now(),
-        ]);
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            $this->error('Invalid email address.');
+            return;
+        }
 
+        try {
+            User::create([
+                'name' => $name,
+                'email' => $email,
+                'password' => Hash::make($password),
+                'email_verified_at' => now(),
+            ]);
+        } catch (\Exception $e) {
+            $this->error('Failed to create user: ' . $e->getMessage());
+            return;
+        }
         $this->info('User created successfully!');
     }
 }

--- a/app/Console/Commands/MakeUserCommand.php
+++ b/app/Console/Commands/MakeUserCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+
+class MakeUserCommand extends Command
+{
+    protected $signature = 'make:user';
+    protected $description = 'Create a new user';
+
+    public function handle(): void
+    {
+        $name = $this->ask('What is the user\'s name?');
+        $email = $this->ask('What is the user\'s email?');
+        $password = $this->secret('What is the user\'s password?');
+
+        User::create([
+            'name' => $name,
+            'email' => $email,
+            'password' => Hash::make($password),
+            'email_verified_at' => now(),
+        ]);
+
+        $this->info('User created successfully!');
+    }
+}

--- a/app/Enums/AccessLevel.php
+++ b/app/Enums/AccessLevel.php
@@ -24,8 +24,12 @@ enum AccessLevel: int
 
     public static function max(?self $a, ?self $b): ?self
     {
-        if (! $a) { return $b; }
-        if (! $b) { return $a; }
+        if (! $a) {
+            return $b;
+        }
+        if (! $b) {
+            return $a;
+        }
         return $a->value >= $b->value ? $a : $b;
     }
 }

--- a/app/Enums/AccessLevel.php
+++ b/app/Enums/AccessLevel.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Enums;
+
+enum AccessLevel: int
+{
+    case View = 10;
+    case Comment = 20;
+    case Edit = 30;
+    case Delete = 40;
+    case Manage = 50;
+
+    public function allows(string $ability): bool
+    {
+        return match ($ability) {
+            'view' => $this->value >= self::View->value,
+            'comment' => $this->value >= self::Comment->value,
+            'update' => $this->value >= self::Edit->value,
+            'delete' => $this->value >= self::Delete->value,
+            'manage', 'share' => $this->value >= self::Manage->value,
+            default => false,
+        };
+    }
+
+    public static function max(?self $a, ?self $b): ?self
+    {
+        if (! $a) { return $b; }
+        if (! $b) { return $a; }
+        return $a->value >= $b->value ? $a : $b;
+    }
+}

--- a/app/Livewire/Dashboard/Overview.php
+++ b/app/Livewire/Dashboard/Overview.php
@@ -223,7 +223,7 @@ final class Overview extends Component
                     $targetLabel = "{$project->key} — {$project->name}";
                     $targetUrl   = route('projects.show', ['project' => $project]);
                 }
-            } else if (isset($props['issue_key'], $props['issue_summary'])) {
+            } elseif (isset($props['issue_key'], $props['issue_summary'])) {
                 $targetLabel = "{$props['issue_key']}: {$props['issue_summary']}";
                 if (!empty($props['project_id']) && ($p = $projectsById->get($props['project_id']))) {
                     $targetUrl = route('issues.index', ['project' => $p, 'search' => $props['issue_key']]);

--- a/app/Livewire/Dashboard/Overview.php
+++ b/app/Livewire/Dashboard/Overview.php
@@ -39,7 +39,17 @@ final class Overview extends Component
         $user = auth()->user();
         $teamId = $user->currentTeam?->id;
 
-        // my issues
+        // Subquery of projects visible to the user (lead, direct member, or via team)
+        $visibleProjectsSub = Project::query()
+            ->visibleTo($user)
+            ->select('id');
+
+        // Materialized set for activity hydration
+        $visibleProjectIds = Project::query()
+            ->visibleTo($user)
+            ->pluck('id');
+
+        // My issues (only from visible projects)
         $this->myIssues = Issue::query()
             ->select(['id', 'summary', 'key', 'project_id', 'issue_status_id', 'issue_type_id', 'assignee_id', 'updated_at', 'due_at'])
             ->with([
@@ -48,32 +58,36 @@ final class Overview extends Component
                 'type:id,key,name',
             ])
             ->where('assignee_id', $user->id)
+            ->whereIn('project_id', $visibleProjectsSub)
             ->whereHas('status', fn ($q) => $q->where('is_done', false))
             ->latest('updated_at')
             ->limit(10)
             ->get();
 
-        // status summary
+        // Status summary (only from visible projects)
         $this->statusSummary = Issue::query()
             ->where('assignee_id', $user->id)
+            ->whereIn('project_id', $visibleProjectsSub)
             ->selectRaw('issue_status_id, COUNT(*) as total')
             ->groupBy('issue_status_id')
             ->pluck('total', 'issue_status_id')
             ->toArray();
 
-        // due soon
+        // Due soon (only from visible projects)
         $this->upcomingDue = Issue::query()
             ->select(['id', 'summary', 'key', 'project_id', 'due_at', 'issue_status_id'])
             ->with(['project:id,key,name', 'status:id,name,color,is_done'])
             ->where('assignee_id', $user->id)
+            ->whereIn('project_id', $visibleProjectsSub)
             ->whereNotNull('due_at')
             ->whereBetween('due_at', [now(), now()->addDays(14)])
             ->orderBy('due_at')
             ->limit(10)
             ->get();
 
-        // my projects
-        $this->myProjects = $user->projects()
+        // My projects (already visibility-scoped)
+        $this->myProjects = Project::query()
+            ->visibleTo($user)
             ->select(['projects.id', 'projects.name', 'projects.key'])
             ->withCount([
                 'issues as open_issues_count' => fn ($q) => $q->whereHas(
@@ -133,8 +147,17 @@ final class Overview extends Component
             }
         }
 
+        // Only hydrate projects the user can access
+        $projectsById = Project::query()
+            ->whereIn('id', array_filter($projectIds->all()))
+            ->whereIn('id', $visibleProjectIds)
+            ->get(['id', 'key', 'name'])
+            ->keyBy('id');
+
+        // Only hydrate issues whose projects the user can access
         $issuesById = Issue::query()
             ->whereIn('id', array_filter($issueIds->all()))
+            ->whereIn('project_id', $visibleProjectIds)
             ->with(['project:id,key,name'])
             ->get(['id', 'key', 'summary', 'project_id'])
             ->keyBy('id');
@@ -142,11 +165,6 @@ final class Overview extends Component
         $usersById = User::query()
             ->whereIn('id', array_filter($causerIds->all()))
             ->get(['id', 'name', 'profile_photo_path'])
-            ->keyBy('id');
-
-        $projectsById = Project::query()
-            ->whereIn('id', array_filter($projectIds->all()))
-            ->get(['id', 'key', 'name'])
             ->keyBy('id');
 
         $statusMap   = IssueStatus::query()->whereIn('id', array_filter($statusIds))->get(['id', 'name', 'color'])->keyBy('id');
@@ -185,7 +203,6 @@ final class Overview extends Component
             $actorName   = $actor?->name ?? 'System';
             $actorAvatar = $actor?->profile_photo_url ?? $actor?->profile_photo_path ?? null;
 
-            // Target + link resolution (dashboard-wide)
             $targetType  = $a->subject_type === Issue::class ? 'issue'
                 : ($a->subject_type === Project::class ? 'project' : ($a->log_name ?: 'record'));
             $targetLabel = 'record';
@@ -213,11 +230,9 @@ final class Overview extends Component
                 }
             }
 
-            // Verb
             $verb = $a->event ?: (Str::contains((string)$a->description, '.') ? Str::after((string)$a->description, '.') : (string)$a->description);
             $verb = Str::of($verb)->replace(['issue.', 'project.'], '')->headline();
 
-            // Field diffs
             $changes = [];
             $keys = array_unique(array_merge(array_keys($new), array_keys($old)));
             foreach ($keys as $k) {
@@ -258,16 +273,16 @@ final class Overview extends Component
             }
 
             return [
-                'id'          => $a->id,
-                'actor_name'  => $actorName,
+                'id'           => $a->id,
+                'actor_name'   => $actorName,
                 'actor_avatar' => $actorAvatar,
-                'verb'        => (string)$verb,
-                'target_type' => $targetType,
+                'verb'         => (string)$verb,
+                'target_type'  => $targetType,
                 'target_label' => $targetLabel,
-                'target_url'  => $targetUrl,
-                'changes'     => $changes,
-                'created_at'  => $a->created_at,
-                'ago'         => $a->created_at?->diffForHumans(),
+                'target_url'   => $targetUrl,
+                'changes'      => $changes,
+                'created_at'   => $a->created_at,
+                'ago'          => $a->created_at?->diffForHumans(),
             ];
         });
 

--- a/app/Models/Goal.php
+++ b/app/Models/Goal.php
@@ -7,6 +7,7 @@ use App\Enums\GoalHealth;
 use App\Enums\GoalStatus;
 use App\Enums\GoalType;
 use App\Observers\GoalObserver;
+use App\Traits\HasRecordShares;
 use App\Traits\IsPermissible;
 use DateTimeInterface;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
@@ -32,6 +33,7 @@ class Goal extends Model
 {
     use HasFactory;
     use IsPermissible;
+    use HasRecordShares;
 
     protected $keyType = 'string';
     public $incrementing = false;

--- a/app/Models/Issue.php
+++ b/app/Models/Issue.php
@@ -391,4 +391,13 @@ class Issue extends BaseModel implements HasMedia
     {
         return $query->where('is_public', true);
     }
+
+    /** Determine if the user can access this issue via its project. */
+    public function isAccessibleBy(User $user): bool
+    {
+        $project = $this->parentShareable();
+
+        return $project?->isAccessibleBy($user) ?? false;
+    }
+
 }

--- a/app/Models/Issue.php
+++ b/app/Models/Issue.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Support\ActivityContext;
 use App\Traits\HasExternalId;
+use App\Traits\HasRecordShares;
 use App\Traits\IsPermissible;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -31,6 +32,7 @@ class Issue extends BaseModel implements HasMedia
     use InteractsWithMedia;
     use IsPermissible;
     use HasExternalId;
+    use HasRecordShares;
 
     protected $keyType = 'string';
     public $incrementing = false;
@@ -377,6 +379,11 @@ class Issue extends BaseModel implements HasMedia
             get: fn () => $this->issue_priority_id,
             set: static fn ($value) => ['issue_priority_id' => $value],
         );
+    }
+
+    public function parentShareable(): ?object
+    {
+        return $this->project;
     }
 
     /** @return Builder<Model, static> */

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\ProjectStage;
 use App\Support\ActivityContext;
 use App\Traits\HasExternalId;
+use App\Traits\HasRecordShares;
 use App\Traits\IsPermissible;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -23,6 +24,7 @@ class Project extends BaseModel
     use LogsActivity;
     use IsPermissible;
     use HasExternalId;
+    use HasRecordShares;
 
     protected $keyType = 'string';
     public $incrementing = false;

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -184,9 +184,9 @@ class Project extends BaseModel
             ->withTimestamps();
     }
 
-    public function lead(): HasOne
+    public function lead(): BelongsTo
     {
-        return $this->hasOne(User::class, 'lead_id');
+        return $this->belongsTo(User::class, 'lead_id');
     }
 
     public function issues(): HasMany
@@ -295,17 +295,30 @@ class Project extends BaseModel
     /** Quick access check */
     public function isAccessibleBy(User $user): bool
     {
+        // If this Project model has no primary key loaded, don’t try to build relations.
+        if (! filled($this->id)) {
+            return false;
+        }
+
         if ($user->hasPermissionTo('is-super-admin')) {
             return true;
         }
+
         if ((string) $this->lead_id === (string) $user->id) {
             return true;
         }
+
+        // Direct project membership
         if ($this->users()->whereKey($user->id)->exists()) {
             return true;
         }
-        // Jetstream pivot is team_user (team_id, user_id)
-        return $this->teams()->whereHas('allUsers', fn ($q) => $q->where('users.id', $user->id))->exists();
+
+        // Team membership (owner or member)
+        return $this->teams()->where(function ($t) use ($user) {
+            // if teams table has owner column:
+            $t->where('teams.user_id', $user->id) // owner
+            ->orWhereHas('users', fn ($u) => $u->whereKey($user->id)); // members via team_user
+        })->exists();
     }
 
     /** Scope: projects visible to a user (lead, direct member, or member of any attached team) */

--- a/app/Models/RecordShare.php
+++ b/app/Models/RecordShare.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\AccessLevel;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+/**
+ * @property string $id
+ * @property string $shareable_type
+ * @property string $shareable_id
+ * @property string $principal_type
+ * @property string $principal_id
+ * @property AccessLevel $access_level
+ * @property bool $propagate_to_children
+ * @property CarbonImmutable|null $expires_at
+ */
+class RecordShare extends Model
+{
+    /** @var array<int, string> */
+    protected $fillable = [
+        'shareable_type', 'shareable_id',
+        'principal_type', 'principal_id',
+        'access_level', 'propagate_to_children', 'expires_at', 'grantor_id',
+    ];
+
+    /** @return array<string, string> */
+    public function casts(): array
+    {
+        return [
+            'access_level' => AccessLevel::class,
+            'expires_at' => 'immutable_datetime',
+            'propagate_to_children' => 'boolean',
+        ];
+    }
+
+    public function shareable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function principal(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function scopeNotExpired($q)
+    {
+        return $q->where(function ($q) {
+            $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
+        });
+    }
+}

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Traits\HasRecordShares;
 use App\Traits\IsPermissible;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
@@ -12,6 +13,7 @@ class Repository extends BaseModel
 {
     use HasUuids;
     use IsPermissible;
+    use HasRecordShares;
 
     protected $fillable = [
         'provider',

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -42,17 +42,20 @@ class Repository extends BaseModel
     }
 
     /** @return HasMany<ProjectRepository> */
-    public function projectLinks(): HasMany {
+    public function projectLinks(): HasMany
+    {
         return $this->hasMany(ProjectRepository::class);
     }
 
     /** @return HasMany<IssueExternalRef> */
-    public function externalIssues(): HasMany {
+    public function externalIssues(): HasMany
+    {
         return $this->hasMany(IssueExternalRef::class);
     }
 
     /** @return HasMany<IssueStatusMapping> */
-    public function statusMappings(): HasMany {
+    public function statusMappings(): HasMany
+    {
         return $this->hasMany(IssueStatusMapping::class);
     }
 }

--- a/app/Models/Sprint.php
+++ b/app/Models/Sprint.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\SprintState;
+use App\Traits\HasRecordShares;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
@@ -14,6 +15,7 @@ class Sprint extends Model
 {
     use HasUuids;
     use SoftDeletes;
+    use HasRecordShares;
 
     protected $fillable = [
         'project_id', 'name', 'goal', 'start_date', 'end_date', 'sort_order',

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Services\Support\TicketKeyService;
 use App\Support\ActivityContext;
+use App\Traits\HasRecordShares;
 use App\Traits\IsPermissible;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -25,6 +26,7 @@ class Ticket extends BaseModel
     use HasUlids;
     use LogsActivity;
     use IsPermissible;
+    use HasRecordShares;
 
     protected $guarded = [];
 

--- a/app/Policies/IssuePolicy.php
+++ b/app/Policies/IssuePolicy.php
@@ -73,6 +73,6 @@ class IssuePolicy
         }
 
         $level = $this->shares->levelFor($user, $issue);
-        return $level?->allows('manage') === true;
+        return $level?->allows('manage') ?? false;
     }
 }

--- a/app/Policies/IssuePolicy.php
+++ b/app/Policies/IssuePolicy.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Issue;
+use App\Models\User;
+use App\Services\RecordAccessService;
+
+class IssuePolicy
+{
+    public function __construct(private RecordAccessService $shares) {
+    }
+
+    public function view(User $user, Issue $issue): bool
+    {
+        if ($user->hasPermissionTo('is-super-admin')) {
+            return true;
+        }
+
+        $level = $this->shares->levelFor($user, $issue);
+        if ($level?->allows('view') === true) {
+            return true;
+        }
+
+        if (! $user->can('issues.view')) {
+            return false;
+        }
+
+        return $issue->isAccessibleBy($user);
+    }
+
+    public function update(User $user, Issue $issue): bool
+    {
+        if ($user->hasPermissionTo('is-super-admin') || $user->hasPermissionTo('issues.manage')) {
+            return true;
+        }
+
+        $level = $this->shares->levelFor($user, $issue);
+        if ($level?->allows('update') === true) {
+            return true;
+        }
+
+        if (! $issue->isAccessibleBy($user)) {
+            return false;
+        }
+
+        return $user->hasPermissionTo('issues.update') || $user->hasPermissionTo('issues.manage');
+    }
+
+    public function delete(User $user, Issue $issue): bool
+    {
+        if ($user->hasPermissionTo('is-super-admin') || $user->hasPermissionTo('issues.manage')) {
+            return true;
+        }
+
+        $level = $this->shares->levelFor($user, $issue);
+        if ($level?->allows('manage') === true) {
+            return true;
+        }
+
+        if (! $issue->isAccessibleBy($user)) {
+            return false;
+        }
+
+        return $user->hasPermissionTo('issues.delete') || $user->hasPermissionTo('issues.manage');
+    }
+
+    public function share(User $user, Issue $issue): bool
+    {
+        if ($user->hasPermissionTo('is-super-admin') || $user->hasPermissionTo('issues.manage')) {
+            return true;
+        }
+
+        $level = $this->shares->levelFor($user, $issue);
+        return $level?->allows('manage') === true;
+    }
+}

--- a/app/Policies/IssuePolicy.php
+++ b/app/Policies/IssuePolicy.php
@@ -8,7 +8,8 @@ use App\Services\RecordAccessService;
 
 class IssuePolicy
 {
-    public function __construct(private RecordAccessService $shares) {
+    public function __construct(private RecordAccessService $shares)
+    {
     }
 
     public function view(User $user, Issue $issue): bool

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -5,70 +5,81 @@ namespace App\Policies;
 use App\Models\Permission;
 use App\Models\Project;
 use App\Models\User;
+use App\Services\RecordAccessService;
 use Illuminate\Support\Facades\DB;
 
 class ProjectPolicy
 {
-    public function view(User $user, Project $project): bool
-    {
-        if (! $user->can('projects.view')) {
-            return false;
-        }
-
-        return $project->isAccessibleBy($user);
+    public function __construct(private RecordAccessService $shares) {
     }
 
-    public function create(User $user): bool
+    public function view(User $user, Project $project): bool
     {
-        // Super admin wins
         if ($user->hasPermissionTo('is-super-admin')) {
             return true;
         }
 
-        // Direct user permission (global or team-scoped) — fast path
+        if ($user->can('projects.view') && $project->isAccessibleBy($user)) {
+            return true;
+        }
+
+        $level = $this->shares->levelFor($user, $project);
+        return $level?->allows('view') ?? false;
+    }
+
+    public function create(User $user): bool
+    {
+        if ($user->hasPermissionTo('is-super-admin')) {
+            return true;
+        }
+
         if ($user->hasPermissionTo('projects.manage')) {
             return true;
         }
 
-        // Resolve the permission id once
-        return $this->resolveThePermissionIdOnce($user);
-    }
-
-    public function delete(User $user, Project $project): bool
-    {
-        // Keep delete tied to access + manage
-        if (! $project->isAccessibleBy($user)) {
-            return false;
-        }
-
-        // Same cross-team logic as create, but reuse the quick checks
-        if ($user->hasPermissionTo('is-super-admin') || $user->hasPermissionTo('projects.manage')) {
-            return true;
-        }
-
-        return $this->resolveThePermissionIdOnce($user) || $user->hasPermissionTo('projects.delete');
+        return $this->hasManageViaRole($user);
     }
 
     public function update(User $user, Project $project): bool
     {
-        // Keep update tied to access + manage
-        if (! $project->isAccessibleBy($user)) {
-            return false;
-        }
-
-        // Same cross-team logic as create, but reuse the quick checks
         if ($user->hasPermissionTo('is-super-admin') || $user->hasPermissionTo('projects.manage')) {
             return true;
         }
 
-        return $this->resolveThePermissionIdOnce($user);
+        if ($project->isAccessibleBy($user) && ($this->hasManageViaRole($user))) {
+            return true;
+        }
+
+        $level = $this->shares->levelFor($user, $project);
+        return $level?->allows('update') ?? false;
     }
 
-    /**
-     * @param User $user
-     * @return bool
-     */
-    private function resolveThePermissionIdOnce(User $user): bool
+    public function delete(User $user, Project $project): bool
+    {
+        if ($user->hasPermissionTo('is-super-admin') || $user->hasPermissionTo('projects.manage')) {
+            return true;
+        }
+
+        if ($project->isAccessibleBy($user) && ($this->hasManageViaRole($user) || $user->hasPermissionTo('projects.delete'))) {
+            return true;
+        }
+
+        $level = $this->shares->levelFor($user, $project);
+        return $level?->allows('manage') ?? false;
+    }
+
+    public function share(User $user, Project $project): bool
+    {
+        if ($user->hasPermissionTo('is-super-admin') || $user->hasPermissionTo('projects.manage')) {
+            return true;
+        }
+
+        $level = $this->shares->levelFor($user, $project);
+        return $level?->allows('manage') ?? false;
+    }
+
+    /** Resolve once: does the user have projects.manage via any role? */
+    private function hasManageViaRole(User $user): bool
     {
         $permId = Permission::query()->where('name', 'projects.manage')->value('id');
         if (! $permId) {

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -10,7 +10,8 @@ use Illuminate\Support\Facades\DB;
 
 class ProjectPolicy
 {
-    public function __construct(private RecordAccessService $shares) {
+    public function __construct(private RecordAccessService $shares)
+    {
     }
 
     public function view(User $user, Project $project): bool

--- a/app/Policies/ProjectPolicy.php
+++ b/app/Policies/ProjectPolicy.php
@@ -82,7 +82,10 @@ class ProjectPolicy
     /** Resolve once: does the user have projects.manage via any role? */
     private function hasManageViaRole(User $user): bool
     {
-        $permId = Permission::query()->where('name', 'projects.manage')->value('id');
+        static $permId = null;
+        if ($permId === null) {
+            $permId = Permission::query()->where('name', 'projects.manage')->value('id');
+        }
         if (! $permId) {
             return false;
         }

--- a/app/Services/RecordAccessService.php
+++ b/app/Services/RecordAccessService.php
@@ -114,7 +114,7 @@ class RecordAccessService
     private function principalPairsFor(User $user): Collection
     {
         return collect()
-            ->push(['type' => \App\Models\User::class, 'id' => $user->id])
+            ->push(['type' => User::class, 'id' => $user->id])
             ->when(method_exists($user, 'roles'), fn ($c) => $c->merge(
                 $user->roles->map(fn ($r) => ['type' => Role::class, 'id' => $r->id])
             ))

--- a/app/Services/RecordAccessService.php
+++ b/app/Services/RecordAccessService.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Services;
+
+use App\Enums\AccessLevel;
+use App\Models\Organization;
+use App\Models\RecordShare;
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Cache\TaggableStore;
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Resolves effective per-record share level only.
+ * Returns null when sharing is disabled or no shares exist.
+ */
+class RecordAccessService
+{
+    public function levelFor(User $user, Model $record): ?AccessLevel
+    {
+        if (! feature('PerRecordSharing')->active($user)) {
+            return null;
+        }
+
+        if (! $this->hasAnyShare($record)) {
+            return null;
+        }
+
+        $cache = $this->cache();
+        $cacheKey = $this->cacheKeyFor($user, $record);
+
+        return $cache->remember($cacheKey, now()->addMinutes(10), function () use ($user, $record) {
+            $candidates = $this->principalPairsFor($user);
+
+            $levels = new Collection();
+
+            $levels->push(
+                $this->highestLevelFromShares($record, $candidates)
+            );
+
+            if (method_exists($record, 'parentShareable')) {
+                $parent = $record->parentShareable();
+                if ($parent && $this->hasAnyShare($parent)) {
+                    $levels->push(
+                        $this->highestLevelFromShares($parent, $candidates, true)
+                    );
+                }
+            }
+
+            $levels = $levels->filter();
+
+            if ($levels->isEmpty()) {
+                return null;
+            }
+
+            return $levels->reduce(
+                fn (?AccessLevel $carry, AccessLevel $lvl) => AccessLevel::max($carry, $lvl),
+                null
+            );
+        });
+    }
+
+    /**
+     * Light existence check, cached, so we can skip heavy work when there are no shares.
+     */
+    public function hasAnyShare(Model $record): bool
+    {
+        $key = sprintf('rs:any:%s:%s', $record::class, $record->id);
+
+        return $this->cache()->remember($key, now()->addMinutes(10), function () use ($record) {
+            return RecordShare::query()
+                ->where('shareable_type', $record::class)
+                ->where('shareable_id', $record->id)
+                ->notExpired()
+                ->exists();
+        });
+    }
+
+    public function bustCacheForShareable(Model $record): void
+    {
+        $this->cache()->flush();
+    }
+
+    private function highestLevelFromShares(object $shareable, Collection $pairs, bool $requirePropagation = false): ?AccessLevel
+    {
+        $rows = RecordShare::query()
+            ->select(['access_level', 'propagate_to_children'])
+            ->where('shareable_type', $shareable::class)
+            ->where('shareable_id', $shareable->id)
+            ->whereIn('principal_type', $pairs->pluck('type'))
+            ->whereIn('principal_id', $pairs->pluck('id'))
+            ->notExpired()
+            ->when($requirePropagation, fn ($q) => $q->where('propagate_to_children', true))
+            ->get();
+
+        if ($rows->isEmpty()) {
+            return null;
+        }
+
+        return $rows->reduce(
+            fn (?AccessLevel $carry, RecordShare $row) => AccessLevel::max($carry, $row->access_level),
+            null
+        );
+    }
+
+    /** @return Collection<int, array{type: class-string, id: string}> */
+    private function principalPairsFor(User $user): Collection
+    {
+        return collect()
+            ->push(['type' => \App\Models\User::class, 'id' => $user->id])
+            ->when(method_exists($user, 'roles'), fn ($c) => $c->merge(
+                $user->roles->map(fn ($r) => ['type' => Role::class, 'id' => $r->id])
+            ))
+            ->when(method_exists($user, 'teams'), fn ($c) => $c->merge(
+                $user->teams->map(fn ($t) => ['type' => Team::class, 'id' => $t->id])
+            ))
+            ->when(method_exists($user, 'organizations'), fn ($c) => $c->merge(
+                $user->organizations->map(fn ($o) => ['type' => Organization::class, 'id' => $o->id])
+            ));
+    }
+
+    private function cache(): CacheRepository
+    {
+        $store = Cache::getStore();
+
+        if ($store instanceof TaggableStore) {
+            return Cache::tags(['record-shares']);
+        }
+
+        return Cache::store();
+    }
+
+    private function cacheKeyFor(User $user, Model $record): string
+    {
+        return sprintf('rs:%s:%s:%s', $user->id, $record::class, $record->id);
+    }
+}

--- a/app/Services/RecordAccessService.php
+++ b/app/Services/RecordAccessService.php
@@ -86,6 +86,18 @@ class RecordAccessService
         // Remove only the cache entry for this record's share existence
         $key = sprintf('rs:any:%s:%s', $record::class, $record->id);
         $this->cache()->forget($key);
+
+        // Also remove all user-specific access level caches for this record
+        $userIds = RecordShare::query()
+            ->where('shareable_type', $record::class)
+            ->where('shareable_id', $record->id)
+            ->where('principal_type', User::class)
+            ->pluck('principal_id');
+
+        foreach ($userIds as $userId) {
+            $user = new User(['id' => $userId]);
+            $this->cache()->forget($this->cacheKeyFor($user, $record));
+        }
     }
 
     private function highestLevelFromShares(object $shareable, Collection $pairs, bool $requirePropagation = false): ?AccessLevel

--- a/app/Services/RecordAccessService.php
+++ b/app/Services/RecordAccessService.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Laravel\Pennant\Feature;
 
 /**
  * Resolves effective per-record share level only.
@@ -23,7 +24,11 @@ class RecordAccessService
 {
     public function levelFor(User $user, Model $record): ?AccessLevel
     {
-        if (! feature('PerRecordSharing')->active($user)) {
+        if (! Feature::active('PerRecordSharing')) {
+            return null;
+        }
+
+        if (! Feature::for($record->organization ?? $user)->active('PerRecordSharing')) {
             return null;
         }
 

--- a/app/Services/RecordAccessService.php
+++ b/app/Services/RecordAccessService.php
@@ -134,11 +134,16 @@ class RecordAccessService
             return Cache::tags(['record-shares']);
         }
 
+        // Fallback: Use a dedicated cache prefix to avoid key conflicts (cache pollution)
+        // when tags are not supported.
+        // Note: Laravel's Cache facade does not provide a withPrefix() method directly,
+        // so we ensure the prefix is unique in cacheKeyFor().
         return Cache::store();
     }
 
     private function cacheKeyFor(User $user, Model $record): string
     {
-        return sprintf('rs:%s:%s:%s', $user->id, $record::class, $record->id);
+        // Use a unique prefix to avoid cache pollution when tags are not supported.
+        return sprintf('record-shares:%s:%s:%s', $user->id, $record::class, $record->id);
     }
 }

--- a/app/Services/RecordAccessService.php
+++ b/app/Services/RecordAccessService.php
@@ -83,7 +83,9 @@ class RecordAccessService
 
     public function bustCacheForShareable(Model $record): void
     {
-        $this->cache()->flush();
+        // Remove only the cache entry for this record's share existence
+        $key = sprintf('rs:any:%s:%s', $record::class, $record->id);
+        $this->cache()->forget($key);
     }
 
     private function highestLevelFromShares(object $shareable, Collection $pairs, bool $requirePropagation = false): ?AccessLevel

--- a/app/Traits/HasRecordShares.php
+++ b/app/Traits/HasRecordShares.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Traits;
+
+use App\Enums\AccessLevel;
+use App\Models\RecordShare;
+use App\Models\User;
+use App\Services\RecordAccessService;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Support\Collection;
+
+/**
+ * @method static Builder visibleTo(User $user, string $ability = 'view')
+ */
+trait HasRecordShares
+{
+    public function shares(): MorphMany
+    {
+        return $this->morphMany(RecordShare::class, 'shareable');
+    }
+
+    public function shareWith(object $principal, AccessLevel $level, ?CarbonInterface $expiresAt = null, bool $propagate = false, ?string $grantorId = null): RecordShare
+    {
+        /** @var RecordShare $row */
+        $row = $this->shares()->updateOrCreate(
+            [
+                'principal_type' => $principal::class,
+                'principal_id' => $principal->id,
+            ],
+            [
+                'access_level' => $level,
+                'propagate_to_children' => $propagate,
+                'expires_at' => $expiresAt,
+                'grantor_id' => $grantorId,
+            ],
+        );
+
+        app(RecordAccessService::class)->bustCacheForShareable($this);
+
+        return $row;
+    }
+
+    public function revokeShare(object $principal): void
+    {
+        $this->shares()
+            ->where('principal_type', $principal::class)
+            ->where('principal_id', $principal->id)
+            ->delete();
+
+        app(RecordAccessService::class)->bustCacheForShareable($this);
+    }
+
+    public function parentShareable(): ?object
+    {
+        return null;
+    }
+
+    public function scopeVisibleTo(Builder $query, User $user, string $ability = 'view'): Builder
+    {
+        return app(RecordAccessService::class)->scopeVisibleTo($query, $user, $ability);
+    }
+
+    public function effectiveAccessFor(User $user): ?AccessLevel
+    {
+        return app(RecordAccessService::class)->levelFor($user, $this);
+    }
+}

--- a/database/migrations/2025_10_11_222329_create_record_shares_table.php
+++ b/database/migrations/2025_10_11_222329_create_record_shares_table.php
@@ -5,8 +5,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::create('record_shares', static function (Blueprint $t) {

--- a/database/migrations/2025_10_11_222329_create_record_shares_table.php
+++ b/database/migrations/2025_10_11_222329_create_record_shares_table.php
@@ -18,7 +18,7 @@ return new class () extends Migration {
             $t->boolean('propagate_to_children')->default(false);
             $t->timestampTz('expires_at')->nullable();
 
-            $t->foreignUuid('grantor_id')->nullable(); // who shared
+            $t->foreignUuid('grantor_id')->nullable()->constrained('users')->nullOnDelete(); // who shared
             $t->timestamps();
 
             $t->unique([

--- a/database/migrations/2025_10_11_222329_create_record_shares_table.php
+++ b/database/migrations/2025_10_11_222329_create_record_shares_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Enums\AccessLevel;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('record_shares', static function (Blueprint $t) {
+            $t->uuid('id')->primary();
+
+            $t->uuidMorphs('shareable');              // shareable_type, shareable_id (e.g., Project, Issue)
+            $t->uuidMorphs('principal');              // principal_type, principal_id (User|Role|Team|Organization)
+
+            $t->unsignedTinyInteger('access_level');  // AccessLevel enum (backed by int)
+            $t->boolean('propagate_to_children')->default(false);
+            $t->timestampTz('expires_at')->nullable();
+
+            $t->foreignUuid('grantor_id')->nullable(); // who shared
+            $t->timestamps();
+
+            $t->unique([
+                'shareable_type', 'shareable_id',
+                'principal_type', 'principal_id',
+            ], 'record_shares_unique');
+
+            $t->index(['shareable_type', 'shareable_id', 'access_level']);
+            $t->index(['expires_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('record_shares');
+    }
+};

--- a/resources/views/livewire/dashboard/overview.blade.php
+++ b/resources/views/livewire/dashboard/overview.blade.php
@@ -18,10 +18,16 @@
                             @foreach($myIssues as $issue)
                                 <li class="d-flex align-items-start justify-content-between gap-2">
                                     <div class="flex-grow-1 min-w-0">
-                                        <a class="fw-medium small text-reset text-decoration-none d-block text-break"
-                                           href="{{ route('issues.show', ['project' => $issue->project, 'issue' => $issue]) }}">
-                                            {{ $issue->project->key }}-{{ $issue->key }} — {{ $issue->summary }}
-                                        </a>
+                                        @can('view', $issue)
+                                            <a class="fw-medium small text-reset text-decoration-none d-block text-break"
+                                               href="{{ route('issues.show', ['project' => $issue->project, 'issue' => $issue]) }}">
+                                                {{ $issue->key }} — {{ $issue->summary }}
+                                            </a>
+                                        @else
+                                            <span class="fw-medium small d-block text-break">
+                                                {{ $issue->key }} — {{ $issue->summary }}
+                                            </span>
+                                        @endcan
                                         <div class="small text-body-secondary mt-1">
                                             {{ $issue->status?->name ?? '—' }}
                                             @if($issue->due_at)
@@ -33,8 +39,8 @@
                                     @if($issue->status)
                                         <span class="badge rounded-pill flex-shrink-0 text-nowrap"
                                               style="background-color: {{ $issue->status->color }}20; color: {{ $issue->status->color }}">
-                                        {{ $issue->status->name }}
-                                    </span>
+                                            {{ $issue->status->name }}
+                                        </span>
                                     @endif
                                 </li>
                             @endforeach
@@ -55,10 +61,16 @@
                         <ul class="list-unstyled mb-0 d-flex flex-column gap-2">
                             @foreach($upcomingDue as $issue)
                                 <li class="d-flex align-items-center justify-content-between gap-2">
-                                    <a class="small text-reset text-decoration-none d-block text-break"
-                                       href="{{ route('issues.show', ['project' => $issue->project, 'issue' => $issue]) }}">
-                                        {{ $issue->project->key }}-{{ $issue->key }} — {{ $issue->summary }}
-                                    </a>
+                                    @can('view', $issue)
+                                        <a class="small text-reset text-decoration-none d-block text-break"
+                                           href="{{ route('issues.show', ['project' => $issue->project, 'issue' => $issue]) }}">
+                                            {{ $issue->key }} — {{ $issue->summary }}
+                                        </a>
+                                    @else
+                                        <span class="small d-block text-break">
+                                            {{ $issue->key }} — {{ $issue->summary }}
+                                        </span>
+                                    @endcan
                                     <span class="small text-body-secondary flex-shrink-0">
                                         {{ $issue->due_at->toFormattedDateString() }}
                                     </span>
@@ -88,16 +100,29 @@
                     <div class="row row-cols-1 row-cols-sm-1 g-3">
                         @foreach($myProjects as $project)
                             <div class="col">
-                                <a href="{{ route('projects.show', ['project' => $project]) }}" class="card h-100 text-reset text-decoration-none border">
-                                    <div class="card-body p-3">
-                                        <div class="small fw-semibold text-truncate">
-                                            {{ $project->name }}
+                                @can('view', $project)
+                                    <a href="{{ route('projects.show', ['project' => $project]) }}" class="card h-100 text-reset text-decoration-none border">
+                                        <div class="card-body p-3">
+                                            <div class="small fw-semibold text-truncate">
+                                                {{ $project->name }}
+                                            </div>
+                                            <div class="small text-body-secondary mt-1">
+                                                {{ $project->key }} • {{ $project->open_issues_count }} {{ __('open') }}
+                                            </div>
                                         </div>
-                                        <div class="small text-body-secondary mt-1">
-                                            {{ $project->key }} • {{ $project->open_issues_count }} {{ __('open') }}
+                                    </a>
+                                @else
+                                    <div class="card h-100 border">
+                                        <div class="card-body p-3">
+                                            <div class="small fw-semibold text-truncate">
+                                                {{ $project->name }}
+                                            </div>
+                                            <div class="small text-body-secondary mt-1">
+                                                {{ $project->key }} • {{ $project->open_issues_count }} {{ __('open') }}
+                                            </div>
                                         </div>
                                     </div>
-                                </a>
+                                @endcan
                             </div>
                         @endforeach
                     </div>
@@ -150,7 +175,6 @@
                                                     {{ $i['ago'] }}
                                                 </div>
 
-                                                {{-- Compact “headline” for Status change --}}
                                                 @php $statusChange = collect($i['changes'])->firstWhere('key','issue_status_id'); @endphp
                                                 @if($statusChange)
                                                     <div class="small d-flex align-items-center gap-2 mt-2">
@@ -159,12 +183,11 @@
                                                         <span>→</span>
                                                         <span class="badge"
                                                               style="background-color: {{ $statusChange['to_color'] ?? 'transparent' }}20;">
-                              {{ $statusChange['to'] ?? '—' }}
-                            </span>
+                                                            {{ $statusChange['to'] ?? '—' }}
+                                                        </span>
                                                     </div>
                                                 @endif
 
-                                                {{-- Toggle full diff --}}
                                                 @if(!empty($i['changes']))
                                                     <div x-data="{ open: false }" class="mt-2">
                                                         <button type="button"
@@ -186,8 +209,8 @@
                                                                             <span>→</span>
                                                                             <span class="badge border"
                                                                                   @if($c['to_color']) style="background-color: {{ $c['to_color'] }}20" @endif>
-                                        {{ $c['to'] ?? '—' }}
-                                      </span>
+                                                                                {{ $c['to'] ?? '—' }}
+                                                                            </span>
                                                                         </div>
                                                                     </div>
                                                                 </div>


### PR DESCRIPTION
Introduce the `RecordShare` model, `HasRecordShares` trait, and `RecordAccessService` to enable share-based permissions on records. Policies for `Issue` and `Project` were updated to utilize the new sharing model. A migration was added to create the `record_shares` table, and an `AccessLevel` enum was defined to manage granular permissions.

## Summary by Sourcery

Implement per-record share-based access control by introducing a new RecordShare model, AccessLevel enum, RecordAccessService, and HasRecordShares trait, and integrate sharing logic into core models and their policies.

New Features:
- Introduce RecordShare model, migration, and AccessLevel enum for hierarchical per-record permissions
- Add HasRecordShares trait with methods to share, revoke, and scope visibility on records
- Implement RecordAccessService to resolve and cache effective access levels for shared records
- Extend Issue, Goal, Project, Repository, Sprint, and Ticket models to support record sharing
- Update ProjectPolicy and IssuePolicy to incorporate share-based permissions via RecordAccessService