### PR TITLE
Add `ScopeDashboardTest` with shared visibility checks and update mod…

### DIFF
--- a/app/Livewire/Dashboard/Overview.php
+++ b/app/Livewire/Dashboard/Overview.php
@@ -11,6 +11,7 @@ use App\Models\Project;
 use App\Models\User;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Livewire\Component;
@@ -37,8 +38,6 @@ final class Overview extends Component
     public function mount(): void
     {
         $user = auth()->user();
-        $teamId = $user->currentTeam?->id;
-
         // Subquery of projects visible to the user (lead, direct member, or via team)
         $visibleProjectsSub = Project::query()
             ->visibleTo($user)
@@ -101,7 +100,15 @@ final class Overview extends Component
 
         /** @var Collection<int, Activity> $rawActivity */
         $rawActivity = Activity::query()
-            ->when($teamId, fn ($q) => $q->where('team_id', $teamId))
+            ->where(function ($query) use ($visibleProjectIds) {
+                $query
+                    ->where(function ($projectActivity) use ($visibleProjectIds) {
+                        $projectActivity
+                            ->where('subject_type', Project::class)
+                            ->whereIn('subject_id', $visibleProjectIds);
+                    })
+                    ->orWhereIn('properties->project_id', $visibleProjectIds);
+            })
             ->latest()
             ->limit(50)
             ->get([
@@ -115,22 +122,21 @@ final class Overview extends Component
                 'subject_type',
                 'subject_id',
                 'log_name',
-                'team_id',
             ]);
 
         // Collect IDs to avoid N+1s
-        $issueIds   = $rawActivity->where('subject_type', Issue::class)->pluck('subject_id')->filter()->unique();
+        $issueIds = $rawActivity->where('subject_type', Issue::class)->pluck('subject_id')->filter()->unique();
         $projectIds = $rawActivity->where('subject_type', Project::class)->pluck('subject_id')->filter()->unique();
-        $causerIds  = $rawActivity->where('causer_type', User::class)->pluck('causer_id')->filter()->unique();
+        $causerIds = $rawActivity->where('causer_type', User::class)->pluck('causer_id')->filter()->unique();
 
         // Scan changed fields to preload related labels
         $statusIds = $assigneeIds = $priorityIds = $typeIds = $parentIds = [];
 
         foreach ($rawActivity as $a) {
             /** @var array<string,mixed> $props */
-            $props = (array)($a->properties ?? []);
-            $new   = (array)($props['attributes'] ?? $props['new'] ?? []);
-            $old   = (array)($props['old'] ?? $props['attributes_before'] ?? []);
+            $props = (array) ($a->properties ?? []);
+            $new = (array) ($props['attributes'] ?? $props['new'] ?? []);
+            $old = (array) ($props['old'] ?? $props['attributes_before'] ?? []);
 
             foreach (['issue_status_id', 'assignee_id', 'issue_priority_id', 'issue_type_id', 'parent_id'] as $k) {
                 if (isset($new[$k])) {
@@ -142,7 +148,7 @@ final class Overview extends Component
             }
 
             // Also harvest project_id from properties (so we can link)
-            if (!empty($props['project_id'])) {
+            if (! empty($props['project_id'])) {
                 $projectIds->push($props['project_id']);
             }
         }
@@ -167,20 +173,20 @@ final class Overview extends Component
             ->get(['id', 'name', 'profile_photo_path'])
             ->keyBy('id');
 
-        $statusMap   = IssueStatus::query()->whereIn('id', array_filter($statusIds))->get(['id', 'name', 'color'])->keyBy('id');
+        $statusMap = IssueStatus::query()->whereIn('id', array_filter($statusIds))->get(['id', 'name', 'color'])->keyBy('id');
         $assigneeMap = User::query()->whereIn('id', array_filter($assigneeIds))->get(['id', 'name', 'profile_photo_path'])->keyBy('id');
         $priorityMap = IssuePriority::query()->whereIn('id', array_filter($priorityIds))->get(['id', 'name'])->keyBy('id');
-        $typeMap     = IssueType::query()->whereIn('id', array_filter($typeIds))->get(['id', 'name'])->keyBy('id');
-        $parentMap   = Issue::query()->whereIn('id', array_filter($parentIds))->get(['id', 'key', 'summary'])->keyBy('id');
+        $typeMap = IssueType::query()->whereIn('id', array_filter($typeIds))->get(['id', 'name'])->keyBy('id');
+        $parentMap = Issue::query()->whereIn('id', array_filter($parentIds))->get(['id', 'key', 'summary'])->keyBy('id');
 
         $labelMap = [
-            'summary'           => 'Summary',
-            'description'       => 'Description',
-            'issue_status_id'   => 'Status',
-            'assignee_id'       => 'Assignee',
+            'summary' => 'Summary',
+            'description' => 'Description',
+            'issue_status_id' => 'Status',
+            'assignee_id' => 'Assignee',
             'issue_priority_id' => 'Priority',
-            'issue_type_id'     => 'Type',
-            'parent_id'         => 'Parent',
+            'issue_type_id' => 'Type',
+            'parent_id' => 'Parent',
         ];
 
         $enriched = $rawActivity->map(function (Activity $a) use (
@@ -195,18 +201,18 @@ final class Overview extends Component
             $parentMap
         ) {
             /** @var array<string,mixed> $props */
-            $props = (array)($a->properties ?? []);
-            $new   = (array)($props['attributes'] ?? $props['new'] ?? []);
-            $old   = (array)($props['old'] ?? $props['attributes_before'] ?? []);
+            $props = (array) ($a->properties ?? []);
+            $new = (array) ($props['attributes'] ?? $props['new'] ?? []);
+            $old = (array) ($props['old'] ?? $props['attributes_before'] ?? []);
 
             $actor = $a->causer_type === User::class ? $usersById->get($a->causer_id) : null;
-            $actorName   = $actor?->name ?? 'System';
+            $actorName = $actor?->name ?? 'System';
             $actorAvatar = $actor?->profile_photo_url ?? $actor?->profile_photo_path ?? null;
 
-            $targetType  = $a->subject_type === Issue::class ? 'issue'
+            $targetType = $a->subject_type === Issue::class ? 'issue'
                 : ($a->subject_type === Project::class ? 'project' : ($a->log_name ?: 'record'));
             $targetLabel = 'record';
-            $targetUrl   = null;
+            $targetUrl = null;
 
             if ($a->subject_type === Issue::class) {
                 $issue = $issuesById->get($a->subject_id);
@@ -221,40 +227,40 @@ final class Overview extends Component
                 $project = $projectsById->get($a->subject_id);
                 if ($project) {
                     $targetLabel = "{$project->key} — {$project->name}";
-                    $targetUrl   = route('projects.show', ['project' => $project]);
+                    $targetUrl = route('projects.show', ['project' => $project]);
                 }
             } elseif (isset($props['issue_key'], $props['issue_summary'])) {
                 $targetLabel = "{$props['issue_key']}: {$props['issue_summary']}";
-                if (!empty($props['project_id']) && ($p = $projectsById->get($props['project_id']))) {
+                if (! empty($props['project_id']) && ($p = $projectsById->get($props['project_id']))) {
                     $targetUrl = route('issues.index', ['project' => $p, 'search' => $props['issue_key']]);
                 }
             }
 
-            $verb = $a->event ?: (Str::contains((string)$a->description, '.') ? Str::after((string)$a->description, '.') : (string)$a->description);
+            $verb = $a->event ?: (Str::contains((string) $a->description, '.') ? Str::after((string) $a->description, '.') : (string) $a->description);
             $verb = Str::of($verb)->replace(['issue.', 'project.'], '')->headline();
 
             $changes = [];
             $keys = array_unique(array_merge(array_keys($new), array_keys($old)));
             foreach ($keys as $k) {
                 $label = $labelMap[$k] ?? Str::of($k)->headline()->toString();
-                $from  = $old[$k] ?? null;
-                $to    = $new[$k] ?? null;
+                $from = $old[$k] ?? null;
+                $to = $new[$k] ?? null;
 
                 if ($k === 'issue_status_id') {
                     $from = $from ? ($statusMap->get($from)?->name ?? $from) : null;
-                    $to   = $to ? ($statusMap->get($to)?->name ?? $to) : null;
+                    $to = $to ? ($statusMap->get($to)?->name ?? $to) : null;
                 } elseif ($k === 'assignee_id') {
                     $from = $from ? ($assigneeMap->get($from)?->name ?? $from) : null;
-                    $to   = $to ? ($assigneeMap->get($to)?->name ?? $to) : null;
+                    $to = $to ? ($assigneeMap->get($to)?->name ?? $to) : null;
                 } elseif ($k === 'issue_priority_id') {
                     $from = $from ? ($priorityMap->get($from)?->name ?? $from) : null;
-                    $to   = $to ? ($priorityMap->get($to)?->name ?? $to) : null;
+                    $to = $to ? ($priorityMap->get($to)?->name ?? $to) : null;
                 } elseif ($k === 'issue_type_id') {
                     $from = $from ? ($typeMap->get($from)?->name ?? $from) : null;
-                    $to   = $to ? ($typeMap->get($to)?->name ?? $to) : null;
+                    $to = $to ? ($typeMap->get($to)?->name ?? $to) : null;
                 } elseif ($k === 'parent_id') {
                     $from = $from ? (($p = $parentMap->get($from)) ? "{$p->key}: {$p->summary}" : $from) : null;
-                    $to   = $to ? (($p = $parentMap->get($to)) ? "{$p->key}: {$p->summary}" : $to) : null;
+                    $to = $to ? (($p = $parentMap->get($to)) ? "{$p->key}: {$p->summary}" : $to) : null;
                 }
 
                 if (($from ?? '') === ($to ?? '')) {
@@ -262,10 +268,10 @@ final class Overview extends Component
                 }
 
                 $changes[] = [
-                    'label'    => $label,
-                    'from'     => $from,
-                    'to'       => $to,
-                    'key'      => $k,
+                    'label' => $label,
+                    'from' => $from,
+                    'to' => $to,
+                    'key' => $k,
                     'to_color' => $k === 'issue_status_id' && isset($new['issue_status_id'])
                         ? ($statusMap->get($new['issue_status_id'])->color ?? null)
                         : null,
@@ -273,16 +279,16 @@ final class Overview extends Component
             }
 
             return [
-                'id'           => $a->id,
-                'actor_name'   => $actorName,
+                'id' => $a->id,
+                'actor_name' => $actorName,
                 'actor_avatar' => $actorAvatar,
-                'verb'         => (string)$verb,
-                'target_type'  => $targetType,
+                'verb' => (string) $verb,
+                'target_type' => $targetType,
                 'target_label' => $targetLabel,
-                'target_url'   => $targetUrl,
-                'changes'      => $changes,
-                'created_at'   => $a->created_at,
-                'ago'          => $a->created_at?->diffForHumans(),
+                'target_url' => $targetUrl,
+                'changes' => $changes,
+                'created_at' => $a->created_at,
+                'ago' => $a->created_at?->diffForHumans(),
             ];
         });
 
@@ -294,19 +300,21 @@ final class Overview extends Component
             if ($dt?->isYesterday()) {
                 return 'Yesterday';
             }
+
             return $dt?->toFormattedDateString() ?? 'Recent';
         });
     }
 
     /**
-     * @param Collection<int,mixed>|array<int,mixed> $ids
+     * @param  Collection<int,mixed>|array<int,mixed>  $ids
      * @return array<int,int>
      */
     private function idsList(Collection|array $ids): array
     {
         $arr = $ids instanceof Collection ? $ids->all() : $ids;
-        $arr = \Illuminate\Support\Arr::flatten($arr);
+        $arr = Arr::flatten($arr);
         $arr = array_map('intval', $arr);
+
         return array_values(array_unique(array_filter($arr)));
     }
 

--- a/app/Livewire/Organizations/Form.php
+++ b/app/Livewire/Organizations/Form.php
@@ -5,7 +5,6 @@ namespace App\Livewire\Organizations;
 use App\Models\Organization;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Validation\Rule;
-use Illuminate\View\View;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
 
@@ -18,19 +17,21 @@ final class Form extends Component
     #[Locked]
     public bool $isEditing = false;
 
-    public ?string $name = ''; // <-- make nullable
+    public ?string $name = '';
 
     public function mount(?Organization $organization = null): void
     {
+        $organization = $organization?->exists ? $organization : null;
+
         $this->organization = $organization;
-        $this->isEditing    = $organization !== null;
+        $this->isEditing = $organization !== null;
 
         if ($this->isEditing) {
             $this->authorize('update', $organization);
             $this->name = (string) $organization->name;
         } else {
             $this->authorize('create', Organization::class);
-            $this->name ??= ''; // <-- ensure not null after hydration
+            $this->name ??= '';
         }
     }
 
@@ -53,27 +54,28 @@ final class Form extends Component
         $this->name = trim((string) $this->name);
         $this->validate();
 
-        if ($this->isEditing) {
+        if ($this->isEditing && $this->organization?->exists) {
             $this->organization->update(['name' => $this->name]);
             session()->flash('status', 'Organization updated.');
             $this->redirectRoute(
                 'organizations.show',
-                ['organization' => $this->organization->slug],
+                ['organization' => $this->organization],
                 navigate: true
             );
+
             return;
         }
 
         $org = Organization::query()->create(['name' => $this->name]);
+        $this->organization = $org;
         $org->refresh(); // ensures slug is present on the instance
 
         session()->flash('status', 'Organization created.');
         $this->redirectRoute(
             'organizations.show',
-            ['organization' => $org->slug],
+            ['organization' => $org],
             navigate: true
         );
-        return;
-    }
 
+    }
 }

