### PR TITLE
Update to fix repo ref issues

### DIFF
--- a/app/Console/Commands/RepairIssueExternalRefNumbers.php
+++ b/app/Console/Commands/RepairIssueExternalRefNumbers.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\IssueExternalRef;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class RepairIssueExternalRefNumbers extends Command
+{
+    protected $signature = 'forge:repair-issue-external-ref-numbers
+                            {--repository= : Limit repairs to a single repository UUID}
+                            {--dry-run : Show what would change without saving}
+                            {--chunk=200 : Number of records to process per chunk}';
+
+    protected $description = 'Repair issue_external_refs.number when it no longer matches payload.number';
+
+    public function handle(): int
+    {
+        $repositoryId = $this->option('repository');
+        $dryRun = (bool) $this->option('dry-run');
+        $chunkSize = max((int) $this->option('chunk'), 1);
+
+        $query = IssueExternalRef::query()
+            ->select([
+                'id',
+                'repository_id',
+                'issue_id',
+                'external_issue_id',
+                'number',
+                'payload',
+            ])
+            ->whereNotNull('payload')
+            ->whereRaw("JSON_EXTRACT(payload, '$.number') IS NOT NULL")
+            ->when(
+                filled($repositoryId),
+                static fn ($query) => $query->where('repository_id', $repositoryId)
+            )
+            ->orderBy('id');
+
+        $scanned = 0;
+        $mismatched = 0;
+        $repaired = 0;
+        $skipped = 0;
+        $conflicts = 0;
+
+        $this->info($dryRun ? 'Running in dry-run mode.' : 'Applying repairs.');
+
+        $query->chunk($chunkSize, function ($refs) use (
+            &$scanned,
+            &$mismatched,
+            &$repaired,
+            &$skipped,
+            &$conflicts,
+            $dryRun
+        ): void {
+            foreach ($refs as $ref) {
+                $scanned++;
+
+                $payloadNumber = $this->extractPayloadNumber($ref->payload);
+
+                if ($payloadNumber === null) {
+                    $skipped++;
+                    continue;
+                }
+
+                if ((int) $ref->number === $payloadNumber) {
+                    continue;
+                }
+
+                $mismatched++;
+
+                $conflictingRefExists = IssueExternalRef::query()
+                    ->where('repository_id', $ref->repository_id)
+                    ->where('number', $payloadNumber)
+                    ->where('id', '!=', $ref->id)
+                    ->exists();
+
+                if ($conflictingRefExists) {
+                    $conflicts++;
+
+                    $this->warn(sprintf(
+                        'Conflict for ref %s in repository %s: current=%d payload=%d',
+                        $ref->id,
+                        $ref->repository_id,
+                        (int) $ref->number,
+                        $payloadNumber
+                    ));
+
+                    continue;
+                }
+
+                $this->line(sprintf(
+                    '%s ref %s repo=%s issue=%s external_issue_id=%s %d -> %d',
+                    $dryRun ? '[DRY-RUN]' : '[REPAIR]',
+                    $ref->id,
+                    $ref->repository_id,
+                    $ref->issue_id,
+                    $ref->external_issue_id,
+                    (int) $ref->number,
+                    $payloadNumber
+                ));
+
+                if ($dryRun) {
+                    continue;
+                }
+
+                DB::transaction(function () use ($ref, $payloadNumber, &$repaired): void {
+                    $lockedRef = IssueExternalRef::query()
+                        ->whereKey($ref->id)
+                        ->lockForUpdate()
+                        ->first();
+
+                    if (! $lockedRef instanceof IssueExternalRef) {
+                        return;
+                    }
+
+                    $currentPayloadNumber = $this->extractPayloadNumber($lockedRef->payload);
+
+                    if ($currentPayloadNumber === null) {
+                        return;
+                    }
+
+                    if ((int) $lockedRef->number === $currentPayloadNumber) {
+                        return;
+                    }
+
+                    $conflictingRefExists = IssueExternalRef::query()
+                        ->where('repository_id', $lockedRef->repository_id)
+                        ->where('number', $currentPayloadNumber)
+                        ->where('id', '!=', $lockedRef->id)
+                        ->lockForUpdate()
+                        ->exists();
+
+                    if ($conflictingRefExists) {
+                        return;
+                    }
+
+                    $lockedRef->number = $currentPayloadNumber;
+                    $lockedRef->save();
+
+                    $repaired++;
+                });
+            }
+        });
+
+        $this->newLine();
+        $this->table(
+            ['Scanned', 'Mismatched', 'Repaired', 'Skipped', 'Conflicts'],
+            [[
+                $scanned,
+                $mismatched,
+                $repaired,
+                $skipped,
+                $conflicts,
+            ]]
+        );
+
+        if ($dryRun) {
+            $this->comment('No database changes were made.');
+        }
+
+        if ($conflicts > 0) {
+            $this->warn('Some rows were not repaired because the target repository/number pair already exists.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $payload
+     */
+    private function extractPayloadNumber(?array $payload): ?int
+    {
+        $number = data_get($payload, 'number');
+
+        if (is_int($number)) {
+            return $number > 0 ? $number : null;
+        }
+
+        if (is_string($number) && ctype_digit($number)) {
+            $parsed = (int) $number;
+
+            return $parsed > 0 ? $parsed : null;
+        }
+
+        return null;
+    }
+}

--- a/app/Jobs/InitialImportRepositoryIssues.php
+++ b/app/Jobs/InitialImportRepositoryIssues.php
@@ -109,10 +109,35 @@ final class InitialImportRepositoryIssues implements ShouldQueue
         }
     }
 
-    private function processSingleIssue($i, $repository, $project, $statusMap, $defaultTypeId, $typeByKey, $typeByName, $typeByTier, $defaultPriorityId, $prioByKey, $prioByName): void
+    private function resolveStatusId(string $state, $statusMap): int
     {
-        $state = strtolower($i['state'] ?? '');
+        $statusId = optional($statusMap->get($state))->issue_status_id;
+        return $statusId ?? IssueStatus::query()
+            ->when(
+                $state === 'closed',
+                fn($q) => $q->where('is_done', true),
+                fn($q) => $q->where('is_done', false)
+            )
+            ->orderBy('order')
+            ->value('id');
+    }
+
+    private function processSingleIssue(
+        array $i,
+              $repository,
+              $project,
+              $statusMap,
+        string $defaultTypeId,
+        array $typeByKey,
+        array $typeByName,
+        array $typeByTier,
+        string $defaultPriorityId,
+        array $prioByKey,
+        array $prioByName
+    ): void {
+        $state = strtolower((string) ($i['state'] ?? ''));
         $statusId = $this->resolveStatusId($state, $statusMap);
+
         $issueTypeId = $this->inferIssueTypeIdFromLabels(
             $i['labels'] ?? [],
             $typeByKey,
@@ -128,84 +153,92 @@ final class InitialImportRepositoryIssues implements ShouldQueue
             $defaultPriorityId
         );
 
-        $externalIssueId = (string)($i['external_issue_id'] ?? '');
-        $number = (int)($i['number'] ?? 0);
+        $externalIssueId = (string) ($i['external_issue_id'] ?? '');
+        $number = (int) ($i['number'] ?? 0);
 
         $existingExternalRef = IssueExternalRef::query()
             ->where('repository_id', $repository->id)
-            ->when($externalIssueId !== '', fn($q) => $q->where('external_issue_id', $externalIssueId))
-            ->when($externalIssueId === '' && $number > 0, fn($q) => $q->where('number', $number))
+            ->when(
+                $externalIssueId !== '',
+                fn ($query) => $query->where('external_issue_id', $externalIssueId)
+            )
+            ->when(
+                $externalIssueId === '' && $number > 0,
+                fn ($query) => $query->where('number', $number)
+            )
             ->first();
 
-        if ($existingExternalRef) {
-            $this->updateExistingIssue($existingExternalRef, $i, $statusId, $issueTypeId, $issuePriorityId);
-        } else {
-            $this->createNewIssue($i, $project, $repository, $statusId, $issueTypeId, $issuePriorityId);
-        }
+        $issue = $existingExternalRef
+            ? $this->updateExistingIssue($existingExternalRef, $i, $statusId, $issueTypeId, $issuePriorityId)
+            : $this->createNewIssue($i, $project, $repository, $statusId, $issueTypeId, $issuePriorityId);
 
-        $this->mapUsersToIssue($i, $repository, $existingExternalRef?->issue ?? null);
+        $this->mapUsersToIssue($i, $repository, $issue);
     }
 
-    private function resolveStatusId(string $state, $statusMap): int
-    {
-        $statusId = optional($statusMap->get($state))->issue_status_id;
-        return $statusId ?? IssueStatus::query()
-            ->when(
-                $state === 'closed',
-                fn($q) => $q->where('is_done', true),
-                fn($q) => $q->where('is_done', false)
-            )
-            ->orderBy('order')
-            ->value('id');
-    }
-
-    private function updateExistingIssue($existingExternalRef, $i, $statusId, $issueTypeId, $issuePriorityId): void
-    {
+    private function updateExistingIssue(
+        IssueExternalRef $existingExternalRef,
+        array $i,
+        int $statusId,
+        string $issueTypeId,
+        string $issuePriorityId
+    ): ?Issue {
         $issue = Issue::query()->find($existingExternalRef->issue_id);
-        if ($issue) {
+
+        if ($issue instanceof Issue) {
             $issue->fill([
-                'summary'           => $i['title'],
-                'description'       => $i['body'] ?? null,
-                'issue_status_id'   => $statusId,
-                'issue_type_id'     => $issueTypeId,
+                'summary' => $i['title'],
+                'description' => $i['body'] ?? null,
+                'issue_status_id' => $statusId,
+                'issue_type_id' => $issueTypeId,
                 'issue_priority_id' => $issuePriorityId,
-                'updated_at'        => $i['updated_at'] ?? now(),
-                'closed_at'         => $i['closed_at'] ?? null,
+                'updated_at' => $i['updated_at'] ?? now(),
+                'closed_at' => $i['closed_at'] ?? null,
             ])->save();
         }
 
         $existingExternalRef->fill([
-            'state'   => $i['state'] ?? null,
-            'url'     => $i['url'] ?? null,
+            'external_issue_id' => (string) ($i['external_issue_id'] ?? $existingExternalRef->external_issue_id),
+            'state' => $i['state'] ?? null,
+            'url' => $i['url'] ?? null,
             'payload' => $i['raw'] ?? null,
-            'number'  => $issue?->number ?? $existingExternalRef->number,
+            'number' => (int) ($i['number'] ?? $existingExternalRef->number),
         ])->save();
+
+        return $issue;
     }
 
-    private function createNewIssue($i, $project, $repository, $statusId, $issueTypeId, $issuePriorityId): void
-    {
+    private function createNewIssue(
+        array $i,
+              $project,
+              $repository,
+        int $statusId,
+        string $issueTypeId,
+        string $issuePriorityId
+    ): Issue {
         $issue = Issue::query()->create([
-            'project_id'        => $project->id,
-            'summary'           => $i['title'],
-            'description'       => $i['body'] ?? null,
-            'issue_status_id'   => $statusId,
-            'issue_type_id'     => $issueTypeId,
+            'project_id' => $project->id,
+            'summary' => $i['title'],
+            'description' => $i['body'] ?? null,
+            'issue_status_id' => $statusId,
+            'issue_type_id' => $issueTypeId,
             'issue_priority_id' => $issuePriorityId,
-            'created_at'        => $i['created_at'] ?? now(),
-            'updated_at'        => $i['updated_at'] ?? now(),
-            'closed_at'         => $i['closed_at'] ?? null,
+            'created_at' => $i['created_at'] ?? now(),
+            'updated_at' => $i['updated_at'] ?? now(),
+            'closed_at' => $i['closed_at'] ?? null,
         ]);
 
         IssueExternalRef::query()->create([
-            'issue_id'          => $issue->id,
-            'repository_id'     => $repository->id,
-            'provider'          => $repository->provider,
-            'external_issue_id' => (string)($i['external_issue_id'] ?? ''),
-            'number'            => (int)($i['number'] ?? 0),
-            'url'               => $i['url'] ?? null,
-            'state'             => $i['state'] ?? null,
-            'payload'           => $i['raw'] ?? null,
+            'issue_id' => $issue->id,
+            'repository_id' => $repository->id,
+            'provider' => $repository->provider,
+            'external_issue_id' => (string) ($i['external_issue_id'] ?? ''),
+            'number' => (int) ($i['number'] ?? 0),
+            'url' => $i['url'] ?? null,
+            'state' => $i['state'] ?? null,
+            'payload' => $i['raw'] ?? null,
         ]);
+
+        return $issue;
     }
 
     private function mapUsersToIssue($i, $repository, $issue): void


### PR DESCRIPTION
## Summary by Sourcery

Align issue import with updated external reference behavior and add a repair utility for inconsistent issue external reference numbers.

Bug Fixes:
- Ensure imported issues return the updated or newly created Issue instance so user mappings are applied to the correct record.
- Keep issue_external_refs in sync with incoming external_issue_id and number values during updates to prevent stale references.

Enhancements:
- Extract issue status resolution into a dedicated helper for clearer status mapping during imports.
- Return Issue instances from create/update helpers to simplify downstream processing logic.

Chores:
- Introduce an artisan command to scan and repair issue_external_refs.number values that drift from their stored payload, with dry-run and per-repository options.