--- a/app/Livewire/Organizations/Index.php
+++ b/app/Livewire/Organizations/Index.php
@@ -15,8 +15,8 @@ use Livewire\WithPagination;
  */
 final class Index extends Component
 {
-    use WithPagination;
     use AuthorizesRequests;
+    use WithPagination;
 
     #[Url]
     public string $q = '';
@@ -26,6 +26,10 @@ final class Index extends Component
         $this->authorize('viewAny', Organization::class);
 
         $query = Organization::query()
+            ->visibleTo(auth()->user())
+            ->withCount([
+                'projects as accessible_projects_count' => fn ($projects) => $projects->visibleTo(auth()->user()),
+            ])
             ->when($this->q !== '', static fn ($q) => $q->where('name', 'like', '%'.$this->q.'%'))
             ->orderBy('name');
 

--- a/app/Livewire/Projects/CreateProjectForm.php
+++ b/app/Livewire/Projects/CreateProjectForm.php
@@ -3,18 +3,17 @@
 namespace App\Livewire\Projects;
 
 use App\Enums\ProjectStage;
+use App\Models\Organization;
 use App\Models\Project;
 use App\Models\Team;
 use App\Models\User;
-use App\Policies\ProjectPolicy;
 use App\Services\Projects\ProjectSchemeCloner;
 use App\Support\Keys\ProjectKeyGenerator;
-use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
-use Illuminate\Support\Str;
 use Livewire\Features\SupportRedirects\Redirector;
 use Throwable;
 
@@ -30,6 +29,9 @@ final class CreateProjectForm extends Component
 
     #[Validate('nullable|string|max:10000')]
     public ?string $description = null;
+
+    #[Validate('nullable|uuid|exists:organizations,id')]
+    public ?string $organization_id = null;
 
     #[Validate('nullable|uuid|exists:users,id')]
     public ?string $lead_id = null;
@@ -47,6 +49,9 @@ final class CreateProjectForm extends Component
     public array $teamOptions = [];
 
     /** @var array<int, array{id:string,name:string}> */
+    public array $organizationOptions = [];
+
+    /** @var array<int, string> */
     public array $attach_team_ids = []; // uuids as strings
 
     /** @return array<string, mixed> */
@@ -56,31 +61,42 @@ final class CreateProjectForm extends Component
             'name' => 'required|string|max:120',
             'key' => ['required', 'string', 'alpha_num:ascii', 'min:2', 'max:10', Rule::unique('projects', 'key')],
             'description' => 'nullable|string|max:10000',
+            'organization_id' => 'nullable|uuid|exists:organizations,id',
             'lead_id' => 'nullable|uuid|exists:users,id',
             'stage' => ['required', Rule::in(array_column(ProjectStage::cases(), 'value'))],
             'copy_from_project_id' => 'nullable|uuid|exists:projects,id',
+            'attach_team_ids' => ['array'],
+            'attach_team_ids.*' => ['uuid', 'exists:teams,id'],
         ];
     }
 
     public function mount(): void
     {
-        $this->authorize('create', \App\Models\Project::class);
+        $this->authorize('create', Project::class);
 
-        // Team options for multiselect
-        $teams = auth()->user()?->allTeams() ?? collect();
-        $this->teamOptions = $teams
-            ->map(fn ($t) => ['id' => (string) $t->id, 'name' => $t->name])
+        $this->organizationOptions = $this->availableOrganizations()
+            ->map(fn (Organization $organization) => ['id' => (string) $organization->id, 'name' => $organization->name])
             ->values()
             ->all();
 
-        // Lead select options (current team’s users if you like, or just the current user)
-        $this->teamMembers = $teams->first()
-            ? $teams->first()->allUsers()->map(fn ($u) => ['id' => (string) $u->id, 'name' => $u->name])->all()
-            : [['id' => (string) auth()->id(), 'name' => auth()->user()->name]];
+        $this->teamOptions = $this->availableTeams()
+            ->map(fn (Team $team) => ['id' => (string) $team->id, 'name' => $team->name])
+            ->values()
+            ->all();
 
-        // Preselect current team if present
         if (auth()->user()?->currentTeam) {
             $this->attach_team_ids = [(string) auth()->user()->currentTeam->id];
+        }
+
+        $this->refreshAssignableUsers();
+    }
+
+    public function updatedAttachTeamIds(): void
+    {
+        $this->refreshAssignableUsers();
+
+        if ($this->lead_id && ! collect($this->teamMembers)->pluck('id')->contains($this->lead_id)) {
+            $this->lead_id = null;
         }
     }
 
@@ -98,18 +114,20 @@ final class CreateProjectForm extends Component
     {
         $this->authorize('create', Project::class);
         $data = $this->validate();
+        $this->ensureAllowedScopeSelections();
 
-        $project = new Project();
+        $project = new Project;
         $project->name = $data['name'];
         $project->key = Str::upper($data['key']);
         $project->description = $data['description'] ?? null;
+        $project->organization_id = $data['organization_id'] ?? null;
         $project->lead_id = $data['lead_id'] ?? auth()->id();
         $project->stage = ProjectStage::from($data['stage']);
         $project->settings = $project->settings ?? $data['settings'] ?? [];
         $project->save();
 
         if (! empty($this->attach_team_ids)) {
-            $project->teams()->syncWithPivotValues($this->attach_team_ids, ['role' => 'Contributor'], false);
+            $project->teams()->sync($this->teamSyncPayload());
         }
 
         $project->users()->syncWithoutDetaching([auth()->id() => ['role' => 'Owner']]);
@@ -133,8 +151,104 @@ final class CreateProjectForm extends Component
             'stages' => ProjectStage::cases(),
             'projectsForCopy' => Project::query()
                 ->visibleTo(auth()->user())
-                ->orderBy('name')->get(['id','name']),
+                ->orderBy('name')->get(['id', 'name']),
         ]);
     }
-}
 
+    private function availableOrganizations()
+    {
+        $user = auth()->user();
+
+        $query = Organization::query()->orderBy('name');
+
+        if (! $this->canManageAllOrganizations()) {
+            $query->visibleTo($user);
+        }
+
+        return $query->get(['id', 'name']);
+    }
+
+    private function availableTeams()
+    {
+        $user = auth()->user();
+
+        if ($this->canManageAllOrganizations()) {
+            return Team::query()
+                ->orderBy('name')
+                ->get(['id', 'name', 'user_id']);
+        }
+
+        return $user?->allTeams()
+            ->sortBy('name')
+            ->values() ?? collect();
+    }
+
+    private function canManageAllOrganizations(): bool
+    {
+        return auth()->user()?->hasPermissionTo('is-super-admin')
+            || auth()->user()?->can('is-admin');
+    }
+
+    private function refreshAssignableUsers(): void
+    {
+        $teamIds = array_values(array_filter($this->attach_team_ids));
+
+        if ($teamIds === []) {
+            $this->teamMembers = [[
+                'id' => (string) auth()->id(),
+                'name' => (string) auth()->user()?->name,
+            ]];
+
+            return;
+        }
+
+        $users = Team::query()
+            ->whereKey($teamIds)
+            ->with(['users:id,name', 'owner:id,name'])
+            ->get()
+            ->flatMap(function (Team $team) {
+                return $team->users
+                    ->push($team->owner)
+                    ->filter();
+            })
+            ->unique('id')
+            ->sortBy('name')
+            ->values();
+
+        $this->teamMembers = $users
+            ->map(fn (User $user) => ['id' => (string) $user->id, 'name' => $user->name])
+            ->all();
+    }
+
+    private function ensureAllowedScopeSelections(): void
+    {
+        $selectedTeamIds = collect($this->attach_team_ids)
+            ->filter()
+            ->unique()
+            ->values();
+        $allowedTeamIds = collect($this->teamOptions)->pluck('id');
+
+        abort_unless(
+            $allowedTeamIds->intersect($selectedTeamIds)->count() === $selectedTeamIds->count(),
+            403
+        );
+
+        if ($this->organization_id === null) {
+            return;
+        }
+
+        $allowedOrganizationIds = collect($this->organizationOptions)->pluck('id');
+
+        abort_unless($allowedOrganizationIds->contains($this->organization_id), 403);
+    }
+
+    /** @return array<string, array{role:string}> */
+    private function teamSyncPayload(): array
+    {
+        return collect($this->attach_team_ids)
+            ->filter()
+            ->unique()
+            ->mapWithKeys(fn (string $teamId) => [$teamId => ['role' => 'Contributor']])
+            ->all();
+    }
+}

--- a/app/Livewire/Projects/EditProjectForm.php
+++ b/app/Livewire/Projects/EditProjectForm.php
@@ -3,7 +3,9 @@
 namespace App\Livewire\Projects;
 
 use App\Enums\ProjectStage;
+use App\Models\Organization;
 use App\Models\Project;
+use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Validation\Rule;
@@ -16,58 +18,128 @@ final class EditProjectForm extends Component
 
     public Project $project;
 
-    #[Validate('required|string|max:120')] public string $name = '';
-    #[Validate(['required','string','alpha_num:ascii','min:2','max:10'])] public string $key = '';
-    #[Validate('nullable|string|max:10000')] public ?string $description = null;
-    #[Validate('nullable|uuid|exists:users,id')] public ?string $lead_id = null;
-    #[Validate] public string $stage = ProjectStage::Planning->value;
-    #[Validate('nullable|date')] public ?string $started_at = null;
-    #[Validate('nullable|date')] public ?string $due_at = null;
-    #[Validate('nullable|date')] public ?string $ended_at = null;
+    #[Validate('required|string|max:120')]
+    public string $name = '';
+
+    #[Validate(['required', 'string', 'alpha_num:ascii', 'min:2', 'max:10'])]
+    public string $key = '';
+
+    #[Validate('nullable|string|max:10000')]
+    public ?string $description = null;
+
+    #[Validate('nullable|uuid|exists:organizations,id')]
+    public ?string $organization_id = null;
+
+    #[Validate('nullable|uuid|exists:users,id')]
+    public ?string $lead_id = null;
+
+    #[Validate]
+    public string $stage = ProjectStage::Planning->value;
+
+    #[Validate('nullable|date')]
+    public ?string $started_at = null;
+
+    #[Validate('nullable|date')]
+    public ?string $due_at = null;
+
+    #[Validate('nullable|date')]
+    public ?string $ended_at = null;
+
+    /** @var array<int, array{id:string,name:string}> */
+    public array $teamOptions = [];
+
+    /** @var array<int, array{id:string,name:string}> */
+    public array $organizationOptions = [];
+
+    /** @var array<int, array{id:string,name:string}> */
+    public array $leadOptions = [];
+
+    /** @var array<int, string> */
+    public array $attach_team_ids = [];
 
     public function mount(Project $project): void
     {
         $this->authorize('update', $project);
-        $this->project      = $project;
-        $this->name         = $project->name;
-        $this->key          = $project->key;
-        $this->description  = $project->description;
-        $this->lead_id      = $project->lead_id;
-        $this->stage        = ($project->stage?->value) ?? ProjectStage::Planning->value;
-        $this->started_at   = optional($project->started_at)->toDateString();
-        $this->due_at       = optional($project->due_at)->toDateString();
-        $this->ended_at     = optional($project->ended_at)->toDateString();
+        $this->project = $project;
+        $this->name = $project->name;
+        $this->key = $project->key;
+        $this->description = $project->description;
+        $this->organization_id = $project->organization_id;
+        $this->lead_id = $project->lead_id;
+        $this->stage = ($project->stage?->value) ?? ProjectStage::Planning->value;
+        $this->started_at = optional($project->started_at)->toDateString();
+        $this->due_at = optional($project->due_at)->toDateString();
+        $this->ended_at = optional($project->ended_at)->toDateString();
+        $this->attach_team_ids = $project->teams()
+            ->pluck('teams.id')
+            ->map(fn ($id) => (string) $id)
+            ->all();
+
+        $this->organizationOptions = $this->availableOrganizations()
+            ->map(fn (Organization $organization) => ['id' => (string) $organization->id, 'name' => $organization->name])
+            ->values()
+            ->all();
+
+        $this->teamOptions = $this->availableTeams()
+            ->map(fn (Team $team) => ['id' => (string) $team->id, 'name' => $team->name])
+            ->values()
+            ->all();
+
+        $this->refreshAssignableUsers();
+
+        if ($this->lead_id && ! collect($this->leadOptions)->pluck('id')->contains($this->lead_id)) {
+            $this->leadOptions[] = [
+                'id' => (string) $this->project->lead?->id,
+                'name' => (string) $this->project->lead?->name,
+            ];
+        }
     }
 
     protected function rules(): array
     {
         return [
             'name' => 'required|string|max:120',
-            'key'  => ['required','string','alpha_num:ascii','min:2','max:10', Rule::unique('projects','key')->ignore($this->project->id)],
+            'key' => ['required', 'string', 'alpha_num:ascii', 'min:2', 'max:10', Rule::unique('projects', 'key')->ignore($this->project->id)],
             'description' => 'nullable|string|max:10000',
+            'organization_id' => 'nullable|uuid|exists:organizations,id',
             'lead_id' => 'nullable|uuid|exists:users,id',
-            'stage' => ['required', Rule::in(array_column(ProjectStage::cases(),'value'))],
+            'stage' => ['required', Rule::in(array_column(ProjectStage::cases(), 'value'))],
             'started_at' => 'nullable|date',
             'due_at' => 'nullable|date',
             'ended_at' => 'nullable|date',
+            'attach_team_ids' => ['array'],
+            'attach_team_ids.*' => ['uuid', 'exists:teams,id'],
         ];
+    }
+
+    public function updatedAttachTeamIds(): void
+    {
+        $this->refreshAssignableUsers();
+
+        if ($this->lead_id && ! collect($this->leadOptions)->pluck('id')->contains($this->lead_id)) {
+            $this->lead_id = null;
+        }
     }
 
     public function save(): mixed
     {
         $this->authorize('update', $this->project);
         $data = $this->validate();
+        $this->ensureAllowedScopeSelections();
 
         $this->project->fill([
             'name' => $data['name'],
             'key' => strtoupper($data['key']),
             'description' => $data['description'] ?? null,
+            'organization_id' => $data['organization_id'] ?? null,
             'lead_id' => $data['lead_id'] ?? $this->project->lead_id ?? null,
             'stage' => ProjectStage::from($data['stage']),
             'started_at' => $data['started_at'] ?: null,
             'due_at' => $data['due_at'] ?: null,
             'ended_at' => $data['ended_at'] ?: null,
         ])->save();
+
+        $this->project->teams()->sync($this->teamSyncPayload());
 
         session()->flash('flash.banner', 'Project updated.');
         session()->flash('flash.bannerStyle', 'success');
@@ -79,7 +151,120 @@ final class EditProjectForm extends Component
     {
         return view('livewire.projects.edit-project-form', [
             'stages' => ProjectStage::cases(),
-            'users'  => User::query()->orderBy('name')->get(['id', 'name']),
         ]);
+    }
+
+    private function availableOrganizations()
+    {
+        $query = Organization::query()
+            ->orderBy('name');
+
+        if (! $this->canManageAllOrganizations()) {
+            $query->where(function ($organizations) {
+                $organizations
+                    ->visibleTo(auth()->user())
+                    ->orWhereKey($this->project->organization_id);
+            });
+        }
+
+        return $query->get(['id', 'name']);
+    }
+
+    private function availableTeams()
+    {
+        if ($this->canManageAllOrganizations()) {
+            return Team::query()
+                ->orderBy('name')
+                ->get(['id', 'name', 'user_id']);
+        }
+
+        return Team::query()
+            ->where(function ($teams) {
+                $teams
+                    ->whereIn('id', auth()->user()?->allTeams()->pluck('id') ?? [])
+                    ->orWhereHas('projects', fn ($projects) => $projects->whereKey($this->project->getKey()));
+            })
+            ->orderBy('name')
+            ->get(['id', 'name', 'user_id']);
+    }
+
+    private function canManageAllOrganizations(): bool
+    {
+        return auth()->user()?->hasPermissionTo('is-super-admin')
+            || auth()->user()?->can('is-admin');
+    }
+
+    private function refreshAssignableUsers(): void
+    {
+        $teamIds = array_values(array_filter($this->attach_team_ids));
+
+        if ($teamIds === []) {
+            $users = collect([$this->project->lead, auth()->user()])
+                ->filter()
+                ->unique('id')
+                ->sortBy('name')
+                ->values();
+
+            $this->leadOptions = $users
+                ->map(fn (User $user) => ['id' => (string) $user->id, 'name' => $user->name])
+                ->all();
+
+            return;
+        }
+
+        $users = Team::query()
+            ->whereKey($teamIds)
+            ->with(['users:id,name', 'owner:id,name'])
+            ->get()
+            ->flatMap(function (Team $team) {
+                return $team->users
+                    ->push($team->owner)
+                    ->filter();
+            })
+            ->unique('id')
+            ->sortBy('name')
+            ->values();
+
+        $this->leadOptions = $users
+            ->map(fn (User $user) => ['id' => (string) $user->id, 'name' => $user->name])
+            ->all();
+    }
+
+    private function ensureAllowedScopeSelections(): void
+    {
+        $selectedTeamIds = collect($this->attach_team_ids)
+            ->filter()
+            ->unique()
+            ->values();
+        $allowedTeamIds = collect($this->teamOptions)->pluck('id');
+
+        abort_unless(
+            $allowedTeamIds->intersect($selectedTeamIds)->count() === $selectedTeamIds->count(),
+            403
+        );
+
+        if ($this->organization_id === null) {
+            return;
+        }
+
+        $allowedOrganizationIds = collect($this->organizationOptions)->pluck('id');
+
+        abort_unless($allowedOrganizationIds->contains($this->organization_id), 403);
+    }
+
+    /** @return array<string, array{role:string}> */
+    private function teamSyncPayload(): array
+    {
+        $existingRoles = $this->project->teams()
+            ->pluck('project_team.role', 'teams.id')
+            ->mapWithKeys(fn ($role, $teamId) => [(string) $teamId => (string) ($role ?: 'Contributor')]);
+
+        return collect($this->attach_team_ids)
+            ->filter()
+            ->unique()
+            ->mapWithKeys(function (string $teamId) use ($existingRoles) {
+                return [$teamId => ['role' => $existingRoles->get($teamId, 'Contributor')]];
+            })
+            ->all();
     }
 }

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -3,8 +3,11 @@
 namespace App\Models;
 
 use App\Traits\IsPermissible;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
 use Spatie\Sluggable\HasSlug;
@@ -21,6 +24,7 @@ class Organization extends BaseModel
     protected $table = 'organizations';
 
     protected $keyType = 'string';
+
     public $incrementing = false;
 
     /** @var array<string, string> */
@@ -29,9 +33,39 @@ class Organization extends BaseModel
     /** @var array<int, string> */
     protected $fillable = ['name', 'slug'];
 
+    public function projects(): HasMany
+    {
+        return $this->hasMany(Project::class);
+    }
+
+    public function goals(): MorphMany
+    {
+        return $this->morphMany(Goal::class, 'owner');
+    }
+
     public function getRouteKeyName(): string
     {
         return 'slug';
+    }
+
+    public function isAccessibleBy(User $user): bool
+    {
+        if ($user->hasPermissionTo('is-super-admin') || $user->can('is-admin')) {
+            return true;
+        }
+
+        return $this->projects()
+            ->visibleTo($user)
+            ->exists();
+    }
+
+    public function scopeVisibleTo(Builder $query, User $user): Builder
+    {
+        if ($user->hasPermissionTo('is-super-admin') || $user->can('is-admin')) {
+            return $query;
+        }
+
+        return $query->whereHas('projects', fn (Builder $projects) => $projects->visibleTo($user));
     }
 
     protected static function booted(): void
@@ -75,7 +109,7 @@ class Organization extends BaseModel
     /**
      * Get the options for generating the slug.
      */
-    public function getSlugOptions() : SlugOptions
+    public function getSlugOptions(): SlugOptions
     {
         return SlugOptions::create()
             ->generateSlugsFrom('name')

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -17,19 +17,21 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Spatie\Activitylog\Traits\LogsActivity;
+use Spatie\Activitylog\Contracts\Activity;
 use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
 
 class Project extends BaseModel
 {
-    use HasFactory;
-    use HasUuids;
-    use LogsActivity;
-    use IsPermissible;
     use HasExternalId;
+    use HasFactory;
     use HasRecordShares;
+    use HasUuids;
+    use IsPermissible;
+    use LogsActivity;
 
     protected $keyType = 'string';
+
     public $incrementing = false;
 
     public const KEY_MAX_LENGTH = 8;
@@ -115,7 +117,7 @@ class Project extends BaseModel
             ],
             'attachments' => [
                 'max_mb' => 50,
-                'allowed_mime' => ['image/*','application/pdf'],
+                'allowed_mime' => ['image/*', 'application/pdf'],
             ],
             'comments' => [
                 'mentions_enabled' => true,
@@ -129,6 +131,7 @@ class Project extends BaseModel
     public function setting(string $key, mixed $default = null): mixed
     {
         $merged = array_replace_recursive($this->defaultSettings(), $this->settings ?? []);
+
         return Arr::get($merged, $key, $default);
     }
 
@@ -137,12 +140,14 @@ class Project extends BaseModel
         $settings = $this->settings ?? [];
         Arr::set($settings, $key, $value);
         $this->settings = $settings;
+
         return $this;
     }
 
     public function updateSettings(array $values): static
     {
         $this->settings = array_replace_recursive($this->settings ?? [], $values);
+
         return $this;
     }
 
@@ -150,22 +155,22 @@ class Project extends BaseModel
     {
         return LogOptions::defaults()
             ->useLogName('forge.project')
-            ->logOnly(['name','key','description','lead_id'])
+            ->logOnly(['name', 'key', 'description', 'lead_id'])
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs();
     }
 
-    public function tapActivity(\Spatie\Activitylog\Contracts\Activity $activity): void
+    public function tapActivity(Activity $activity): void
     {
         $ctx = ActivityContext::base();
         $activity->team_id = $ctx['team_id'];                 // persisted column
         $activity->properties = $activity->properties->merge([ // JSON props
             'actor_id' => $ctx['user_id'],
-            'ip'       => $ctx['ip'],
-            'ua'       => $ctx['user_agent'],
+            'ip' => $ctx['ip'],
+            'ua' => $ctx['user_agent'],
         ]);
         $activity->event = $activity->event ?: 'updated'; // create/update/delete auto-populate
-        $activity->description = 'project.' . $activity->event;
+        $activity->description = 'project.'.$activity->event;
     }
 
     public function organization(): BelongsTo
@@ -175,14 +180,14 @@ class Project extends BaseModel
 
     public function teams(): BelongsToMany
     {
-        return $this->belongsToMany(\App\Models\Team::class, 'project_team', 'project_id', 'team_id')
+        return $this->belongsToMany(Team::class, 'project_team', 'project_id', 'team_id')
             ->withPivot(['role'])
             ->withTimestamps();
     }
 
     public function users(): BelongsToMany
     {
-        return $this->belongsToMany(\App\Models\User::class, 'project_user', 'project_id', 'user_id')
+        return $this->belongsToMany(User::class, 'project_user', 'project_id', 'user_id')
             ->withPivot(['role'])
             ->withTimestamps();
     }
@@ -205,21 +210,21 @@ class Project extends BaseModel
     public function issueTypes(): BelongsToMany
     {
         return $this->belongsToMany(IssueType::class, 'project_issue_types')
-            ->withPivot(['order','is_default'])
+            ->withPivot(['order', 'is_default'])
             ->orderBy('project_issue_types.order');
     }
 
     public function issueStatuses(): BelongsToMany
     {
         return $this->belongsToMany(IssueStatus::class, 'project_issue_statuses')
-            ->withPivot(['order','is_initial','is_default_done'])
+            ->withPivot(['order', 'is_initial', 'is_default_done'])
             ->orderBy('project_issue_statuses.order');
     }
 
     public function issuePriorities(): BelongsToMany
     {
         return $this->belongsToMany(IssuePriority::class, 'project_issue_priorities')
-            ->withPivot(['order','is_default'])
+            ->withPivot(['order', 'is_default'])
             ->orderBy('project_issue_priorities.order');
     }
 
@@ -241,20 +246,23 @@ class Project extends BaseModel
     /** IDs / selections (with global fallback) */
     public function allowedTypeIds(): array
     {
-        $ids = $this->issueTypes()->pluck('issue_types.id')->map(fn ($id) => (int)$id)->all();
-        return $ids ?: IssueType::query()->pluck('id')->map(fn ($id) => (int)$id)->all();
+        $ids = $this->issueTypes()->pluck('issue_types.id')->map(fn ($id) => (int) $id)->all();
+
+        return $ids ?: IssueType::query()->pluck('id')->map(fn ($id) => (int) $id)->all();
     }
 
     public function allowedStatusIds(): array
     {
-        $ids = $this->issueStatuses()->pluck('issue_statuses.id')->map(fn ($id) => (int)$id)->all();
-        return $ids ?: IssueStatus::query()->pluck('id')->map(fn ($id) => (int)$id)->all();
+        $ids = $this->issueStatuses()->pluck('issue_statuses.id')->map(fn ($id) => (int) $id)->all();
+
+        return $ids ?: IssueStatus::query()->pluck('id')->map(fn ($id) => (int) $id)->all();
     }
 
     public function allowedPriorityIds(): array
     {
-        $ids = $this->issuePriorities()->pluck('issue_priorities.id')->map(fn ($id) => (int)$id)->all();
-        return $ids ?: IssuePriority::query()->pluck('id')->map(fn ($id) => (int)$id)->all();
+        $ids = $this->issuePriorities()->pluck('issue_priorities.id')->map(fn ($id) => (int) $id)->all();
+
+        return $ids ?: IssuePriority::query()->pluck('id')->map(fn ($id) => (int) $id)->all();
     }
 
     public function defaultTypeId(): ?int
@@ -279,7 +287,6 @@ class Project extends BaseModel
         return $this->hasMany(ImportExportRecord::class);
     }
 
-
     public function initialStatusId(): ?int
     {
         $id = $this->issueStatuses()->wherePivot('is_initial', true)->value('issue_statuses.id');
@@ -289,7 +296,8 @@ class Project extends BaseModel
 
         // global fallback, but only if it's included in project’s allowed set
         $fallback = IssueStatus::query()->where('is_done', false)->orderBy('order')->value('id');
-        return in_array((int)$fallback, $this->allowedStatusIds(), true) ? (int)$fallback : null;
+
+        return in_array((int) $fallback, $this->allowedStatusIds(), true) ? (int) $fallback : null;
     }
 
     public function canTransition(string $fromStatusId, string $toStatusId, ?string $issueTypeId = null): bool
@@ -313,7 +321,7 @@ class Project extends BaseModel
             return false;
         }
 
-        if ($user->hasPermissionTo('is-super-admin')) {
+        if ($user->hasPermissionTo('is-super-admin') || $user->can('is-admin')) {
             return true;
         }
 
@@ -330,13 +338,17 @@ class Project extends BaseModel
         return $this->teams()->where(function ($t) use ($user) {
             // if teams table has owner column:
             $t->where('teams.user_id', $user->id) // owner
-            ->orWhereHas('users', fn ($u) => $u->whereKey($user->id)); // members via team_user
+                ->orWhereHas('users', fn ($u) => $u->whereKey($user->id)); // members via team_user
         })->exists();
     }
 
     /** Scope: projects visible to a user (lead, direct member, or member of any attached team) */
     public function scopeVisibleTo(Builder $q, User $user): Builder
     {
+        if ($user->hasPermissionTo('is-super-admin') || $user->can('is-admin')) {
+            return $q;
+        }
+
         return $q->where(function ($w) use ($user) {
             // Lead always sees
             $w->where('lead_id', $user->id)
@@ -347,7 +359,7 @@ class Project extends BaseModel
                 // Any attached team where the user is owner OR a member
                 ->orWhereHas('teams', function ($t) use ($user) {
                     $t->where('teams.user_id', $user->id) // team owner
-                    ->orWhereHas('users', fn ($u) => $u->whereKey($user->id)); // team_user membership
+                        ->orWhereHas('users', fn ($u) => $u->whereKey($user->id)); // team_user membership
                 });
         });
     }
@@ -355,6 +367,7 @@ class Project extends BaseModel
     public function getStageLabelAttribute(): string
     {
         $s = $this->stage;
+
         return $s instanceof ProjectStage ? $s->label() : ucfirst((string) ($s ?? ''));
     }
 

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -6,6 +6,8 @@ use App\Traits\IsPermissible;
 use Database\Factories\TeamFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Support\Str;
 use Laravel\Jetstream\Events\TeamCreated;
 use Laravel\Jetstream\Events\TeamDeleted;
@@ -16,10 +18,12 @@ class Team extends JetstreamTeam
 {
     /** @use HasFactory<TeamFactory> */
     use HasFactory;
+
     use HasUuids;
     use IsPermissible;
 
     protected $keyType = 'string';
+
     public $incrementing = false;
 
     /**
@@ -52,8 +56,20 @@ class Team extends JetstreamTeam
     {
         return [
             'personal_team' => 'boolean',
-            'id' => 'string'
+            'id' => 'string',
         ];
+    }
+
+    public function projects(): BelongsToMany
+    {
+        return $this->belongsToMany(Project::class, 'project_team', 'team_id', 'project_id')
+            ->withPivot(['role'])
+            ->withTimestamps();
+    }
+
+    public function goals(): MorphMany
+    {
+        return $this->morphMany(Goal::class, 'owner');
     }
 
     public static function boot(): void

--- a/app/Policies/OrganizationPolicy.php
+++ b/app/Policies/OrganizationPolicy.php
@@ -9,32 +9,32 @@ final class OrganizationPolicy
 {
     public function viewAny(User $user): bool
     {
-        return $user->can('is-admin') || $user->can('is-super-admin');
+        return true;
     }
 
     public function view(User $user, Organization $organization): bool
     {
-        return $user->can('is-admin') || $user->can('is-super-admin');
+        return $organization->isAccessibleBy($user);
     }
 
     public function create(User $user): bool
     {
-        return $user->can('is-admin') || $user->can('is-super-admin');
+        return $user->can('is-admin') || $user->hasPermissionTo('is-super-admin');
     }
 
     public function update(User $user, Organization $organization): bool
     {
-        return $user->can('is-admin') || $user->can('is-super-admin');
+        return $user->can('is-admin') || $user->hasPermissionTo('is-super-admin');
     }
 
     public function delete(User $user, Organization $organization): bool
     {
-        return $user->can('is-super-admin');
+        return $user->hasPermissionTo('is-super-admin');
     }
 
     public function restore(User $user, Organization $organization): bool
     {
-        return $user->can('is-super-admin');
+        return $user->hasPermissionTo('is-super-admin');
     }
 
     public function forceDelete(User $user, Organization $organization): bool

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -49,7 +49,7 @@ class JetstreamServiceProvider extends ServiceProvider
             'projects:read',
         ]);
 
-        \Laravel\Jetstream\Jetstream::permissions([
+        Jetstream::permissions([
             'projects:read',
             'issues:read',
             'issues:write',
@@ -58,12 +58,16 @@ class JetstreamServiceProvider extends ServiceProvider
             'time:write',
         ]);
 
-        \Laravel\Jetstream\Jetstream::role('admin', 'Administrator', [
+        Jetstream::role('admin', 'Administrator', [
             'create', 'read', 'update', 'delete',
         ])->description('Administrator users can perform any action.');
 
-        \Laravel\Jetstream\Jetstream::role('editor', 'Editor', [
+        Jetstream::role('editor', 'Editor', [
             'read', 'create', 'update',
         ])->description('Editor users have the ability to read, create, and update.');
+
+        Jetstream::role('collaborator', 'Collaborator', [
+            'read', 'create', 'update',
+        ])->description('Collaborators can work with shared records without managing the team itself.');
     }
 }

--- a/app/Services/Dashboards/SharedDashboardService.php
+++ b/app/Services/Dashboards/SharedDashboardService.php
@@ -1,0 +1,323 @@
+<?php
+
+namespace App\Services\Dashboards;
+
+use App\Enums\GoalStatus;
+use App\Models\Activity;
+use App\Models\Goal;
+use App\Models\Issue;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+
+final class SharedDashboardService
+{
+    /**
+     * @return array{
+     *     projectCount:int,
+     *     openIssuesCount:int,
+     *     activeGoalsCount:int,
+     *     projects:Collection<int, Project>,
+     *     dueSoon:Collection<int, Issue>,
+     *     goals:Collection<int, Goal>,
+     *     recentActivity:Collection<int, array<string, mixed>>,
+     *     members:Collection<int, User>
+     * }
+     */
+    public function forTeam(User $viewer, Team $team): array
+    {
+        $members = $team->allUsers()
+            ->sortBy('name')
+            ->values();
+
+        return array_merge(
+            $this->build(
+                projectQuery: $this->teamProjectQuery($viewer, $team),
+                goalOwnerType: Team::class,
+                goalOwnerId: (string) $team->getKey(),
+            ),
+            ['members' => $members],
+        );
+    }
+
+    /**
+     * @return array{
+     *     projectCount:int,
+     *     openIssuesCount:int,
+     *     activeGoalsCount:int,
+     *     projects:Collection<int, Project>,
+     *     dueSoon:Collection<int, Issue>,
+     *     goals:Collection<int, Goal>,
+     *     recentActivity:Collection<int, array<string, mixed>>,
+     *     teams:Collection<int, Team>
+     * }
+     */
+    public function forOrganization(User $viewer, Organization $organization): array
+    {
+        $projectQuery = $this->organizationProjectQuery($viewer, $organization);
+        $projectIds = (clone $projectQuery)->pluck('projects.id')->values()->all();
+
+        $teams = empty($projectIds)
+            ? Team::query()->whereRaw('1 = 0')->get()
+            : Team::query()
+                ->whereHas('projects', fn (Builder $projects) => $projects->whereIn('projects.id', $projectIds))
+                ->withCount([
+                    'projects as scoped_projects_count' => fn (Builder $projects) => $projects->whereIn('projects.id', $projectIds),
+                ])
+                ->orderBy('name')
+                ->get(['id', 'name']);
+
+        return array_merge(
+            $this->build(
+                projectQuery: $projectQuery,
+                goalOwnerType: Organization::class,
+                goalOwnerId: (string) $organization->getKey(),
+            ),
+            ['teams' => $teams],
+        );
+    }
+
+    private function viewerCanSeeAllProjects(User $viewer): bool
+    {
+        return $viewer->hasPermissionTo('is-super-admin') || $viewer->can('is-admin');
+    }
+
+    private function teamProjectQuery(User $viewer, Team $team): Builder
+    {
+        $query = Project::query()
+            ->whereHas('teams', fn (Builder $teams) => $teams->whereKey($team->getKey()));
+
+        if (! $this->viewerCanSeeAllProjects($viewer)) {
+            $query->visibleTo($viewer);
+        }
+
+        return $query;
+    }
+
+    private function organizationProjectQuery(User $viewer, Organization $organization): Builder
+    {
+        $query = Project::query()
+            ->where('organization_id', $organization->getKey());
+
+        if (! $this->viewerCanSeeAllProjects($viewer)) {
+            $query->visibleTo($viewer);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return array{
+     *     projectCount:int,
+     *     openIssuesCount:int,
+     *     activeGoalsCount:int,
+     *     projects:Collection<int, Project>,
+     *     dueSoon:Collection<int, Issue>,
+     *     goals:Collection<int, Goal>,
+     *     recentActivity:Collection<int, array<string, mixed>>
+     * }
+     */
+    private function build(Builder $projectQuery, string $goalOwnerType, string $goalOwnerId): array
+    {
+        $projectIds = (clone $projectQuery)->pluck('projects.id')->values()->all();
+
+        $projects = empty($projectIds)
+            ? Project::query()->whereRaw('1 = 0')->get()
+            : (clone $projectQuery)
+                ->select(['projects.id', 'projects.name', 'projects.key', 'projects.organization_id', 'projects.updated_at'])
+                ->with(['organization:id,name,slug', 'teams:id,name'])
+                ->withCount([
+                    'issues as open_issues_count' => fn (Builder $issues) => $issues->whereHas(
+                        'status',
+                        fn (Builder $statuses) => $statuses->where('is_done', false)
+                    ),
+                ])
+                ->latest('projects.updated_at')
+                ->limit(8)
+                ->get();
+
+        $dueSoon = empty($projectIds)
+            ? Issue::query()->whereRaw('1 = 0')->get()
+            : Issue::query()
+                ->select(['id', 'key', 'summary', 'project_id', 'issue_status_id', 'due_at'])
+                ->with(['project:id,key,name', 'status:id,name,color,is_done'])
+                ->whereIn('project_id', $projectIds)
+                ->whereHas('status', fn (Builder $statuses) => $statuses->where('is_done', false))
+                ->whereNotNull('due_at')
+                ->whereBetween('due_at', [now(), now()->addDays(14)])
+                ->orderBy('due_at')
+                ->limit(8)
+                ->get();
+
+        $goals = Goal::query()
+            ->with('owner')
+            ->where('owner_type', $goalOwnerType)
+            ->where('owner_id', $goalOwnerId)
+            ->latest()
+            ->limit(6)
+            ->get(['id', 'name', 'status', 'progress', 'due_date', 'owner_type', 'owner_id']);
+
+        $openIssuesCount = empty($projectIds)
+            ? 0
+            : Issue::query()
+                ->whereIn('project_id', $projectIds)
+                ->whereHas('status', fn (Builder $statuses) => $statuses->where('is_done', false))
+                ->count();
+
+        $activeGoalsCount = Goal::query()
+            ->where('owner_type', $goalOwnerType)
+            ->where('owner_id', $goalOwnerId)
+            ->where('status', GoalStatus::Active->value)
+            ->count();
+
+        return [
+            'projectCount' => count($projectIds),
+            'openIssuesCount' => $openIssuesCount,
+            'activeGoalsCount' => $activeGoalsCount,
+            'projects' => $projects,
+            'dueSoon' => $dueSoon,
+            'goals' => $goals,
+            'recentActivity' => $this->recentActivity($projectIds),
+        ];
+    }
+
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function recentActivity(array $projectIds): Collection
+    {
+        if ($projectIds === []) {
+            return collect();
+        }
+
+        /** @var Collection<int, Activity> $raw */
+        $raw = Activity::query()
+            ->where(function (Builder $query) use ($projectIds) {
+                $query
+                    ->where(function (Builder $projectActivity) use ($projectIds) {
+                        $projectActivity
+                            ->where('subject_type', Project::class)
+                            ->whereIn('subject_id', $projectIds);
+                    })
+                    ->orWhereIn('properties->project_id', $projectIds);
+            })
+            ->latest()
+            ->limit(12)
+            ->get([
+                'id',
+                'description',
+                'event',
+                'created_at',
+                'properties',
+                'causer_id',
+                'causer_type',
+                'subject_type',
+                'subject_id',
+                'log_name',
+            ]);
+
+        if ($raw->isEmpty()) {
+            return collect();
+        }
+
+        $issueIds = $raw
+            ->where('subject_type', Issue::class)
+            ->pluck('subject_id')
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        $referencedProjectIds = collect($projectIds)
+            ->merge(
+                $raw->where('subject_type', Project::class)
+                    ->pluck('subject_id')
+                    ->filter()
+            )
+            ->merge(
+                $raw->pluck('properties.project_id')
+                    ->filter()
+            )
+            ->unique()
+            ->values()
+            ->all();
+
+        $causerIds = $raw
+            ->where('causer_type', User::class)
+            ->pluck('causer_id')
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        $projectsById = Project::query()
+            ->whereIn('id', $referencedProjectIds)
+            ->get(['id', 'key', 'name'])
+            ->keyBy('id');
+
+        $issuesById = Issue::query()
+            ->whereIn('id', $issueIds)
+            ->with(['project:id,key,name'])
+            ->get(['id', 'key', 'summary', 'project_id'])
+            ->keyBy('id');
+
+        $usersById = User::query()
+            ->whereIn('id', $causerIds)
+            ->get(['id', 'name', 'profile_photo_path'])
+            ->keyBy('id');
+
+        return $raw->map(function (Activity $activity) use ($projectsById, $issuesById, $usersById): array {
+            $actor = $activity->causer_type === User::class
+                ? $usersById->get($activity->causer_id)
+                : null;
+
+            $targetLabel = 'Shared record';
+            $targetUrl = null;
+
+            if ($activity->subject_type === Issue::class) {
+                /** @var Issue|null $issue */
+                $issue = $issuesById->get($activity->subject_id);
+
+                if ($issue && $issue->project) {
+                    $targetLabel = "{$issue->key}: {$issue->summary}";
+                    $targetUrl = route('issues.show', ['project' => $issue->project, 'issue' => $issue]);
+                }
+            } elseif ($activity->subject_type === Project::class) {
+                /** @var Project|null $project */
+                $project = $projectsById->get($activity->subject_id);
+
+                if ($project) {
+                    $targetLabel = "{$project->key} — {$project->name}";
+                    $targetUrl = route('projects.show', ['project' => $project]);
+                }
+            } else {
+                /** @var Project|null $project */
+                $project = $projectsById->get(data_get($activity->properties, 'project_id'));
+
+                if ($project) {
+                    $targetLabel = "{$project->key} — {$project->name}";
+                    $targetUrl = route('projects.show', ['project' => $project]);
+                }
+            }
+
+            $verb = $activity->event
+                ?: (Str::contains((string) $activity->description, '.')
+                    ? Str::after((string) $activity->description, '.')
+                    : (string) $activity->description);
+
+            return [
+                'id' => $activity->id,
+                'actor_name' => $actor?->name ?? 'System',
+                'actor_avatar' => $actor?->profile_photo_url ?? $actor?->profile_photo_path ?? null,
+                'verb' => (string) Str::of($verb)->replace(['issue.', 'project.', 'comment.'], '')->headline(),
+                'target_label' => $targetLabel,
+                'target_url' => $targetUrl,
+                'ago' => $activity->created_at?->diffForHumans(),
+            ];
+        });
+    }
+}

--- a/resources/views/livewire/organizations/form.blade.php
+++ b/resources/views/livewire/organizations/form.blade.php
@@ -14,7 +14,7 @@
         </button>
 
         @if ($isEditing && $organization?->exists && filled($organization->slug))
-            <a href="{{ route('organizations.show', ['organization' => $organization->slug]) }}" class="btn btn-outline-secondary">
+            <a href="{{ route('organizations.show', ['organization' => $organization]) }}" class="btn btn-outline-secondary">
                 Cancel
             </a>
         @else

--- a/resources/views/livewire/organizations/index.blade.php
+++ b/resources/views/livewire/organizations/index.blade.php
@@ -10,7 +10,9 @@
                 class="form-control"
                 style="width: 18rem"
             >
-            <a href="{{ route('organizations.create') }}" class="btn btn-primary">New Organization</a>
+            @can('create', \App\Models\Organization::class)
+                <a href="{{ route('organizations.create') }}" class="btn btn-primary">New Organization</a>
+            @endcan
         </div>
     </div>
 
@@ -23,19 +25,28 @@
             @forelse($organizations as $org)
                 <div class="list-group-item d-flex align-items-center justify-content-between">
                     <div>
-                        <a href="{{ route('organizations.show', ['organization' => $org->slug]) }}"
+                        <a href="{{ route('organizations.show', ['organization' => $org]) }}"
                            class="fw-semibold link-primary text-decoration-none">{{ $org->name }}</a>
-                        <div class="text-body-secondary small">slug: {{ $org->slug }}</div>
+                        <div class="text-body-secondary small">
+                            {{ $org->accessible_projects_count }} {{ \Illuminate\Support\Str::plural('shared project', $org->accessible_projects_count) }}
+                            • slug: {{ $org->slug }}
+                        </div>
                     </div>
 
                     <div class="d-flex align-items-center gap-2">
-                        <a href="{{ route('organizations.edit', ['organization' => $org->slug]) }}"
-                           class="btn btn-sm btn-outline-secondary">Edit</a>
-                        <button wire:click="delete('{{ $org->id }}')"
-                                onclick="return confirm('Move this organization to trash?')"
-                                class="btn btn-sm btn-danger">
-                            Delete
-                        </button>
+                        <a href="{{ route('organizations.show', ['organization' => $org]) }}"
+                           class="btn btn-sm btn-outline-primary">Dashboard</a>
+                        @can('update', $org)
+                            <a href="{{ route('organizations.edit', ['organization' => $org]) }}"
+                               class="btn btn-sm btn-outline-secondary">Edit</a>
+                        @endcan
+                        @can('delete', $org)
+                            <button wire:click="delete('{{ $org->id }}')"
+                                    onclick="return confirm('Move this organization to trash?')"
+                                    class="btn btn-sm btn-danger">
+                                Delete
+                            </button>
+                        @endcan
                     </div>
                 </div>
             @empty

--- a/resources/views/livewire/projects/create-project-form.blade.php
+++ b/resources/views/livewire/projects/create-project-form.blade.php
@@ -20,6 +20,18 @@
             </div>
 
             <div class="col-sm-6">
+                <x-label for="organization_id" value="Organization"/>
+                <select wire:model.defer="organization_id" id="organization_id" class="form-select">
+                    <option value="">(No organization)</option>
+                    @foreach($organizationOptions as $organization)
+                        <option value="{{ $organization['id'] }}">{{ $organization['name'] }}</option>
+                    @endforeach
+                </select>
+                <div class="form-text">{{ __('Projects can belong to an organization and one or more teams at the same time.') }}</div>
+                <x-input-error for="organization_id" class="mt-1"/>
+            </div>
+
+            <div class="col-sm-6">
                 <x-label for="lead_id" value="Project Lead"/>
                 <select wire:model.defer="lead_id" id="lead_id" class="form-select">
                     <option value="">(Select)</option>
@@ -47,6 +59,7 @@
                         <option value="{{ $t['id'] }}">{{ $t['name'] }}</option>
                     @endforeach
                 </select>
+                <div class="form-text">{{ __('Use teams for collaboration boundaries, and use the organization for shared reporting and rollups.') }}</div>
                 <x-input-error for="attach_team_ids" class="mt-1"/>
             </div>
 

--- a/resources/views/livewire/projects/edit-project-form.blade.php
+++ b/resources/views/livewire/projects/edit-project-form.blade.php
@@ -20,6 +20,18 @@
             </div>
 
             <div class="col-sm-6">
+                <x-label for="organization_id" value="Organization"/>
+                <select id="organization_id" class="form-select" wire:model.defer="organization_id">
+                    <option value="">— {{ __('None') }} —</option>
+                    @foreach($organizationOptions as $organization)
+                        <option value="{{ $organization['id'] }}">{{ $organization['name'] }}</option>
+                    @endforeach
+                </select>
+                <div class="form-text">{{ __('Organizations and teams can both scope the same project.') }}</div>
+                <x-input-error for="organization_id" class="mt-1"/>
+            </div>
+
+            <div class="col-sm-6">
                 <x-label for="stage" value="Stage"/>
                 <select id="stage" class="form-select" wire:model.defer="stage">
                     @foreach($stages as $s)
@@ -33,11 +45,22 @@
                 <x-label for="lead_id" value="Project lead (optional)"/>
                 <select id="lead_id" class="form-select" wire:model.defer="lead_id">
                     <option value="">— {{ __('None') }} —</option>
-                    @foreach($users as $u)
-                        <option value="{{ $u->id }}">{{ $u->name }}</option>
+                    @foreach($leadOptions as $user)
+                        <option value="{{ $user['id'] }}">{{ $user['name'] }}</option>
                     @endforeach
                 </select>
                 <x-input-error for="lead_id" class="mt-1"/>
+            </div>
+
+            <div class="col-12">
+                <x-label for="teams" value="Teams included in this project"/>
+                <select id="teams" multiple class="form-select" wire:model.defer="attach_team_ids">
+                    @foreach($teamOptions as $team)
+                        <option value="{{ $team['id'] }}">{{ $team['name'] }}</option>
+                    @endforeach
+                </select>
+                <div class="form-text">{{ __('Selected teams will see this project as shared team work.') }}</div>
+                <x-input-error for="attach_team_ids" class="mt-1"/>
             </div>
 
             <div class="col-sm-4">

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -193,6 +193,9 @@
 
                                 @if ($currentTeam)
                                     <li>
+                                        <x-dropdown-link href="{{ route('teams.dashboard', ['team' => $currentTeam]) }}">{{ __('Team Dashboard') }}</x-dropdown-link>
+                                    </li>
+                                    <li>
                                         <x-dropdown-link href="{{ route('teams.show', $currentTeam->id) }}">{{ __('Team Settings') }}</x-dropdown-link>
                                     </li>
                                 @else

--- a/resources/views/pages/organizations/[organization]/edit.blade.php
+++ b/resources/views/pages/organizations/[organization]/edit.blade.php
@@ -11,7 +11,7 @@ middleware(['auth','verified']);
         <div class="d-flex align-items-center justify-content-between">
             <h2 class="h4 mb-0">Edit Organization</h2>
             <a class="btn btn-sm btn-outline-secondary"
-               href="{{ route('organizations.show', ['organization' => $organization->slug]) }}">Back</a>
+               href="{{ route('organizations.show', ['organization' => $organization]) }}">Back</a>
         </div>
     </x-slot>
 

--- a/resources/views/pages/projects/[project].blade.php
+++ b/resources/views/pages/projects/[project].blade.php
@@ -278,10 +278,22 @@ render(function (View $view, Project $project) {
             {{ ucfirst($project->stage->value ?? 'planning') }}
           </span>
                     @if ($project->organization?->name)
-                        <span>Org: {{ $project->organization->name }}</span>
+                        <span>
+                            Org:
+                            <a class="link-primary text-decoration-none" href="{{ route('organizations.show', ['organization' => $project->organization]) }}">
+                                {{ $project->organization->name }}
+                            </a>
+                        </span>
                     @endif
                     @if ($project->teams->isNotEmpty())
-                        <span>Teams: {{ $project->teams->pluck('name')->implode(', ') }}</span>
+                        <span>
+                            Teams:
+                            @foreach($project->teams as $team)
+                                <a class="link-primary text-decoration-none" href="{{ route('teams.dashboard', ['team' => $team]) }}">
+                                    {{ $team->name }}
+                                </a>@if (! $loop->last), @endif
+                            @endforeach
+                        </span>
                     @endif
                 </div>
             </div>

--- a/resources/views/pages/projects/index.blade.php
+++ b/resources/views/pages/projects/index.blade.php
@@ -13,6 +13,7 @@ render(function (View $view) {
 
     $projects = Project::query()
         ->visibleTo($u)
+        ->with(['organization:id,name,slug', 'teams:id,name'])
         ->latest()
         ->paginate(12)
         ->withQueryString();
@@ -46,6 +47,14 @@ render(function (View $view) {
                                 </div>
                                 <div class="fw-semibold mt-2">{{ $project->name }}</div>
                                 <div class="small text-body-secondary mt-1">{{ $project->description }}</div>
+                                <div class="small text-body-secondary mt-2 d-flex flex-column gap-1">
+                                    @if($project->organization)
+                                        <span>{{ __('Org') }}: {{ $project->organization->name }}</span>
+                                    @endif
+                                    @if($project->teams->isNotEmpty())
+                                        <span>{{ __('Teams') }}: {{ $project->teams->pluck('name')->implode(', ') }}</span>
+                                    @endif
+                                </div>
                             </div>
                         </a>
                     </div>

--- a/resources/views/pages/search.blade.php
+++ b/resources/views/pages/search.blade.php
@@ -1,13 +1,18 @@
 <?php
 
-use App\Models\{Project, Issue, Organization, Goal};
+use App\Models\Goal;
+use App\Models\Issue;
+use App\Models\Organization;
+use App\Models\Project;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
-use function Laravel\Folio\{name, middleware, render};
+use function Laravel\Folio\middleware;
+use function Laravel\Folio\name;
+use function Laravel\Folio\render;
 
 name('search');
-middleware(['auth','verified']);
+middleware(['auth', 'verified']);
 /** Provide page data */
 render(function (View $view, Request $request) {
     $q = trim((string) $request->query('q', ''));
@@ -24,7 +29,7 @@ render(function (View $view, Request $request) {
         ]);
     }
 
-    $like = '%' . str_replace(['%', '_'], ['\%', '\_'], $q) . '%';
+    $like = '%'.str_replace(['%', '_'], ['\%', '\_'], $q).'%';
 
     $projects = Project::query()
         ->select(['id', 'name', 'key', 'description'])
@@ -48,6 +53,7 @@ render(function (View $view, Request $request) {
         ->get();
 
     $organizations = Organization::query()
+        ->visibleTo($user)
         ->select(['id', 'name', 'slug'])
         ->where(fn ($sub) => $sub
             ->where('name', 'like', $like))
@@ -123,7 +129,7 @@ render(function (View $view, Request $request) {
                             <h2 class="h6 mb-2">{{ __('Organizations') }}</h2>
                             <div class="list-group">
                                 @forelse ($organizations as $o)
-                                    <a class="list-group-item list-group-item-action" href="{{ route('organizations.show', $o) }}">
+                                    <a class="list-group-item list-group-item-action" href="{{ route('organizations.show', ['organization' => $o]) }}">
                                         {{ $o->name }}
                                     </a>
                                 @empty

--- a/resources/views/pages/teams/[team]/dashboard.blade.php
+++ b/resources/views/pages/teams/[team]/dashboard.blade.php
@@ -1,19 +1,19 @@
 <?php
 
-use App\Models\Organization;
+use App\Models\Team;
 use App\Services\Dashboards\SharedDashboardService;
 use Illuminate\Support\Facades\Gate;
 
 use function Laravel\Folio\{name, middleware, render};
 
-name('organizations.show');
+name('teams.dashboard');
 middleware(['auth', 'verified']);
 
-render(function (\Illuminate\View\View $view, Organization $organization) {
-    Gate::authorize('view', $organization);
+render(function (\Illuminate\View\View $view, Team $team) {
+    Gate::authorize('view', $team);
 
     return $view->with(
-        ['organization' => $organization] + app(SharedDashboardService::class)->forOrganization(auth()->user(), $organization)
+        ['team' => $team] + app(SharedDashboardService::class)->forTeam(auth()->user(), $team)
     );
 });
 ?>
@@ -22,23 +22,19 @@ render(function (\Illuminate\View\View $view, Organization $organization) {
     <x-slot name="header">
         <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
             <div>
-                <h2 class="h4 mb-0">{{ $organization->name }}</h2>
-                <div class="small text-body-secondary">{{ __('Organization dashboard') }}</div>
+                <h2 class="h4 mb-0">{{ $team->name }}</h2>
+                <div class="small text-body-secondary">{{ __('Team dashboard') }}</div>
             </div>
             <div class="d-flex gap-2">
-                @can('update', $organization)
-                    <a class="btn btn-sm btn-primary"
-                       href="{{ route('organizations.edit', ['organization' => $organization]) }}">Edit</a>
-                @endcan
-                <a class="btn btn-sm btn-outline-secondary"
-                   href="{{ route('organizations.index') }}">Back</a>
+                <a class="btn btn-sm btn-outline-primary" href="{{ route('teams.show', ['team' => $team]) }}">
+                    {{ __('Team Settings') }}
+                </a>
+                <a class="btn btn-sm btn-outline-secondary" href="{{ route('dashboard') }}">
+                    {{ __('Main Dashboard') }}
+                </a>
             </div>
         </div>
     </x-slot>
-
-    @if (session('status'))
-        <div class="alert alert-success my-3">{{ session('status') }}</div>
-    @endif
 
     <div class="py-4">
         <div class="container mx-auto py-4 d-flex flex-column gap-4">
@@ -46,16 +42,16 @@ render(function (\Illuminate\View\View $view, Organization $organization) {
                 <div class="col">
                     <div class="card h-100 shadow-sm">
                         <div class="card-body">
-                            <div class="text-uppercase small text-body-secondary">{{ __('Projects') }}</div>
-                            <div class="display-6 mb-0">{{ $projectCount }}</div>
+                            <div class="text-uppercase small text-body-secondary">{{ __('Members') }}</div>
+                            <div class="display-6 mb-0">{{ $members->count() }}</div>
                         </div>
                     </div>
                 </div>
                 <div class="col">
                     <div class="card h-100 shadow-sm">
                         <div class="card-body">
-                            <div class="text-uppercase small text-body-secondary">{{ __('Teams') }}</div>
-                            <div class="display-6 mb-0">{{ $teams->count() }}</div>
+                            <div class="text-uppercase small text-body-secondary">{{ __('Projects') }}</div>
+                            <div class="display-6 mb-0">{{ $projectCount }}</div>
                         </div>
                     </div>
                 </div>
@@ -87,7 +83,7 @@ render(function (\Illuminate\View\View $view, Organization $organization) {
                             </div>
 
                             @if($projects->isEmpty())
-                                <p class="small text-body-secondary mb-0">{{ __('No shared projects are attached to this organization yet.') }}</p>
+                                <p class="small text-body-secondary mb-0">{{ __('This team does not have any shared projects yet.') }}</p>
                             @else
                                 <div class="row row-cols-1 row-cols-md-2 g-3">
                                     @foreach($projects as $project)
@@ -100,9 +96,9 @@ render(function (\Illuminate\View\View $view, Organization $organization) {
                                                             <span class="badge bg-body-tertiary text-body">{{ $project->open_issues_count }} {{ __('open') }}</span>
                                                         </div>
                                                         <div class="fw-semibold mt-2">{{ $project->name }}</div>
-                                                        @if($project->teams->isNotEmpty())
+                                                        @if($project->organization)
                                                             <div class="small text-body-secondary mt-2">
-                                                                {{ __('Teams') }}: {{ $project->teams->pluck('name')->implode(', ') }}
+                                                                {{ __('Organization') }}: {{ $project->organization->name }}
                                                             </div>
                                                         @endif
                                                     </div>
@@ -115,9 +111,9 @@ render(function (\Illuminate\View\View $view, Organization $organization) {
                                                             <span class="badge bg-body-tertiary text-body">{{ $project->open_issues_count }} {{ __('open') }}</span>
                                                         </div>
                                                         <div class="fw-semibold mt-2">{{ $project->name }}</div>
-                                                        @if($project->teams->isNotEmpty())
+                                                        @if($project->organization)
                                                             <div class="small text-body-secondary mt-2">
-                                                                {{ __('Teams') }}: {{ $project->teams->pluck('name')->implode(', ') }}
+                                                                {{ __('Organization') }}: {{ $project->organization->name }}
                                                             </div>
                                                         @endif
                                                     </div>
@@ -132,7 +128,7 @@ render(function (\Illuminate\View\View $view, Organization $organization) {
 
                     <div class="card shadow-sm">
                         <div class="card-body">
-                            <h3 class="h6 mb-3">{{ __('Due soon across the organization') }}</h3>
+                            <h3 class="h6 mb-3">{{ __('Due soon') }}</h3>
 
                             @if($dueSoon->isEmpty())
                                 <p class="small text-body-secondary mb-0">{{ __('Nothing due in the next two weeks.') }}</p>
@@ -196,25 +192,20 @@ render(function (\Illuminate\View\View $view, Organization $organization) {
                 <section class="col-lg-4 d-flex flex-column gap-4">
                     <div class="card shadow-sm">
                         <div class="card-body">
-                            <h3 class="h6 mb-3">{{ __('Teams in this organization') }}</h3>
+                            <h3 class="h6 mb-3">{{ __('Team members') }}</h3>
 
-                            @if($teams->isEmpty())
-                                <p class="small text-body-secondary mb-0">{{ __('No teams are attached to the visible projects in this organization.') }}</p>
+                            @if($members->isEmpty())
+                                <p class="small text-body-secondary mb-0">{{ __('No members yet.') }}</p>
                             @else
                                 <div class="list-group list-group-flush">
-                                    @foreach($teams as $team)
-                                        @can('view', $team)
-                                            <a href="{{ route('teams.dashboard', ['team' => $team]) }}"
-                                               class="list-group-item list-group-item-action px-0 d-flex align-items-center justify-content-between">
-                                                <span class="fw-medium">{{ $team->name }}</span>
-                                                <span class="badge bg-body-tertiary text-body">{{ $team->scoped_projects_count }}</span>
-                                            </a>
-                                        @else
-                                            <div class="list-group-item px-0 d-flex align-items-center justify-content-between">
-                                                <span class="fw-medium">{{ $team->name }}</span>
-                                                <span class="badge bg-body-tertiary text-body">{{ $team->scoped_projects_count }}</span>
+                                    @foreach($members as $member)
+                                        <div class="list-group-item px-0 d-flex align-items-center gap-3">
+                                            <x-avatar :src="$member->profile_photo_url" :name="$member->name" preset="sm" />
+                                            <div>
+                                                <div class="fw-medium">{{ $member->name }}</div>
+                                                <div class="small text-body-secondary">{{ $member->email }}</div>
                                             </div>
-                                        @endcan
+                                        </div>
                                     @endforeach
                                 </div>
                             @endif
@@ -224,12 +215,12 @@ render(function (\Illuminate\View\View $view, Organization $organization) {
                     <div class="card shadow-sm">
                         <div class="card-body">
                             <div class="d-flex align-items-center justify-content-between mb-3">
-                                <h3 class="h6 mb-0">{{ __('Organization goals') }}</h3>
+                                <h3 class="h6 mb-0">{{ __('Team goals') }}</h3>
                                 <a class="small text-decoration-underline" href="{{ route('goals.index') }}">{{ __('Browse goals') }}</a>
                             </div>
 
                             @if($goals->isEmpty())
-                                <p class="small text-body-secondary mb-0">{{ __('No organization goals yet.') }}</p>
+                                <p class="small text-body-secondary mb-0">{{ __('No team goals yet.') }}</p>
                             @else
                                 <div class="list-group list-group-flush">
                                     @foreach($goals as $goal)

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -2,6 +2,9 @@
     <x-slot name="header">
         <div class="d-flex align-items-center justify-content-between">
             <h2 class="h4 mb-0">{{ __('Team Settings') }}</h2>
+            <a class="btn btn-sm btn-outline-primary" href="{{ route('teams.dashboard', ['team' => $team]) }}">
+                {{ __('Team Dashboard') }}
+            </a>
         </div>
     </x-slot>
 

--- a/tests/Feature/ScopeDashboardTest.php
+++ b/tests/Feature/ScopeDashboardTest.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\Organizations\Form as OrganizationForm;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\PermissionSeeder;
+use Illuminate\Auth\Access\Response as AccessResponse;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+use Laravel\Jetstream\Jetstream;
+use Tests\TestCase;
+
+class ScopeDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_organizations_only_show_when_the_user_has_visible_shared_work(): void
+    {
+        [$owner, $teammate, $team] = $this->teamContext();
+
+        $visibleOrganization = Organization::factory()->create([
+            'name' => 'Visible Organization',
+        ]);
+
+        $hiddenOrganization = Organization::factory()->create([
+            'name' => 'Hidden Organization',
+        ]);
+
+        $visibleProject = Project::factory()->create([
+            'name' => 'Shared Platform',
+            'organization_id' => $visibleOrganization->id,
+            'lead_id' => $owner->id,
+        ]);
+
+        $hiddenProject = Project::factory()->create([
+            'name' => 'Private Audit',
+            'organization_id' => $hiddenOrganization->id,
+            'lead_id' => User::factory(),
+        ]);
+
+        $this->attachTeamToProject($team, $visibleProject);
+        $this->attachUserToProject($visibleProject, $owner);
+        $this->attachUserToProject($hiddenProject, $owner);
+
+        $this->actingAs($teammate)
+            ->get('/organizations')
+            ->assertOk()
+            ->assertSee('Visible Organization')
+            ->assertDontSee('Hidden Organization');
+
+        $this->actingAs($teammate)
+            ->get('/organizations/'.$visibleOrganization->slug)
+            ->assertOk()
+            ->assertSee('Organization dashboard')
+            ->assertSee('Shared Platform')
+            ->assertDontSee('Private Audit');
+
+        $this->actingAs($teammate)
+            ->get('/organizations/'.$hiddenOrganization->slug)
+            ->assertForbidden();
+    }
+
+    public function test_team_dashboard_shows_shared_projects_and_members_for_team_members(): void
+    {
+        [$owner, $teammate, $team] = $this->teamContext();
+        $otherTeam = Team::factory()->create([
+            'user_id' => User::factory(),
+            'personal_team' => false,
+            'name' => 'Other Team',
+        ]);
+
+        $organization = Organization::factory()->create([
+            'name' => 'Forge Ops',
+        ]);
+
+        $sharedProject = Project::factory()->create([
+            'name' => 'Release Command Center',
+            'organization_id' => $organization->id,
+            'lead_id' => $owner->id,
+        ]);
+
+        $otherProject = Project::factory()->create([
+            'name' => 'Other Team Work',
+            'organization_id' => $organization->id,
+            'lead_id' => User::factory(),
+        ]);
+
+        $this->attachTeamToProject($team, $sharedProject);
+        $this->attachTeamToProject($otherTeam, $otherProject);
+        $this->attachUserToProject($sharedProject, $owner);
+
+        $this->actingAs($teammate)
+            ->get('/teams/'.$team->id.'/dashboard')
+            ->assertOk()
+            ->assertSee('Team dashboard')
+            ->assertSee('Release Command Center')
+            ->assertSee('Forge Ops')
+            ->assertSee($teammate->email)
+            ->assertDontSee('Other Team Work');
+    }
+
+    public function test_collaborator_role_is_registered_for_team_memberships(): void
+    {
+        $role = Jetstream::findRole('collaborator');
+
+        $this->assertNotNull($role);
+        $this->assertSame('Collaborator', $role->name);
+        $this->assertSame(['read', 'create', 'update'], $role->permissions);
+    }
+
+    public function test_organization_routes_generate_from_the_bound_model(): void
+    {
+        $organization = Organization::factory()->create([
+            'name' => 'Test Org',
+        ]);
+
+        $this->assertSame(
+            url('/organizations/'.$organization->slug),
+            route('organizations.show', ['organization' => $organization])
+        );
+
+        $this->assertSame(
+            url('/organizations/'.$organization->slug.'/edit'),
+            route('organizations.edit', ['organization' => $organization])
+        );
+    }
+
+    public function test_organization_form_treats_unsaved_models_as_create_mode(): void
+    {
+        Gate::shouldReceive('authorize')
+            ->once()
+            ->with('create', Organization::class)
+            ->andReturn(AccessResponse::allow());
+
+        $component = app(OrganizationForm::class);
+        $component->mount(new Organization);
+
+        $this->assertFalse($component->isEditing);
+        $this->assertNull($component->organization);
+        $this->assertSame('', $component->name);
+    }
+
+    /**
+     * @return array{0:User,1:User,2:Team}
+     */
+    private function teamContext(): array
+    {
+        $this->ensurePermissionsExist();
+
+        $owner = User::factory()->create();
+        $teammate = User::factory()->create();
+
+        $team = Team::factory()->create([
+            'user_id' => $owner->id,
+            'personal_team' => false,
+            'name' => 'Platform Team',
+        ]);
+
+        DB::table('team_user')->insert([
+            'id' => (string) Str::uuid(),
+            'team_id' => $team->id,
+            'user_id' => $teammate->id,
+            'role' => 'collaborator',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $owner->forceFill(['current_team_id' => $team->id])->save();
+        $teammate->forceFill(['current_team_id' => $team->id])->save();
+
+        return [$owner, $teammate, $team];
+    }
+
+    private function ensurePermissionsExist(): void
+    {
+        $this->seed(PermissionSeeder::class);
+    }
+
+    private function attachTeamToProject(Team $team, Project $project): void
+    {
+        DB::table('project_team')->insert([
+            'id' => (string) Str::uuid(),
+            'project_id' => $project->id,
+            'team_id' => $team->id,
+            'role' => 'Contributor',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function attachUserToProject(Project $project, User $user): void
+    {
+        DB::table('project_user')->insert([
+            'id' => (string) Str::uuid(),
+            'project_id' => $project->id,
+            'user_id' => $user->id,
+            'role' => 'Owner',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
…els, views, and queries for granular permissions

Added a new `ScopeDashboardTest` for validating shared project and organization visibility based on user roles. Updated `Organization` and `Project` models with `visibleTo` and `isAccessibleBy` methods for permission checks. Modified views and routing to ensure proper gate authorizations. Improved query logic in search and dashboard pages for enhanced filtering of accessible data. Added related tests for comprehensive coverage.

## Summary by Sourcery

Introduce shared dashboards for organizations and teams with visibility scoped to user-accessible projects, and extend project/organization relationships and permissions to support granular shared work reporting.

New Features:
- Add shared organization dashboard page powered by a reusable SharedDashboardService to surface scoped projects, issues, goals, teams, and activity.
- Add team dashboard page showing shared projects, upcoming work, goals, and members for a given team.
- Allow projects to be associated with organizations and multiple teams simultaneously, with UI for selecting organizations and teams when creating or editing projects.
- Expose new project and team relationships on organizations and teams, including organization- and team-owned goals and shared project listings.
- Register a new Jetstream team role "collaborator" for non-admin members to work with shared records.

Bug Fixes:
- Ensure organization, project, and team routes consistently use bound models instead of slugs or IDs where appropriate.
- Fix organization form behavior so unsaved models are treated as create-mode rather than edit-mode.

Enhancements:
- Tighten visibility rules for organizations and projects via isAccessibleBy and visibleTo scopes that respect admin and super-admin capabilities and attached shared work.
- Update organization index, project index, navigation, and project detail views to surface organization/team context, guard actions with policies, and link into the new dashboards.
- Broaden dashboard activity feeds to derive entries from all projects visible to the user instead of only the current team and improve activity enrichment.
- Improve project create/edit forms with scoped organization/team selectors, dynamic lead options based on selected teams, and validation to prevent out-of-scope selections.

Tests:
- Add ScopeDashboardTest to cover organization visibility based on shared projects, team dashboard access and contents, collaborator role registration, organization routing, and organization form modes.