### PR TITLE
Introduce SLA workflows and auto-issue creation for tickets

### DIFF
--- a/app/Livewire/Staff/Support/Products/Create.php
+++ b/app/Livewire/Staff/Support/Products/Create.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Staff\Support\Products;
 use App\Models\Organization;
 use App\Models\Project;
 use App\Models\ServiceProduct;
+use App\Models\TicketType;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Validation\Rule;
@@ -23,6 +24,21 @@ class Create extends Component
 
     #[Validate('nullable|string|max:2000')]
     public ?string $description = null;
+
+    #[Validate('nullable|integer|min:1|max:43200')]
+    public ?int $firstResponseTargetMinutes = null;
+
+    #[Validate('nullable|integer|min:1|max:43200')]
+    public ?int $nextResponseTargetMinutes = null;
+
+    #[Validate('nullable|integer|min:1|max:43200')]
+    public ?int $resolveTargetMinutes = null;
+
+    #[Validate('nullable|integer|exists:ticket_types,id')]
+    public ?int $autoCreateIssueForTicketTypeId = null;
+
+    #[Validate('nullable|uuid|exists:projects,id')]
+    public ?string $autoCreateIssueProjectId = null;
 
     /** Default routing target for new tickets */
     #[Validate('nullable|uuid|exists:projects,id')]
@@ -53,7 +69,7 @@ class Create extends Component
             $organizationId = (string) Project::query()->whereKey($this->defaultProjectId)->value('organization_id');
         }
 
-        if ($organizationId === null && !empty($this->projectIds)) {
+        if ($organizationId === null && ! empty($this->projectIds)) {
             $organizationId = (string) Project::query()->whereKey($this->projectIds[0])->value('organization_id');
         }
 
@@ -64,17 +80,22 @@ class Create extends Component
         // Validate unique key within the organization
         $this->validate([
             'key' => [
-                'required','string','max:32',
+                'required', 'string', 'max:32',
                 Rule::unique('service_products', 'key')->where('organization_id', $organizationId),
             ],
         ]);
 
         $product = ServiceProduct::query()->create([
-            'organization_id'   => $organizationId,
-            'key'               => $this->key,
-            'name'              => $this->name,
-            'description'       => $this->description,
+            'organization_id' => $organizationId,
+            'key' => $this->key,
+            'name' => $this->name,
+            'description' => $this->description,
             'default_project_id' => $this->defaultProjectId,
+            'first_response_target_minutes' => $this->firstResponseTargetMinutes,
+            'next_response_target_minutes' => $this->nextResponseTargetMinutes,
+            'resolve_target_minutes' => $this->resolveTargetMinutes,
+            'auto_create_issue_for_ticket_type_id' => $this->autoCreateIssueForTicketTypeId,
+            'auto_create_issue_project_id' => $this->autoCreateIssueProjectId,
         ]);
 
         // Ensure the default project is included in associations
@@ -91,7 +112,9 @@ class Create extends Component
 
     public function render(): View
     {
-        $projects = Project::query()->orderBy('name')->get(['id','name','key']);
-        return view('livewire.staff.support.products.create', compact('projects'));
+        $projects = Project::query()->orderBy('name')->get(['id', 'name', 'key']);
+        $ticketTypes = TicketType::query()->orderBy('name')->get(['id', 'name']);
+
+        return view('livewire.staff.support.products.create', compact('projects', 'ticketTypes'));
     }
 }

--- a/app/Livewire/Staff/Support/Products/Edit.php
+++ b/app/Livewire/Staff/Support/Products/Edit.php
@@ -7,13 +7,13 @@ use App\Models\IssueStatus;
 use App\Models\IssueType;
 use App\Models\Project;
 use App\Models\ServiceProduct;
+use App\Models\ServiceProductIngestKey;
 use App\Models\ServiceProductPriorityMap;
 use App\Models\ServiceProductStatusMap;
 use App\Models\ServiceProductTypeMap;
 use App\Models\TicketPriority;
 use App\Models\TicketStatus;
 use App\Models\TicketType;
-use App\Models\ServiceProductIngestKey;
 use App\Services\Support\IngestKeyManager;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
@@ -39,6 +39,21 @@ final class Edit extends Component
 
     #[Validate('nullable|string|max:2000')]
     public ?string $description = null;
+
+    #[Validate('nullable|integer|min:1|max:43200')]
+    public ?int $firstResponseTargetMinutes = null;
+
+    #[Validate('nullable|integer|min:1|max:43200')]
+    public ?int $nextResponseTargetMinutes = null;
+
+    #[Validate('nullable|integer|min:1|max:43200')]
+    public ?int $resolveTargetMinutes = null;
+
+    #[Validate('nullable|integer|exists:ticket_types,id')]
+    public ?int $autoCreateIssueForTicketTypeId = null;
+
+    #[Validate('nullable|uuid|exists:projects,id')]
+    public ?string $autoCreateIssueProjectId = null;
 
     public ?string $defaultProjectId = null;
 
@@ -70,6 +85,11 @@ final class Edit extends Component
         $this->key = $this->product->key;
         $this->name = $this->product->name;
         $this->description = $this->product->description;
+        $this->firstResponseTargetMinutes = $this->product->first_response_target_minutes;
+        $this->nextResponseTargetMinutes = $this->product->next_response_target_minutes;
+        $this->resolveTargetMinutes = $this->product->resolve_target_minutes;
+        $this->autoCreateIssueForTicketTypeId = $this->product->auto_create_issue_for_ticket_type_id;
+        $this->autoCreateIssueProjectId = $this->product->auto_create_issue_project_id;
         $this->defaultProjectId = $this->product->default_project_id;
         $this->projectIds = $this->product->projects()->pluck('projects.id')->map(fn ($id) => (string) $id)->all();
 
@@ -96,6 +116,11 @@ final class Edit extends Component
             'name' => $this->name,
             'description' => $this->description,
             'default_project_id' => $this->defaultProjectId,
+            'first_response_target_minutes' => $this->firstResponseTargetMinutes,
+            'next_response_target_minutes' => $this->nextResponseTargetMinutes,
+            'resolve_target_minutes' => $this->resolveTargetMinutes,
+            'auto_create_issue_for_ticket_type_id' => $this->autoCreateIssueForTicketTypeId,
+            'auto_create_issue_project_id' => $this->autoCreateIssueProjectId,
         ]);
 
         $this->product->projects()->sync($this->projectIds);
@@ -175,13 +200,13 @@ final class Edit extends Component
     public function render(): View
     {
         return view('livewire.staff.support.products.edit', [
-            'allProjects'      => Project::query()->orderBy('name')->get(['id', 'name', 'key']),
-            'ticketTypes'      => TicketType::query()->orderBy('name')->get(['id', 'name']),
-            'ticketStatuses'   => TicketStatus::query()->orderBy('name')->get(['id', 'name']),
+            'allProjects' => Project::query()->orderBy('name')->get(['id', 'name', 'key']),
+            'ticketTypes' => TicketType::query()->orderBy('name')->get(['id', 'name']),
+            'ticketStatuses' => TicketStatus::query()->orderBy('name')->get(['id', 'name']),
             'ticketPriorities' => TicketPriority::query()->orderBy('weight')->get(['id', 'name']),
-            'issueTypes'       => IssueType::query()->orderBy('name')->get(['id', 'name']),
-            'issueStatuses'    => IssueStatus::query()->orderBy('order')->get(['id', 'name']),
-            'issuePriorities'  => IssuePriority::query()->orderBy('weight')->get(['id', 'name']),
+            'issueTypes' => IssueType::query()->orderBy('name')->get(['id', 'name']),
+            'issueStatuses' => IssueStatus::query()->orderBy('order')->get(['id', 'name']),
+            'issuePriorities' => IssuePriority::query()->orderBy('weight')->get(['id', 'name']),
         ]);
     }
 }

--- a/app/Livewire/Staff/Support/ShowTicket.php
+++ b/app/Livewire/Staff/Support/ShowTicket.php
@@ -9,6 +9,7 @@ use App\Models\TicketStatus;
 use App\Models\TicketType;
 use App\Models\User;
 use App\Services\Support\ConvertTicketToIssue;
+use App\Services\Support\TicketWorkflowService;
 use Illuminate\Contracts\View\View;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Attributes\Validate;
@@ -27,8 +28,11 @@ final class ShowTicket extends Component
     public string $publicReply = '';
 
     public ?int $statusId = null;
+
     public ?int $priorityId = null;
+
     public ?int $typeId = null;
+
     public ?string $assigneeId = null;
 
     /** Project to use when converting to an Issue (and to store on the ticket) */
@@ -37,33 +41,43 @@ final class ShowTicket extends Component
     public function mount(string $key): void
     {
         $this->ticket = Ticket::query()
-            ->with(['status:id,name', 'priority:id,name', 'type:id,name', 'assignee:id,name', 'product.defaultProject:id,name'])
+            ->with([
+                'status:id,name,is_done',
+                'priority:id,name',
+                'type:id,name',
+                'assignee:id,name',
+                'product.defaultProject:id,name',
+                'product.autoCreateIssueProject:id,name,key',
+            ])
             ->where('key', $key)
             ->firstOrFail();
 
         $this->authorize('view', $this->ticket);
 
-        $this->statusId   = $this->ticket->status_id;
+        $this->statusId = $this->ticket->status_id;
         $this->priorityId = $this->ticket->priority_id;
-        $this->typeId     = $this->ticket->type_id;
+        $this->typeId = $this->ticket->type_id;
         $this->assigneeId = $this->ticket->assigned_to_user_id;
 
         // Prefer the ticket's project; else fall back to the ServiceProduct's default project (if any)
-        $this->projectId  = $this->ticket->project_id ?? $this->ticket->product?->default_project_id;
+        $this->projectId = $this->ticket->project_id ?? $this->ticket->product?->default_project_id;
     }
 
-    public function saveMeta(): void
+    public function saveMeta(TicketWorkflowService $workflow): void
     {
         $this->authorize('manage', $this->ticket);
 
         $this->ticket->update([
-            'status_id'             => $this->statusId,
-            'priority_id'           => $this->priorityId,
-            'type_id'               => $this->typeId,
-            'assigned_to_user_id'   => $this->assigneeId,
-            'project_id'            => $this->projectId,
+            'status_id' => $this->statusId,
+            'priority_id' => $this->priorityId,
+            'type_id' => $this->typeId,
+            'assigned_to_user_id' => $this->assigneeId,
+            'project_id' => $this->projectId,
         ]);
 
+        $this->ticket->refresh()->load(['status:id,name,is_done', 'product.defaultProject:id,name', 'project']);
+        $workflow->syncResolutionState($this->ticket);
+        $workflow->maybeAutoCreateIssue($this->ticket);
         $this->ticket->refresh();
         $this->dispatch('saved');
     }
@@ -74,31 +88,34 @@ final class ShowTicket extends Component
         $this->validateOnly('internalNote');
 
         $this->ticket->comments()->create([
-            'user_id'       => auth()->id(),
-            'body'          => $this->internalNote,
+            'user_id' => auth()->id(),
+            'body' => $this->internalNote,
             'redacted_body' => $this->internalNote,
-            'is_internal'   => true,
+            'is_internal' => true,
         ]);
 
         $this->reset('internalNote');
         $this->dispatch('note-added');
     }
 
-    public function addPublicReply(): void
+    public function addPublicReply(TicketWorkflowService $workflow): void
     {
         $this->authorize('manage', $this->ticket);
         $this->validateOnly('publicReply');
 
         $this->ticket->comments()->create([
-            'user_id'       => auth()->id(),
-            'body'          => $this->publicReply,
+            'user_id' => auth()->id(),
+            'body' => $this->publicReply,
             'redacted_body' => $this->publicReply,
-            'is_internal'   => false,
+            'is_internal' => false,
         ]);
+
+        $workflow->recordStaffReply($this->ticket);
 
         // TODO: notify customer
 
         $this->reset('publicReply');
+        $this->ticket->refresh();
         $this->dispatch('reply-added');
     }
 
@@ -116,6 +133,7 @@ final class ShowTicket extends Component
         if ($project === null) {
             // Guard-rail: require a project before converting
             $this->addError('projectId', 'Please select a project before converting to an Issue.');
+
             return;
         }
 
@@ -130,27 +148,27 @@ final class ShowTicket extends Component
             ->where('is_internal', true)
             ->with('user:id,name,email,profile_photo_path')
             ->latest()
-            ->get(['id','body','created_at','user_id']); // reference $ticket for submitter data
+            ->get(['id', 'body', 'created_at', 'user_id']); // reference $ticket for submitter data
 
         $public = $this->ticket->comments()
             ->where('is_internal', false)
             ->with('user:id,name,email,profile_photo_path')
             ->latest()
-            ->get(['id','body','created_at','user_id']);
+            ->get(['id', 'body', 'created_at', 'user_id']);
 
         $relatedIssues = $this->ticket->issues()
-            ->select(['id','key','summary','project_id'])
+            ->select(['id', 'key', 'summary', 'project_id'])
             ->with('project:id,name,key')
             ->get();
 
         return view('livewire.staff.support.show-ticket', [
-            'statuses'   => TicketStatus::query()->orderBy('name')->get(['id','name']),
-            'priorities' => TicketPriority::query()->orderBy('weight')->get(['id','name']),
-            'types'      => TicketType::query()->orderBy('name')->get(['id','name']),
-            'assignees'  => User::query()->orderBy('name')->get(['id','name']),
-            'projects'   => Project::query()->orderBy('name')->get(['id','name','key']),
+            'statuses' => TicketStatus::query()->orderBy('name')->get(['id', 'name', 'is_done']),
+            'priorities' => TicketPriority::query()->orderBy('weight')->get(['id', 'name']),
+            'types' => TicketType::query()->orderBy('name')->get(['id', 'name']),
+            'assignees' => User::query()->orderBy('name')->get(['id', 'name']),
+            'projects' => Project::query()->orderBy('name')->get(['id', 'name', 'key']),
             'internal' => $internal,
-            'public'   => $public,
+            'public' => $public,
             'relatedIssues' => $relatedIssues,
         ]);
     }

--- a/app/Livewire/Staff/Support/Triage.php
+++ b/app/Livewire/Staff/Support/Triage.php
@@ -45,14 +45,17 @@ final class Triage extends Component
     {
         $this->resetPage();
     }
+
     public function updatingStatusId(): void
     {
         $this->resetPage();
     }
+
     public function updatingPriorityId(): void
     {
         $this->resetPage();
     }
+
     public function updatingTypeId(): void
     {
         $this->resetPage();
@@ -61,12 +64,12 @@ final class Triage extends Component
     public function getRowsProperty(): LengthAwarePaginator
     {
         return Ticket::query()
-            ->with(['status:id,name', 'priority:id,name', 'type:id,name', 'assignee:id,name', 'product:id,name'])
+            ->with(['status:id,name,is_done', 'priority:id,name', 'type:id,name', 'assignee:id,name', 'product:id,name'])
             ->when($this->search !== '', function ($q): void {
                 $q->where(function ($w): void {
-                    $w->where('key', 'like', '%' . $this->search . '%')
-                        ->orWhere('subject', 'like', '%' . $this->search . '%')
-                        ->orWhere('submitter_email', 'like', '%' . $this->search . '%');
+                    $w->where('key', 'like', '%'.$this->search.'%')
+                        ->orWhere('subject', 'like', '%'.$this->search.'%')
+                        ->orWhere('submitter_email', 'like', '%'.$this->search.'%');
                 });
             })
             ->when($this->statusId, fn ($q) => $q->where('status_id', $this->statusId))
@@ -79,10 +82,10 @@ final class Triage extends Component
     public function render(): View
     {
         return view('livewire.staff.support.triage', [
-            'statuses'  => TicketStatus::query()->orderBy('name')->get(['id','name']),
-            'priorities' => TicketPriority::query()->orderBy('weight')->get(['id','name']),
-            'types'     => TicketType::query()->orderBy('name')->get(['id','name']),
-            'rows'      => $this->rows,
+            'statuses' => TicketStatus::query()->orderBy('name')->get(['id', 'name']),
+            'priorities' => TicketPriority::query()->orderBy('weight')->get(['id', 'name']),
+            'types' => TicketType::query()->orderBy('name')->get(['id', 'name']),
+            'rows' => $this->rows,
         ]);
     }
 }

--- a/app/Livewire/Support/MyTickets.php
+++ b/app/Livewire/Support/MyTickets.php
@@ -4,18 +4,48 @@ namespace App\Livewire\Support;
 
 use App\Models\SupportIdentity;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
 use Livewire\Component;
 
 final class MyTickets extends Component
 {
-    public function render(SupportIdentity $identity): View
+    public ?string $identityId = null;
+
+    public function mount(?string $identityId = null): void
     {
-        $tickets = $identity->tickets()
+        $this->identityId = $identityId;
+    }
+
+    public function render(): View
+    {
+        $identity = $this->resolveIdentity();
+
+        $tickets = $identity?->tickets()
             ->latest()
-            ->select(['id','key','subject','status_id','created_at'])
+            ->select(['id', 'key', 'subject', 'status_id', 'created_at'])
             ->with('status:id,name')
-            ->get();
+            ->get()
+            ?? new Collection;
 
         return view('livewire.support.my-tickets', compact('tickets'));
+    }
+
+    private function resolveIdentity(): ?SupportIdentity
+    {
+        if (filled($this->identityId)) {
+            return SupportIdentity::query()
+                ->whereKey($this->identityId)
+                ->whereNull('revoked_at')
+                ->first();
+        }
+
+        if (app()->bound(SupportIdentity::class)) {
+            /** @var SupportIdentity $identity */
+            $identity = app(SupportIdentity::class);
+
+            return $identity;
+        }
+
+        return null;
     }
 }

--- a/app/Livewire/Support/MyTickets.php
+++ b/app/Livewire/Support/MyTickets.php
@@ -25,7 +25,7 @@ final class MyTickets extends Component
             ->select(['id', 'key', 'subject', 'status_id', 'created_at'])
             ->with('status:id,name')
             ->get()
-            ?? new Collection;
+            ?? new Collection();
 
         return view('livewire.support.my-tickets', compact('tickets'));
     }

--- a/app/Livewire/Support/NewTicket.php
+++ b/app/Livewire/Support/NewTicket.php
@@ -9,17 +9,25 @@ use App\Models\TicketPriority;
 use App\Models\TicketStatus;
 use App\Models\TicketType;
 use App\Services\Support\TextRedactor;
+use App\Services\Support\TicketWorkflowService;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
 
 final class NewTicket extends Component
 {
-    /** @var array<int, array{id:string,name:string,project?:string}> */
+    /** @var array<int, array{id:string,name:string,description?:string,project?:string}> */
     public array $products = [];
+
+    /** @var array<int, array{id:int,name:string,slug:string}> */
+    public array $types = [];
 
     #[Validate('required|string|exists:service_products,id')]
     public string $productId = '';
+
+    #[Validate('required|integer|exists:ticket_types,id')]
+    public ?int $typeId = null;
 
     #[Validate('required|string|min:5|max:160')]
     public string $subject = '';
@@ -38,16 +46,30 @@ final class NewTicket extends Component
         $this->products = ServiceProduct::query()
             ->with('defaultProject:id,name')
             ->orderBy('name')
-            ->get(['id','name','default_project_id'])
+            ->get(['id', 'name', 'description', 'default_project_id'])
             ->map(fn (ServiceProduct $p) => [
-                'id'      => $p->getKey(),
-                'name'    => $p->name,
+                'id' => $p->getKey(),
+                'name' => $p->name,
+                'description' => $p->description,
                 'project' => $p->defaultProject?->name,
             ])
             ->all();
+
+        $this->types = TicketType::query()
+            ->orderBy('name')
+            ->get(['id', 'name'])
+            ->map(fn (TicketType $type) => [
+                'id' => (int) $type->getKey(),
+                'name' => $type->name,
+                'slug' => Str::slug($type->name),
+            ])
+            ->all();
+
+        $this->typeId = TicketType::query()->where('name', 'Bug')->value('id')
+            ?? TicketType::query()->orderBy('name')->value('id');
     }
 
-    public function submit(TextRedactor $redactor): void
+    public function submit(TextRedactor $redactor, TicketWorkflowService $workflow): void
     {
         $this->validate();
 
@@ -59,31 +81,31 @@ final class NewTicket extends Component
             ['email_encrypted' => $normalized, 'token' => (string) str()->ulid()]
         );
 
-        $statusId   = (int) TicketStatus::query()->where('name', 'New')->value('id');
+        $statusId = (int) TicketStatus::query()->where('name', 'New')->value('id');
         $priorityId = (int) TicketPriority::query()->where('name', 'Medium')->value('id');
-        $typeId     = (int) TicketType::query()->where('name', 'Bug')->value('id');
-
         /** @var ServiceProduct $product */
         $product = ServiceProduct::query()
-            ->select(['id','organization_id','default_project_id'])
+            ->select(['id', 'organization_id', 'default_project_id'])
             ->findOrFail($this->productId);
 
-        Ticket::query()->create([
-            'organization_id'    => $product->organization_id,
+        $ticket = Ticket::query()->create([
+            'organization_id' => $product->organization_id,
             'service_product_id' => $product->getKey(),
-            'project_id'         => $product->default_project_id,
-            'submitter_name'     => $this->name,
-            'submitter_email'    => $normalized,
-            'email_hash'         => $hash,
-            'subject'            => $this->subject,
-            'body'               => $this->body,
-            'redacted_body'      => $redactor->redact($this->body),
-            'status_id'          => $statusId,
-            'priority_id'        => $priorityId,
-            'type_id'            => $typeId,
-            'access_token'       => (string) str()->ulid(),
-            'via'                => 'public',
+            'project_id' => $product->default_project_id,
+            'submitter_name' => $this->name,
+            'submitter_email' => $normalized,
+            'email_hash' => $hash,
+            'subject' => $this->subject,
+            'body' => $this->body,
+            'redacted_body' => $redactor->redact($this->body),
+            'status_id' => $statusId,
+            'priority_id' => $priorityId,
+            'type_id' => $this->typeId,
+            'access_token' => (string) str()->ulid(),
+            'via' => 'public',
         ]);
+
+        $workflow->initialize($ticket);
 
         // Use Livewire redirect (no SPA navigate) to avoid client-side ResizeObserver churn
         $this->redirect(
@@ -94,6 +116,34 @@ final class NewTicket extends Component
 
     public function render(): View
     {
-        return view('livewire.support.new-ticket');
+        $selectedProduct = collect($this->products)->firstWhere('id', $this->productId);
+        $selectedType = collect($this->types)->firstWhere('id', $this->typeId);
+
+        return view('livewire.support.new-ticket', [
+            'selectedProduct' => $selectedProduct,
+            'typeTemplate' => $this->typeTemplateFor($selectedType['slug'] ?? null),
+        ]);
+    }
+
+    /** @return array{intro:string,subject:string,body:string} */
+    private function typeTemplateFor(?string $typeSlug): array
+    {
+        return match ($typeSlug) {
+            'feature-request' => [
+                'intro' => 'Tell us what outcome you want and how it fits into your workflow.',
+                'subject' => 'Example: Bulk edit tags across multiple tickets',
+                'body' => 'What are you trying to do today? What is missing, and what would a good solution look like?',
+            ],
+            'question' => [
+                'intro' => 'Share the question plus any context that would help us answer it without a back-and-forth.',
+                'subject' => 'Example: How do I map support tickets to a project?',
+                'body' => 'What did you expect to find, what have you tried, and where are you blocked?',
+            ],
+            default => [
+                'intro' => 'Describe the bug, what you expected, and how to reproduce it.',
+                'subject' => 'Example: Portal submission fails after selecting a product',
+                'body' => 'What happened, what should have happened instead, and what steps can we use to reproduce it?',
+            ],
+        };
     }
 }

--- a/app/Livewire/Support/NewTicket.php
+++ b/app/Livewire/Support/NewTicket.php
@@ -55,9 +55,11 @@ final class NewTicket extends Component
             ])
             ->all();
 
-        $this->types = TicketType::query()
+        $types = TicketType::query()
             ->orderBy('name')
-            ->get(['id', 'name'])
+            ->get(['id', 'name']);
+
+        $this->types = $types
             ->map(fn (TicketType $type) => [
                 'id' => (int) $type->getKey(),
                 'name' => $type->name,
@@ -65,8 +67,8 @@ final class NewTicket extends Component
             ])
             ->all();
 
-        $this->typeId = TicketType::query()->where('name', 'Bug')->value('id')
-            ?? TicketType::query()->orderBy('name')->value('id');
+        $defaultType = $types->firstWhere('name', 'Bug') ?? $types->first();
+        $this->typeId = $defaultType ? (int) $defaultType->getKey() : null;
     }
 
     public function submit(TextRedactor $redactor, TicketWorkflowService $workflow): void

--- a/app/Livewire/Support/ShowTicket.php
+++ b/app/Livewire/Support/ShowTicket.php
@@ -4,8 +4,8 @@ namespace App\Livewire\Support;
 
 use App\Models\SupportIdentity;
 use App\Models\Ticket;
-use App\Models\TicketComment;
 use App\Services\Support\TextRedactor;
+use App\Services\Support\TicketWorkflowService;
 use Illuminate\Contracts\View\View;
 use Livewire\Attributes\Validate;
 use Livewire\Component;
@@ -22,23 +22,26 @@ final class ShowTicket extends Component
         $this->ticket = Ticket::query()
             ->where('key', $key)
             ->where('email_hash', $identity->email_hash)
-            ->with(['status:id,name','product:id,name'])
+            ->with(['status:id,name,is_done', 'product:id,name'])
             ->firstOrFail();
     }
 
-    public function postReply(TextRedactor $redactor): void
+    public function postReply(TextRedactor $redactor, TicketWorkflowService $workflow): void
     {
         $this->validate();
 
         $this->ticket->comments()->create([
-            'body'          => $this->reply,
+            'body' => $this->reply,
             'redacted_body' => $redactor->redact($this->reply),
-            'is_internal'   => false,
+            'is_internal' => false,
         ]);
+
+        $workflow->recordCustomerReply($this->ticket);
 
         // TODO: notify staff
 
         $this->reset('reply');
+        $this->ticket->refresh();
     }
 
     public function render(): View
@@ -47,9 +50,8 @@ final class ShowTicket extends Component
             ->where('is_internal', false)
             ->with('user:id,name,email,profile_photo_path')
             ->latest()
-            ->get(['id','redacted_body','created_at','user_id']);
+            ->get(['id', 'redacted_body', 'created_at', 'user_id']);
 
         return view('livewire.support.show-ticket', compact('comments'));
     }
-
 }

--- a/app/Livewire/Support/ShowTicket.php
+++ b/app/Livewire/Support/ShowTicket.php
@@ -22,7 +22,7 @@ final class ShowTicket extends Component
         $this->ticket = Ticket::query()
             ->where('key', $key)
             ->where('email_hash', $identity->email_hash)
-            ->with(['status:id,name,is_done', 'product:id,name'])
+            ->with(['status:id,name,is_done', 'product:id,name,next_response_target_minutes'])
             ->firstOrFail();
     }
 

--- a/app/Models/ServiceProduct.php
+++ b/app/Models/ServiceProduct.php
@@ -16,6 +16,12 @@ class ServiceProduct extends BaseModel
 
     protected $guarded = [];
 
+    protected $casts = [
+        'first_response_target_minutes' => 'integer',
+        'next_response_target_minutes' => 'integer',
+        'resolve_target_minutes' => 'integer',
+    ];
+
     public static function boot(): void
     {
         parent::boot();
@@ -35,6 +41,12 @@ class ServiceProduct extends BaseModel
     public function defaultProject(): BelongsTo
     {
         return $this->belongsTo(Project::class, 'default_project_id');
+    }
+
+    /** @return BelongsTo<Project,ServiceProduct> */
+    public function autoCreateIssueProject(): BelongsTo
+    {
+        return $this->belongsTo(Project::class, 'auto_create_issue_project_id');
     }
 
     /** @return BelongsToMany<Project> */
@@ -74,9 +86,6 @@ class ServiceProduct extends BaseModel
 
     /**
      * Resolve mapped Issue Type ID for a given Ticket Type, honoring project allowed sets.
-     * @param int $ticketTypeId
-     * @param Project|null $project
-     * @return int|null
      */
     public function resolveIssueTypeId(int $ticketTypeId, ?Project $project = null): ?int
     {
@@ -94,9 +103,6 @@ class ServiceProduct extends BaseModel
 
     /**
      * Resolve mapped Issue Priority ID for a given Ticket Priority, honoring project allowed sets.
-     * @param int $ticketPriorityId
-     * @param Project|null $project
-     * @return int|null
      */
     public function resolveIssuePriorityId(int $ticketPriorityId, ?Project $project = null): ?int
     {
@@ -115,9 +121,6 @@ class ServiceProduct extends BaseModel
     /**
      * Resolve mapped Issue Status ID for a given Ticket Status, honoring project allowed sets.
      * Falls back to project initial status if not mapped.
-     * @param int $ticketStatusId
-     * @param Project|null $project
-     * @return int|null
      */
     public function resolveIssueStatusId(int $ticketStatusId, ?Project $project = null): ?int
     {

--- a/app/Models/ServiceProduct.php
+++ b/app/Models/ServiceProduct.php
@@ -16,11 +16,14 @@ class ServiceProduct extends BaseModel
 
     protected $guarded = [];
 
-    protected $casts = [
-        'first_response_target_minutes' => 'integer',
-        'next_response_target_minutes' => 'integer',
-        'resolve_target_minutes' => 'integer',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'first_response_target_minutes' => 'integer',
+            'next_response_target_minutes' => 'integer',
+            'resolve_target_minutes' => 'integer',
+        ];
+    }
 
     public static function boot(): void
     {

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -32,15 +32,18 @@ class Ticket extends BaseModel
 
     protected $guarded = [];
 
-    protected $casts = [
-        'first_response_due_at' => 'immutable_datetime',
-        'first_responded_at' => 'immutable_datetime',
-        'next_response_due_at' => 'immutable_datetime',
-        'last_customer_reply_at' => 'immutable_datetime',
-        'last_staff_reply_at' => 'immutable_datetime',
-        'resolve_due_at' => 'immutable_datetime',
-        'resolved_at' => 'immutable_datetime',
-    ];
+    protected function casts(): array
+    {
+        return [
+            'first_response_due_at' => 'immutable_datetime',
+            'first_responded_at' => 'immutable_datetime',
+            'next_response_due_at' => 'immutable_datetime',
+            'last_customer_reply_at' => 'immutable_datetime',
+            'last_staff_reply_at' => 'immutable_datetime',
+            'resolve_due_at' => 'immutable_datetime',
+            'resolved_at' => 'immutable_datetime',
+        ] + parent::casts();
+    }
 
     public static function boot(): void
     {

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -6,12 +6,14 @@ use App\Services\Support\TicketKeyService;
 use App\Support\ActivityContext;
 use App\Traits\HasRecordShares;
 use App\Traits\IsPermissible;
+use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
+use Spatie\Activitylog\Contracts\Activity;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
@@ -22,13 +24,23 @@ use Spatie\Activitylog\Traits\LogsActivity;
  */
 class Ticket extends BaseModel
 {
-    use SoftDeletes;
-    use HasUlids;
-    use LogsActivity;
-    use IsPermissible;
     use HasRecordShares;
+    use HasUlids;
+    use IsPermissible;
+    use LogsActivity;
+    use SoftDeletes;
 
     protected $guarded = [];
+
+    protected $casts = [
+        'first_response_due_at' => 'immutable_datetime',
+        'first_responded_at' => 'immutable_datetime',
+        'next_response_due_at' => 'immutable_datetime',
+        'last_customer_reply_at' => 'immutable_datetime',
+        'last_staff_reply_at' => 'immutable_datetime',
+        'resolve_due_at' => 'immutable_datetime',
+        'resolved_at' => 'immutable_datetime',
+    ];
 
     public static function boot(): void
     {
@@ -112,21 +124,73 @@ class Ticket extends BaseModel
     {
         return LogOptions::defaults()
             ->useLogName('forge.support.ticket')
-            ->logOnly(['subject','key','body','submitter_email'])
+            ->logOnly(['subject', 'key', 'body', 'submitter_email'])
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs();
     }
 
-    public function tapActivity(\Spatie\Activitylog\Contracts\Activity $activity): void
+    public function tapActivity(Activity $activity): void
     {
         $ctx = ActivityContext::base();
         $activity->team_id = $ctx['team_id'];                 // persisted column
         $activity->properties = $activity->properties->merge([ // JSON props
             'actor_id' => $ctx['user_id'],
-            'ip'       => $ctx['ip'],
-            'ua'       => $ctx['user_agent'],
+            'ip' => $ctx['ip'],
+            'ua' => $ctx['user_agent'],
         ]);
         $activity->event = $activity->event ?: 'updated'; // create/update/delete auto-populate
-        $activity->description = 'ticket.' . $activity->event;
+        $activity->description = 'ticket.'.$activity->event;
+    }
+
+    /** @return array<int, array{key:string,label:string,due_at:CarbonInterface|null,completed_at:CarbonInterface|null,open:bool,breached:bool}> */
+    public function slaWindows(): array
+    {
+        $resolved = $this->isResolved();
+
+        return [
+            [
+                'key' => 'first_response',
+                'label' => 'First response',
+                'due_at' => $this->first_response_due_at,
+                'completed_at' => $this->first_responded_at,
+                'open' => $this->first_response_due_at !== null && $this->first_responded_at === null,
+                'breached' => $this->first_response_due_at !== null
+                    && $this->first_responded_at === null
+                    && $this->first_response_due_at->isPast(),
+            ],
+            [
+                'key' => 'next_response',
+                'label' => 'Next response',
+                'due_at' => $this->next_response_due_at,
+                'completed_at' => $this->last_staff_reply_at,
+                'open' => $this->next_response_due_at !== null && ! $resolved,
+                'breached' => $this->next_response_due_at !== null
+                    && ! $resolved
+                    && $this->next_response_due_at->isPast(),
+            ],
+            [
+                'key' => 'resolve',
+                'label' => 'Resolve',
+                'due_at' => $this->resolve_due_at,
+                'completed_at' => $this->resolved_at,
+                'open' => $this->resolve_due_at !== null && ! $resolved,
+                'breached' => $this->resolve_due_at !== null
+                    && ! $resolved
+                    && $this->resolve_due_at->isPast(),
+            ],
+        ];
+    }
+
+    public function isResolved(): bool
+    {
+        if ($this->resolved_at !== null) {
+            return true;
+        }
+
+        if ($this->relationLoaded('status') && $this->status !== null) {
+            return (bool) $this->status->is_done;
+        }
+
+        return (bool) $this->status()->value('is_done');
     }
 }

--- a/app/Services/Support/ConvertTicketToIssue.php
+++ b/app/Services/Support/ConvertTicketToIssue.php
@@ -5,16 +5,15 @@ namespace App\Services\Support;
 use App\Models\Issue;
 use App\Models\Project;
 use App\Models\Ticket;
+use App\Models\TicketStatus;
 use Illuminate\Database\DatabaseManager;
 use RuntimeException;
 
 final class ConvertTicketToIssue
 {
-    public function __construct(private DatabaseManager $db)
-    {
-    }
+    public function __construct(private DatabaseManager $db) {}
 
-    public function convert(Ticket $ticket, ?Project $project = null): Issue
+    public function convert(Ticket $ticket, ?Project $project = null, bool $moveTicketToWaitingOnSupport = true): Issue
     {
         $project = $project ?? $ticket->project ?? $ticket->product?->defaultProject;
         if ($project === null) {
@@ -28,21 +27,26 @@ final class ConvertTicketToIssue
         $priorityId = $product?->resolveIssuePriorityId((int) $ticket->priority_id, $project) ?? $project->defaultPriorityId();
         $statusId = $product?->resolveIssueStatusId((int) $ticket->status_id, $project) ?? $project->initialStatusId();
 
-        return $this->db->transaction(function () use ($ticket, $project, $typeId, $priorityId, $statusId): Issue {
+        return $this->db->transaction(function () use ($ticket, $project, $typeId, $priorityId, $statusId, $moveTicketToWaitingOnSupport): Issue {
             $issue = Issue::query()->create([
-                'project_id'  => $project->getKey(),
-                'summary'     => $ticket->subject,
+                'project_id' => $project->getKey(),
+                'summary' => $ticket->subject,
                 'description' => $ticket->body,
                 'reporter_id' => auth()->id(),
-                'issue_status_id'   => $statusId,
+                'issue_status_id' => $statusId,
                 'issue_priority_id' => $priorityId,
-                'issue_type_id'     => $typeId,
+                'issue_type_id' => $typeId,
             ]);
 
             $ticket->issues()->syncWithoutDetaching([$issue->getKey()]);
 
-            // Optional: move ticket status using your chosen rule
-            $ticket->update(['status_id' => (int) \App\Models\TicketStatus::query()->where('name', 'Waiting on Support')->value('id')]);
+            if ($moveTicketToWaitingOnSupport) {
+                $ticket->update([
+                    'status_id' => (int) TicketStatus::query()
+                        ->where('name', 'Waiting on Support')
+                        ->value('id'),
+                ]);
+            }
 
             return $issue;
         });

--- a/app/Services/Support/ConvertTicketToIssue.php
+++ b/app/Services/Support/ConvertTicketToIssue.php
@@ -11,11 +11,32 @@ use RuntimeException;
 
 final class ConvertTicketToIssue
 {
-    public function __construct(private DatabaseManager $db)
-    {
-    }
+    public function __construct(private DatabaseManager $db) {}
 
     public function convert(Ticket $ticket, ?Project $project = null, bool $moveTicketToWaitingOnSupport = true): Issue
+    {
+        return $this->db->transaction(
+            fn (): Issue => $this->persistConversion($ticket, $project, $moveTicketToWaitingOnSupport)
+        );
+    }
+
+    public function convertIfUnlinked(Ticket $ticket, ?Project $project = null, bool $moveTicketToWaitingOnSupport = true): ?Issue
+    {
+        return $this->db->transaction(function () use ($ticket, $project, $moveTicketToWaitingOnSupport): ?Issue {
+            $lockedTicket = Ticket::query()
+                ->with(['product.defaultProject', 'project'])
+                ->lockForUpdate()
+                ->findOrFail($ticket->getKey());
+
+            if ($lockedTicket->issues()->exists()) {
+                return null;
+            }
+
+            return $this->persistConversion($lockedTicket, $project, $moveTicketToWaitingOnSupport);
+        });
+    }
+
+    private function persistConversion(Ticket $ticket, ?Project $project, bool $moveTicketToWaitingOnSupport): Issue
     {
         $project = $project ?? $ticket->project ?? $ticket->product?->defaultProject;
         if ($project === null) {
@@ -29,28 +50,26 @@ final class ConvertTicketToIssue
         $priorityId = $product?->resolveIssuePriorityId((int) $ticket->priority_id, $project) ?? $project->defaultPriorityId();
         $statusId = $product?->resolveIssueStatusId((int) $ticket->status_id, $project) ?? $project->initialStatusId();
 
-        return $this->db->transaction(function () use ($ticket, $project, $typeId, $priorityId, $statusId, $moveTicketToWaitingOnSupport): Issue {
-            $issue = Issue::query()->create([
-                'project_id' => $project->getKey(),
-                'summary' => $ticket->subject,
-                'description' => $ticket->body,
-                'reporter_id' => auth()->id(),
-                'issue_status_id' => $statusId,
-                'issue_priority_id' => $priorityId,
-                'issue_type_id' => $typeId,
+        $issue = Issue::query()->create([
+            'project_id' => $project->getKey(),
+            'summary' => $ticket->subject,
+            'description' => $ticket->body,
+            'reporter_id' => auth()->id(),
+            'issue_status_id' => $statusId,
+            'issue_priority_id' => $priorityId,
+            'issue_type_id' => $typeId,
+        ]);
+
+        $ticket->issues()->syncWithoutDetaching([$issue->getKey()]);
+
+        if ($moveTicketToWaitingOnSupport) {
+            $ticket->update([
+                'status_id' => (int) TicketStatus::query()
+                    ->where('name', 'Waiting on Support')
+                    ->value('id'),
             ]);
+        }
 
-            $ticket->issues()->syncWithoutDetaching([$issue->getKey()]);
-
-            if ($moveTicketToWaitingOnSupport) {
-                $ticket->update([
-                    'status_id' => (int) TicketStatus::query()
-                        ->where('name', 'Waiting on Support')
-                        ->value('id'),
-                ]);
-            }
-
-            return $issue;
-        });
+        return $issue;
     }
 }

--- a/app/Services/Support/ConvertTicketToIssue.php
+++ b/app/Services/Support/ConvertTicketToIssue.php
@@ -11,7 +11,9 @@ use RuntimeException;
 
 final class ConvertTicketToIssue
 {
-    public function __construct(private DatabaseManager $db) {}
+    public function __construct(private DatabaseManager $db)
+    {
+    }
 
     public function convert(Ticket $ticket, ?Project $project = null, bool $moveTicketToWaitingOnSupport = true): Issue
     {

--- a/app/Services/Support/TicketWorkflowService.php
+++ b/app/Services/Support/TicketWorkflowService.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace App\Services\Support;
+
+use App\Models\Issue;
+use App\Models\Project;
+use App\Models\ServiceProduct;
+use App\Models\Ticket;
+use App\Models\TicketStatus;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+
+final class TicketWorkflowService
+{
+    public function __construct(private ConvertTicketToIssue $converter) {}
+
+    public function initialize(Ticket $ticket): ?Issue
+    {
+        $product = $ticket->product()->first();
+        $updates = [];
+
+        if ($product instanceof ServiceProduct) {
+            if ($ticket->project_id === null && $product->default_project_id !== null) {
+                $updates['project_id'] = $product->default_project_id;
+            }
+
+            if ($ticket->first_response_due_at === null && $product->first_response_target_minutes !== null) {
+                $updates['first_response_due_at'] = $this->dueAt(
+                    $ticket->created_at ?? CarbonImmutable::now(),
+                    (int) $product->first_response_target_minutes,
+                );
+            }
+
+            if ($ticket->resolve_due_at === null && $product->resolve_target_minutes !== null) {
+                $updates['resolve_due_at'] = $this->dueAt(
+                    $ticket->created_at ?? CarbonImmutable::now(),
+                    (int) $product->resolve_target_minutes,
+                );
+            }
+        }
+
+        if ($ticket->last_customer_reply_at === null) {
+            $updates['last_customer_reply_at'] = $ticket->created_at ?? CarbonImmutable::now();
+        }
+
+        if ($updates !== []) {
+            $ticket->forceFill($updates);
+            $ticket->saveQuietly();
+        }
+
+        $ticket->unsetRelation('product');
+        $ticket->loadMissing(['product.defaultProject', 'project']);
+
+        return $this->maybeAutoCreateIssue($ticket);
+    }
+
+    public function recordStaffReply(Ticket $ticket): void
+    {
+        $now = CarbonImmutable::now();
+        $updates = [
+            'last_staff_reply_at' => $now,
+            'next_response_due_at' => null,
+        ];
+
+        if ($ticket->first_responded_at === null) {
+            $updates['first_responded_at'] = $now;
+        }
+
+        $ticket->forceFill($updates);
+        $ticket->saveQuietly();
+    }
+
+    public function recordCustomerReply(Ticket $ticket): void
+    {
+        /** @var ServiceProduct|null $product */
+        $product = $ticket->product ?? $ticket->product()->first();
+        $now = CarbonImmutable::now();
+        $updates = [
+            'last_customer_reply_at' => $now,
+        ];
+
+        if ($ticket->first_responded_at !== null && $product?->next_response_target_minutes !== null) {
+            $updates['next_response_due_at'] = $this->dueAt(
+                $now,
+                (int) $product->next_response_target_minutes,
+            );
+        }
+
+        $ticket->forceFill($updates);
+        $ticket->saveQuietly();
+    }
+
+    public function syncResolutionState(Ticket $ticket): void
+    {
+        /** @var TicketStatus|null $status */
+        $status = $ticket->status ?? $ticket->status()->first();
+        /** @var ServiceProduct|null $product */
+        $product = $ticket->product ?? $ticket->product()->first();
+        $now = CarbonImmutable::now();
+
+        if ($status === null) {
+            return;
+        }
+
+        $updates = [];
+
+        if ($status->is_done) {
+            if ($ticket->resolved_at === null) {
+                $updates['resolved_at'] = $now;
+            }
+
+            $updates['next_response_due_at'] = null;
+        } else {
+            if ($ticket->resolved_at !== null) {
+                $updates['resolved_at'] = null;
+            }
+
+            if ($ticket->resolve_due_at === null && $product?->resolve_target_minutes !== null) {
+                $updates['resolve_due_at'] = $this->dueAt(
+                    $ticket->created_at ?? CarbonImmutable::now(),
+                    (int) $product->resolve_target_minutes,
+                );
+            }
+        }
+
+        if ($updates === []) {
+            return;
+        }
+
+        $ticket->forceFill($updates);
+        $ticket->saveQuietly();
+    }
+
+    public function maybeAutoCreateIssue(Ticket $ticket): ?Issue
+    {
+        if ($ticket->issues()->exists()) {
+            return null;
+        }
+
+        /** @var ServiceProduct|null $product */
+        $product = $ticket->product ?? $ticket->product()->first();
+        if ($product === null) {
+            return null;
+        }
+
+        if ((int) ($product->auto_create_issue_for_ticket_type_id ?? 0) !== (int) $ticket->type_id) {
+            return null;
+        }
+
+        /** @var Project|null $project */
+        $project = $product->autoCreateIssueProject
+            ?? $ticket->project
+            ?? $product->defaultProject;
+
+        if ($project === null) {
+            return null;
+        }
+
+        if ($ticket->project_id !== $project->getKey()) {
+            $ticket->forceFill(['project_id' => $project->getKey()]);
+            $ticket->saveQuietly();
+        }
+
+        return $this->converter->convert($ticket, $project, moveTicketToWaitingOnSupport: false);
+    }
+
+    private function dueAt(CarbonInterface $from, int $minutes): CarbonImmutable
+    {
+        return CarbonImmutable::instance($from)->addMinutes($minutes);
+    }
+}

--- a/app/Services/Support/TicketWorkflowService.php
+++ b/app/Services/Support/TicketWorkflowService.php
@@ -12,7 +12,9 @@ use Carbon\CarbonInterface;
 
 final class TicketWorkflowService
 {
-    public function __construct(private ConvertTicketToIssue $converter) {}
+    public function __construct(private ConvertTicketToIssue $converter)
+    {
+    }
 
     public function initialize(Ticket $ticket): ?Issue
     {

--- a/app/Services/Support/TicketWorkflowService.php
+++ b/app/Services/Support/TicketWorkflowService.php
@@ -12,14 +12,16 @@ use Carbon\CarbonInterface;
 
 final class TicketWorkflowService
 {
-    public function __construct(private ConvertTicketToIssue $converter)
-    {
-    }
+    public function __construct(private ConvertTicketToIssue $converter) {}
 
     public function initialize(Ticket $ticket): ?Issue
     {
         /** @var ServiceProduct|null $product */
-        $product = $ticket->product ?? $ticket->product()->first();
+        $product = $this->resolveWorkflowProduct($ticket, [
+            'default_project_id',
+            'first_response_target_minutes',
+            'resolve_target_minutes',
+        ]);
         $updates = [];
         $projectWasUpdated = false;
 
@@ -84,7 +86,7 @@ final class TicketWorkflowService
     public function recordCustomerReply(Ticket $ticket): void
     {
         /** @var ServiceProduct|null $product */
-        $product = $ticket->product ?? $ticket->product()->first();
+        $product = $this->resolveWorkflowProduct($ticket, ['next_response_target_minutes']);
         $now = CarbonImmutable::now();
         $updates = [
             'last_customer_reply_at' => $now,
@@ -106,7 +108,7 @@ final class TicketWorkflowService
         /** @var TicketStatus|null $status */
         $status = $ticket->status ?? $ticket->status()->first();
         /** @var ServiceProduct|null $product */
-        $product = $ticket->product ?? $ticket->product()->first();
+        $product = $this->resolveWorkflowProduct($ticket, ['resolve_target_minutes']);
         $now = CarbonImmutable::now();
 
         if ($status === null) {
@@ -145,7 +147,11 @@ final class TicketWorkflowService
     public function maybeAutoCreateIssue(Ticket $ticket): ?Issue
     {
         /** @var ServiceProduct|null $product */
-        $product = $ticket->product ?? $ticket->product()->first();
+        $product = $this->resolveWorkflowProduct($ticket, [
+            'default_project_id',
+            'auto_create_issue_for_ticket_type_id',
+            'auto_create_issue_project_id',
+        ]);
         if ($product === null) {
             return null;
         }
@@ -179,5 +185,48 @@ final class TicketWorkflowService
     private function dueAt(CarbonInterface $from, int $minutes): CarbonImmutable
     {
         return CarbonImmutable::instance($from)->addMinutes($minutes);
+    }
+
+    /**
+     * Refresh a partially eager-loaded product before reading workflow configuration.
+     *
+     * @param  array<int, string>  $requiredAttributes
+     */
+    private function resolveWorkflowProduct(Ticket $ticket, array $requiredAttributes): ?ServiceProduct
+    {
+        /** @var ServiceProduct|null $product */
+        $product = $ticket->relationLoaded('product')
+            ? $ticket->getRelation('product')
+            : null;
+
+        if ($product instanceof ServiceProduct && $this->productHasAttributes($product, $requiredAttributes)) {
+            return $product;
+        }
+
+        $product = $ticket->product()->first();
+
+        if (! $product instanceof ServiceProduct) {
+            return null;
+        }
+
+        $ticket->setRelation('product', $product);
+
+        return $product;
+    }
+
+    /**
+     * @param  array<int, string>  $requiredAttributes
+     */
+    private function productHasAttributes(ServiceProduct $product, array $requiredAttributes): bool
+    {
+        $attributes = $product->getAttributes();
+
+        foreach ($requiredAttributes as $attribute) {
+            if (! array_key_exists($attribute, $attributes)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/app/Services/Support/TicketWorkflowService.php
+++ b/app/Services/Support/TicketWorkflowService.php
@@ -12,18 +12,22 @@ use Carbon\CarbonInterface;
 
 final class TicketWorkflowService
 {
-    public function __construct(private ConvertTicketToIssue $converter)
-    {
-    }
+    public function __construct(private ConvertTicketToIssue $converter) {}
 
     public function initialize(Ticket $ticket): ?Issue
     {
-        $product = $ticket->product()->first();
+        /** @var ServiceProduct|null $product */
+        $product = $ticket->product ?? $ticket->product()->first();
         $updates = [];
+        $projectWasUpdated = false;
 
         if ($product instanceof ServiceProduct) {
+            $product->loadMissing(['defaultProject', 'autoCreateIssueProject']);
+            $ticket->setRelation('product', $product);
+
             if ($ticket->project_id === null && $product->default_project_id !== null) {
                 $updates['project_id'] = $product->default_project_id;
+                $projectWasUpdated = true;
             }
 
             if ($ticket->first_response_due_at === null && $product->first_response_target_minutes !== null) {
@@ -50,8 +54,11 @@ final class TicketWorkflowService
             $ticket->saveQuietly();
         }
 
-        $ticket->unsetRelation('product');
-        $ticket->loadMissing(['product.defaultProject', 'project']);
+        if ($projectWasUpdated) {
+            $ticket->unsetRelation('project');
+        }
+
+        $ticket->loadMissing('project');
 
         return $this->maybeAutoCreateIssue($ticket);
     }
@@ -135,15 +142,14 @@ final class TicketWorkflowService
 
     public function maybeAutoCreateIssue(Ticket $ticket): ?Issue
     {
-        if ($ticket->issues()->exists()) {
-            return null;
-        }
-
         /** @var ServiceProduct|null $product */
         $product = $ticket->product ?? $ticket->product()->first();
         if ($product === null) {
             return null;
         }
+
+        $product->loadMissing(['defaultProject', 'autoCreateIssueProject']);
+        $ticket->setRelation('product', $product);
 
         if ((int) ($product->auto_create_issue_for_ticket_type_id ?? 0) !== (int) $ticket->type_id) {
             return null;
@@ -163,7 +169,9 @@ final class TicketWorkflowService
             $ticket->saveQuietly();
         }
 
-        return $this->converter->convert($ticket, $project, moveTicketToWaitingOnSupport: false);
+        $ticket->setRelation('project', $project);
+
+        return $this->converter->convertIfUnlinked($ticket, $project, moveTicketToWaitingOnSupport: false);
     }
 
     private function dueAt(CarbonInterface $from, int $minutes): CarbonImmutable

--- a/database/migrations/2026_03_20_160000_add_service_desk_workflows.php
+++ b/database/migrations/2026_03_20_160000_add_service_desk_workflows.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_products', static function (Blueprint $table): void {
+            $table->unsignedInteger('first_response_target_minutes')->nullable();
+            $table->unsignedInteger('next_response_target_minutes')->nullable();
+            $table->unsignedInteger('resolve_target_minutes')->nullable();
+            $table->foreignId('auto_create_issue_for_ticket_type_id')->nullable()->index();
+            $table->foreignUuid('auto_create_issue_project_id')->nullable()->index();
+        });
+
+        Schema::table('tickets', static function (Blueprint $table): void {
+            $table->timestamp('first_response_due_at')->nullable()->index();
+            $table->timestamp('first_responded_at')->nullable();
+            $table->timestamp('next_response_due_at')->nullable()->index();
+            $table->timestamp('last_customer_reply_at')->nullable();
+            $table->timestamp('last_staff_reply_at')->nullable();
+            $table->timestamp('resolve_due_at')->nullable()->index();
+            $table->timestamp('resolved_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tickets', static function (Blueprint $table): void {
+            $table->dropColumn([
+                'first_response_due_at',
+                'first_responded_at',
+                'next_response_due_at',
+                'last_customer_reply_at',
+                'last_staff_reply_at',
+                'resolve_due_at',
+                'resolved_at',
+            ]);
+        });
+
+        Schema::table('service_products', static function (Blueprint $table): void {
+            $table->dropColumn([
+                'first_response_target_minutes',
+                'next_response_target_minutes',
+                'resolve_target_minutes',
+                'auto_create_issue_for_ticket_type_id',
+                'auto_create_issue_project_id',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_03_20_160000_add_service_desk_workflows.php
+++ b/database/migrations/2026_03_20_160000_add_service_desk_workflows.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::table('service_products', static function (Blueprint $table): void {

--- a/database/migrations/2026_03_20_160000_add_service_desk_workflows.php
+++ b/database/migrations/2026_03_20_160000_add_service_desk_workflows.php
@@ -4,15 +4,22 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class () extends Migration {
+return new class extends Migration
+{
     public function up(): void
     {
         Schema::table('service_products', static function (Blueprint $table): void {
             $table->unsignedInteger('first_response_target_minutes')->nullable();
             $table->unsignedInteger('next_response_target_minutes')->nullable();
             $table->unsignedInteger('resolve_target_minutes')->nullable();
-            $table->foreignId('auto_create_issue_for_ticket_type_id')->nullable()->index();
-            $table->foreignUuid('auto_create_issue_project_id')->nullable()->index();
+            $table->foreignId('auto_create_issue_for_ticket_type_id')
+                ->nullable()
+                ->constrained('ticket_types')
+                ->nullOnDelete();
+            $table->foreignUuid('auto_create_issue_project_id')
+                ->nullable()
+                ->constrained('projects')
+                ->nullOnDelete();
         });
 
         Schema::table('tickets', static function (Blueprint $table): void {
@@ -41,6 +48,8 @@ return new class () extends Migration {
         });
 
         Schema::table('service_products', static function (Blueprint $table): void {
+            $table->dropForeign(['auto_create_issue_for_ticket_type_id']);
+            $table->dropForeign(['auto_create_issue_project_id']);
             $table->dropColumn([
                 'first_response_target_minutes',
                 'next_response_target_minutes',

--- a/resources/views/livewire/staff/support/partials/sla-windows.blade.php
+++ b/resources/views/livewire/staff/support/partials/sla-windows.blade.php
@@ -1,0 +1,63 @@
+@php
+    $mode = $mode ?? 'detail';
+    $showEmpty = $showEmpty ?? false;
+    $emptyText = $emptyText ?? 'No active timer';
+    $emptyClass = $emptyClass ?? 'text-body-secondary';
+    $windows = collect($windows ?? []);
+    $visibleWindows = $mode === 'compact'
+        ? $windows->filter(fn (array $window) => $window['open'])
+        : $windows->filter(fn (array $window) => $window['due_at'] !== null);
+    $formatSlaTime = static function (array $window, string $mode): string {
+        if ($mode === 'compact') {
+            if ($window['due_at'] === null) {
+                return 'No timer set';
+            }
+
+            return ($window['breached'] ? 'Overdue ' : 'Due ') . $window['due_at']->diffForHumans();
+        }
+
+        if ($window['completed_at'] !== null) {
+            return 'Met ' . $window['completed_at']->diffForHumans();
+        }
+
+        if ($window['due_at'] === null) {
+            return 'No timer set';
+        }
+
+        return ($window['breached'] ? 'Breached ' : 'Due ') . $window['due_at']->diffForHumans();
+    };
+@endphp
+
+@if($visibleWindows->isEmpty())
+    @if($showEmpty)
+        <span class="{{ $emptyClass }}">{{ $emptyText }}</span>
+    @endif
+@elseif($mode === 'compact')
+    @foreach($visibleWindows as $window)
+        <div class="text-nowrap">
+            <span class="badge {{ $window['breached'] ? 'text-bg-danger' : 'text-bg-warning' }}">{{ $window['label'] }}</span>
+            <span class="{{ $window['breached'] ? 'text-danger' : 'text-body-secondary' }}">
+                {{ $formatSlaTime($window, $mode) }}
+            </span>
+        </div>
+    @endforeach
+@else
+    <div class="border rounded p-3 bg-body-tertiary">
+        <div class="small text-uppercase text-body-secondary fw-semibold mb-2">SLA targets</div>
+        <div class="vstack gap-2">
+            @foreach($visibleWindows as $window)
+                <div class="border rounded p-2 {{ $window['breached'] ? 'border-danger bg-danger-subtle' : '' }}">
+                    <div class="d-flex justify-content-between align-items-center gap-2">
+                        <span class="fw-semibold small">{{ $window['label'] }}</span>
+                        <span class="badge {{ $window['breached'] ? 'text-bg-danger' : ($window['open'] ? 'text-bg-warning' : 'text-bg-success') }}">
+                            {{ $window['breached'] ? 'Breached' : ($window['open'] ? 'Open' : 'Met') }}
+                        </span>
+                    </div>
+                    <div class="small text-body-secondary mt-1">
+                        {{ $formatSlaTime($window, $mode) }}
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </div>
+@endif

--- a/resources/views/livewire/staff/support/products/create.blade.php
+++ b/resources/views/livewire/staff/support/products/create.blade.php
@@ -21,6 +21,21 @@
                 <textarea rows="2" class="form-control" wire:model.defer="description"></textarea>
                 @error('description') <div class="text-danger small">{{ $message }}</div> @enderror
             </div>
+            <div class="col-md-4">
+                <label class="form-label">First Response SLA (minutes)</label>
+                <input type="number" min="1" max="43200" class="form-control" wire:model.defer="firstResponseTargetMinutes" placeholder="60">
+                @error('firstResponseTargetMinutes') <div class="text-danger small">{{ $message }}</div> @enderror
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Next Response SLA (minutes)</label>
+                <input type="number" min="1" max="43200" class="form-control" wire:model.defer="nextResponseTargetMinutes" placeholder="240">
+                @error('nextResponseTargetMinutes') <div class="text-danger small">{{ $message }}</div> @enderror
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Resolve SLA (minutes)</label>
+                <input type="number" min="1" max="43200" class="form-control" wire:model.defer="resolveTargetMinutes" placeholder="1440">
+                @error('resolveTargetMinutes') <div class="text-danger small">{{ $message }}</div> @enderror
+            </div>
             <div class="col-md-6">
                 <label class="form-label">Default Project</label>
                 <select class="form-select" wire:model="defaultProjectId">
@@ -41,6 +56,28 @@
                 </select>
                 @error('projectIds') <div class="text-danger small">{{ $message }}</div> @enderror
                 <div class="form-text">Context only. Default Project is used for routing.</div>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Auto-create Issue When Type Is</label>
+                <select class="form-select" wire:model="autoCreateIssueForTicketTypeId">
+                    <option value="">— Disabled —</option>
+                    @foreach($ticketTypes as $type)
+                        <option value="{{ $type->id }}">{{ $type->name }}</option>
+                    @endforeach
+                </select>
+                @error('autoCreateIssueForTicketTypeId') <div class="text-danger small">{{ $message }}</div> @enderror
+                <div class="form-text">Simple automation: create and link an issue as soon as a matching ticket is submitted.</div>
+            </div>
+            <div class="col-md-6">
+                <label class="form-label">Automation Project Override</label>
+                <select class="form-select" wire:model="autoCreateIssueProjectId">
+                    <option value="">— Use ticket/default project —</option>
+                    @foreach($projects as $p)
+                        <option value="{{ $p->id }}">{{ $p->name }} @if($p->key) ({{ $p->key }}) @endif</option>
+                    @endforeach
+                </select>
+                @error('autoCreateIssueProjectId') <div class="text-danger small">{{ $message }}</div> @enderror
+                <div class="form-text">Use this if bug intake should always land in a specific delivery project.</div>
             </div>
         </div>
 

--- a/resources/views/livewire/staff/support/products/edit.blade.php
+++ b/resources/views/livewire/staff/support/products/edit.blade.php
@@ -18,6 +18,21 @@
                     <label class="form-label">Description</label>
                     <textarea rows="2" class="form-control" wire:model.defer="description"></textarea>
                 </div>
+                <div class="col-md-4">
+                    <label class="form-label">First Response SLA (minutes)</label>
+                    <input type="number" min="1" max="43200" class="form-control" wire:model.defer="firstResponseTargetMinutes" placeholder="60">
+                    @error('firstResponseTargetMinutes') <div class="text-danger small">{{ $message }}</div> @enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">Next Response SLA (minutes)</label>
+                    <input type="number" min="1" max="43200" class="form-control" wire:model.defer="nextResponseTargetMinutes" placeholder="240">
+                    @error('nextResponseTargetMinutes') <div class="text-danger small">{{ $message }}</div> @enderror
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">Resolve SLA (minutes)</label>
+                    <input type="number" min="1" max="43200" class="form-control" wire:model.defer="resolveTargetMinutes" placeholder="1440">
+                    @error('resolveTargetMinutes') <div class="text-danger small">{{ $message }}</div> @enderror
+                </div>
                 <div class="col-md-6">
                     <label class="form-label">Default Project</label>
                     <select class="form-select" wire:model="defaultProjectId">
@@ -35,6 +50,28 @@
                         @endforeach
                     </select>
                     <div class="form-text">Used for context; default project is used when routing new tickets.</div>
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">Auto-create Issue When Type Is</label>
+                    <select class="form-select" wire:model="autoCreateIssueForTicketTypeId">
+                        <option value="">— Disabled —</option>
+                        @foreach($ticketTypes as $type)
+                            <option value="{{ $type->id }}">{{ $type->name }}</option>
+                        @endforeach
+                    </select>
+                    @error('autoCreateIssueForTicketTypeId') <div class="text-danger small">{{ $message }}</div> @enderror
+                    <div class="form-text">Create and link an issue automatically for matching tickets.</div>
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">Automation Project Override</label>
+                    <select class="form-select" wire:model="autoCreateIssueProjectId">
+                        <option value="">— Use ticket/default project —</option>
+                        @foreach($allProjects as $p)
+                            <option value="{{ $p->id }}">{{ $p->name }} @if($p->key) ({{ $p->key }}) @endif</option>
+                        @endforeach
+                    </select>
+                    @error('autoCreateIssueProjectId') <div class="text-danger small">{{ $message }}</div> @enderror
+                    <div class="form-text">Helpful for routing bug tickets straight into the owning team backlog.</div>
                 </div>
             </div>
 

--- a/resources/views/livewire/staff/support/show-ticket.blade.php
+++ b/resources/views/livewire/staff/support/show-ticket.blade.php
@@ -1,18 +1,4 @@
 <div class="vstack gap-3">
-    @php
-        $slaWindows = collect($ticket->slaWindows())->filter(fn (array $window) => $window['due_at'] !== null);
-        $formatSlaTime = static function ($dueAt, $completedAt, bool $breached): string {
-            if ($completedAt !== null) {
-                return 'Met ' . $completedAt->diffForHumans();
-            }
-
-            if ($dueAt === null) {
-                return 'No timer set';
-            }
-
-            return ($breached ? 'Breached ' : 'Due ') . $dueAt->diffForHumans();
-        };
-    @endphp
     <div class="card">
         <div class="card-body">
             <div class="d-flex justify-content-between align-items-start">
@@ -61,26 +47,10 @@
                 </div>
                 <div class="col-md-4">
                     <form wire:submit.prevent="saveMeta" class="vstack gap-2">
-                        @if($slaWindows->isNotEmpty())
-                            <div class="border rounded p-3 bg-body-tertiary">
-                                <div class="small text-uppercase text-body-secondary fw-semibold mb-2">SLA targets</div>
-                                <div class="vstack gap-2">
-                                    @foreach($slaWindows as $window)
-                                        <div class="border rounded p-2 {{ $window['breached'] ? 'border-danger bg-danger-subtle' : '' }}">
-                                            <div class="d-flex justify-content-between align-items-center gap-2">
-                                                <span class="fw-semibold small">{{ $window['label'] }}</span>
-                                                <span class="badge {{ $window['breached'] ? 'text-bg-danger' : ($window['open'] ? 'text-bg-warning' : 'text-bg-success') }}">
-                                                    {{ $window['breached'] ? 'Breached' : ($window['open'] ? 'Open' : 'Met') }}
-                                                </span>
-                                            </div>
-                                            <div class="small text-body-secondary mt-1">
-                                                {{ $formatSlaTime($window['due_at'], $window['completed_at'], $window['breached']) }}
-                                            </div>
-                                        </div>
-                                    @endforeach
-                                </div>
-                            </div>
-                        @endif
+                        @include('livewire.staff.support.partials.sla-windows', [
+                            'windows' => $ticket->slaWindows(),
+                            'mode' => 'detail',
+                        ])
 
                         {{-- NEW: Project --}}
                         <div>

--- a/resources/views/livewire/staff/support/show-ticket.blade.php
+++ b/resources/views/livewire/staff/support/show-ticket.blade.php
@@ -1,4 +1,18 @@
 <div class="vstack gap-3">
+    @php
+        $slaWindows = collect($ticket->slaWindows())->filter(fn (array $window) => $window['due_at'] !== null);
+        $formatSlaTime = static function ($dueAt, $completedAt, bool $breached): string {
+            if ($completedAt !== null) {
+                return 'Met ' . $completedAt->diffForHumans();
+            }
+
+            if ($dueAt === null) {
+                return 'No timer set';
+            }
+
+            return ($breached ? 'Breached ' : 'Due ') . $dueAt->diffForHumans();
+        };
+    @endphp
     <div class="card">
         <div class="card-body">
             <div class="d-flex justify-content-between align-items-start">
@@ -47,6 +61,26 @@
                 </div>
                 <div class="col-md-4">
                     <form wire:submit.prevent="saveMeta" class="vstack gap-2">
+                        @if($slaWindows->isNotEmpty())
+                            <div class="border rounded p-3 bg-body-tertiary">
+                                <div class="small text-uppercase text-body-secondary fw-semibold mb-2">SLA targets</div>
+                                <div class="vstack gap-2">
+                                    @foreach($slaWindows as $window)
+                                        <div class="border rounded p-2 {{ $window['breached'] ? 'border-danger bg-danger-subtle' : '' }}">
+                                            <div class="d-flex justify-content-between align-items-center gap-2">
+                                                <span class="fw-semibold small">{{ $window['label'] }}</span>
+                                                <span class="badge {{ $window['breached'] ? 'text-bg-danger' : ($window['open'] ? 'text-bg-warning' : 'text-bg-success') }}">
+                                                    {{ $window['breached'] ? 'Breached' : ($window['open'] ? 'Open' : 'Met') }}
+                                                </span>
+                                            </div>
+                                            <div class="small text-body-secondary mt-1">
+                                                {{ $formatSlaTime($window['due_at'], $window['completed_at'], $window['breached']) }}
+                                            </div>
+                                        </div>
+                                    @endforeach
+                                </div>
+                            </div>
+                        @endif
 
                         {{-- NEW: Project --}}
                         <div>
@@ -79,6 +113,12 @@
                             <select class="form-select" wire:model="typeId">
                                 @foreach($types as $t)<option value="{{ $t->id }}">{{ $t->name }}</option>@endforeach
                             </select>
+                            @if($ticket->product?->auto_create_issue_for_ticket_type_id)
+                                <div class="form-text">
+                                    Auto-creates a linked issue when set to
+                                    {{ $types->firstWhere('id', $ticket->product->auto_create_issue_for_ticket_type_id)?->name ?? 'the configured type' }}.
+                                </div>
+                            @endif
                         </div>
                         <div>
                             <label class="form-label">Assignee</label>

--- a/resources/views/livewire/staff/support/triage.blade.php
+++ b/resources/views/livewire/staff/support/triage.blade.php
@@ -54,9 +54,6 @@
                 </thead>
                 <tbody>
                 @forelse($rows as $t)
-                    @php
-                        $activeWindows = collect($t->slaWindows())->filter(fn (array $window) => $window['open']);
-                    @endphp
                     <tr>
                         <td class="fw-semibold"><a href="{{ route('support.staff.show', ['key' => $t->key]) }}">{{ $t->key }}</a></td>
                         <td>{{ Str::limit($t->subject, 80) }}</td>
@@ -64,18 +61,11 @@
                         <td>{{ $t->status->name ?? '—' }}</td>
                         <td>{{ $t->priority->name ?? '—' }}</td>
                         <td class="small">
-                            @if($activeWindows->isEmpty())
-                                <span class="text-body-secondary">No active timer</span>
-                            @else
-                                @foreach($activeWindows as $window)
-                                    <div class="text-nowrap">
-                                        <span class="badge {{ $window['breached'] ? 'text-bg-danger' : 'text-bg-warning' }}">{{ $window['label'] }}</span>
-                                        <span class="{{ $window['breached'] ? 'text-danger' : 'text-body-secondary' }}">
-                                            {{ $window['breached'] ? 'Overdue' : 'Due' }} {{ $window['due_at']?->diffForHumans() }}
-                                        </span>
-                                    </div>
-                                @endforeach
-                            @endif
+                            @include('livewire.staff.support.partials.sla-windows', [
+                                'windows' => $t->slaWindows(),
+                                'mode' => 'compact',
+                                'showEmpty' => true,
+                            ])
                         </td>
                         <td>{{ $t->assignee->name ?? '—' }}</td>
                         <td class="text-nowrap">{{ $t->created_at->format('M j, Y g:ia') }}</td>

--- a/resources/views/livewire/staff/support/triage.blade.php
+++ b/resources/views/livewire/staff/support/triage.blade.php
@@ -47,23 +47,41 @@
                     <th>Product</th>
                     <th>Status</th>
                     <th>Priority</th>
+                    <th>SLA</th>
                     <th>Assignee</th>
                     <th>Opened</th>
                 </tr>
                 </thead>
                 <tbody>
                 @forelse($rows as $t)
+                    @php
+                        $activeWindows = collect($t->slaWindows())->filter(fn (array $window) => $window['open']);
+                    @endphp
                     <tr>
                         <td class="fw-semibold"><a href="{{ route('support.staff.show', ['key' => $t->key]) }}">{{ $t->key }}</a></td>
                         <td>{{ Str::limit($t->subject, 80) }}</td>
                         <td>{{ $t->product->name ?? '—' }}</td>
                         <td>{{ $t->status->name ?? '—' }}</td>
                         <td>{{ $t->priority->name ?? '—' }}</td>
+                        <td class="small">
+                            @if($activeWindows->isEmpty())
+                                <span class="text-body-secondary">No active timer</span>
+                            @else
+                                @foreach($activeWindows as $window)
+                                    <div class="text-nowrap">
+                                        <span class="badge {{ $window['breached'] ? 'text-bg-danger' : 'text-bg-warning' }}">{{ $window['label'] }}</span>
+                                        <span class="{{ $window['breached'] ? 'text-danger' : 'text-body-secondary' }}">
+                                            {{ $window['breached'] ? 'Overdue' : 'Due' }} {{ $window['due_at']?->diffForHumans() }}
+                                        </span>
+                                    </div>
+                                @endforeach
+                            @endif
+                        </td>
                         <td>{{ $t->assignee->name ?? '—' }}</td>
                         <td class="text-nowrap">{{ $t->created_at->format('M j, Y g:ia') }}</td>
                     </tr>
                 @empty
-                    <tr><td colspan="7" class="text-body-secondary">No tickets found.</td></tr>
+                    <tr><td colspan="8" class="text-body-secondary">No tickets found.</td></tr>
                 @endforelse
                 </tbody>
             </table>

--- a/resources/views/livewire/support/new-ticket.blade.php
+++ b/resources/views/livewire/support/new-ticket.blade.php
@@ -2,14 +2,32 @@
     <form wire:submit.prevent="submit" class="vstack gap-3">
         <div>
             <label class="form-label">Product</label>
-            <select class="form-select" wire:model.defer="productId" required>
+            <select class="form-select" wire:model.live="productId" required>
                 <option value="">— Select a product —</option>
                 @foreach($products as $p)
                     <option value="{{ $p['id'] }}">{{ $p['name'] }}</option>
                 @endforeach
             </select>
             @error('productId') <div class="text-danger small">{{ $message }}</div> @enderror
-            <div class="form-text">We’ll route your ticket to the right project based on the product.</div>
+            <div class="form-text">
+                @if($selectedProduct)
+                    Routed to {{ $selectedProduct['project'] ?? 'the product team' }}.
+                    @if(!empty($selectedProduct['description'])) {{ $selectedProduct['description'] }} @endif
+                @else
+                    We’ll route your ticket to the right project based on the product.
+                @endif
+            </div>
+        </div>
+
+        <div>
+            <label class="form-label">Type</label>
+            <select class="form-select" wire:model.live="typeId">
+                @foreach($types as $type)
+                    <option value="{{ $type['id'] }}">{{ $type['name'] }}</option>
+                @endforeach
+            </select>
+            @error('typeId') <div class="text-danger small">{{ $message }}</div> @enderror
+            <div class="form-text">{{ $typeTemplate['intro'] }}</div>
         </div>
 
         <div>
@@ -26,13 +44,13 @@
 
         <div>
             <label class="form-label">Subject</label>
-            <input type="text" wire:model.defer="subject" class="form-control">
+            <input type="text" wire:model.defer="subject" class="form-control" placeholder="{{ $typeTemplate['subject'] }}">
             @error('subject') <div class="text-danger small">{{ $message }}</div> @enderror
         </div>
 
         <div>
             <label class="form-label">Describe the problem</label>
-            <textarea rows="6" wire:model.defer="body" class="form-control"></textarea>
+            <textarea rows="6" wire:model.defer="body" class="form-control" placeholder="{{ $typeTemplate['body'] }}"></textarea>
             @error('body') <div class="text-danger small">{{ $message }}</div> @enderror
         </div>
 

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -1,5 +1,5 @@
 @php
-    use App\Models\{Project, Organization, Issue, Goal};
+    use App\Models\{Project, Organization, Issue, Goal, Ticket};
     /** @var \App\Models\User|null $user */
     $user = auth()->user();
     $allowReg = app(\App\Settings\AuthSettings::class)->allowRegistration ?? true;
@@ -108,22 +108,53 @@
                         </ul>
                     </li>
 
-                    <!-- Support/Service Desk -->
-                    <li class="nav-item">
-                        <x-nav-link href="{{ $user ? route('support.staff.index') : url('/support/staff') }}" :active="request()->routeIs('support.staff.index')" data-tour="support-nav">
+                    <!-- Support -->
+                    <li class="nav-item dropdown">
+                        <a class="nav-link dropdown-toggle {{ request()->routeIs('support.*') ? 'active' : '' }}"
+                           href="#"
+                           id="supportDropdownAuth"
+                           role="button"
+                           data-bs-toggle="dropdown"
+                           aria-expanded="false"
+                           data-tour="support-nav">
                             {{ __('Support') }}
-                        </x-nav-link>
+                        </a>
+                        <ul class="dropdown-menu" aria-labelledby="supportDropdownAuth">
+                            <li>
+                                <x-dropdown-link href="{{ Route::has('support.index') ? route('support.index') : url('/support') }}">
+                                    {{ __('Support Portal') }}
+                                </x-dropdown-link>
+                            </li>
+                            <li>
+                                <x-dropdown-link href="{{ Route::has('support.my') ? route('support.my') : url('/support/my') }}">
+                                    {{ __('My Tickets') }}
+                                </x-dropdown-link>
+                            </li>
+                            <li>
+                                <x-dropdown-link href="{{ Route::has('support.new') ? route('support.new') : url('/support/new') }}">
+                                    {{ __('Submit Ticket') }}
+                                </x-dropdown-link>
+                            </li>
+                            @can('viewAny', Ticket::class)
+                                <li><hr class="dropdown-divider"></li>
+                                <li>
+                                    <x-dropdown-link href="{{ Route::has('support.staff.index') ? route('support.staff.index') : url('/support/staff') }}">
+                                        {{ __('Support Triage') }}
+                                    </x-dropdown-link>
+                                </li>
+                            @endcan
+                        </ul>
                     </li>
                 @elseguest
-                    <!-- Support/Service Desk -->
+                    <!-- Support -->
                     <li class="nav-item dropdown">
-                        <a class="nav-link dropdown-toggle" href="#" id="supportDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        <a class="nav-link dropdown-toggle {{ request()->routeIs('support.*') ? 'active' : '' }}" href="#" id="supportDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                             {{ __('Support') }}
                         </a>
                         <ul class="dropdown-menu" aria-labelledby="supportDropdown">
                             <li>
                                 <x-dropdown-link href="{{ Route::has('support.index') ? route('support.index') : url('/support') }}">
-                                    {{ __('Support Center') }}
+                                    {{ __('Support Portal') }}
                                 </x-dropdown-link>
                             </li>
                             <li><hr class="dropdown-divider"></li>
@@ -238,6 +269,15 @@
                             @if (Laravel\Jetstream\Jetstream::hasApiFeatures())
                                 <li><x-dropdown-link href="{{ route('api-tokens.index') }}">{{ __('API Tokens') }}</x-dropdown-link></li>
                             @endif
+
+                            <li><hr class="dropdown-divider"></li>
+                            <li class="px-3 py-2 text-muted small">{{ __('Support') }}</li>
+                            <li><x-dropdown-link href="{{ route('support.index') }}">{{ __('Support Portal') }}</x-dropdown-link></li>
+                            <li><x-dropdown-link href="{{ route('support.my') }}">{{ __('My Tickets') }}</x-dropdown-link></li>
+                            <li><x-dropdown-link href="{{ route('support.new') }}">{{ __('Submit Ticket') }}</x-dropdown-link></li>
+                            @can('viewAny', Ticket::class)
+                                <li><x-dropdown-link href="{{ route('support.staff.index') }}">{{ __('Support Triage') }}</x-dropdown-link></li>
+                            @endcan
 
                             @if ($canUseOnboarding)
                                 <li><hr class="dropdown-divider"></li>

--- a/resources/views/pages/support/access/index.blade.php
+++ b/resources/views/pages/support/access/index.blade.php
@@ -1,15 +1,46 @@
 <?php
 
-use function Laravel\Folio\{name};
+use App\Models\SupportIdentity;
+use Illuminate\Http\Request;
+use Illuminate\View\View;
+
+use function Laravel\Folio\{name, render};
 
 name('support.access.request');
 
+render(function (View $view, Request $request) {
+    $cookieId = $request->cookie('support_identity');
+    $identity = is_string($cookieId)
+        ? SupportIdentity::query()->whereKey($cookieId)->whereNull('revoked_at')->first()
+        : null;
+
+    return $view->with(compact('identity'));
+});
+
 ?>
 
-<x-app-layout>
+<x-guest-layout>
     <div class="container mx-auto py-4">
-        <h1 class="h4 mb-3">Access your tickets</h1>
-        <p class="mb-3">Use the magic link we emailed to you when you created a ticket. If you just submitted, you can also follow the link shown on the confirmation page.</p>
-        <a class="btn btn-secondary" href="{{ route('support.index') }}">Back to Support</a>
+        @if($identity)
+            <div class="d-flex justify-content-between align-items-center mb-3 gap-3 flex-wrap">
+                <div>
+                    <h1 class="h4 mb-1">My support tickets</h1>
+                    <p class="text-body-secondary mb-0">Tickets linked to your current support access cookie.</p>
+                </div>
+                <div class="d-flex gap-2">
+                    <a class="btn btn-primary" href="{{ route('support.new') }}">Submit a ticket</a>
+                    <a class="btn btn-outline-secondary" href="{{ route('support.index') }}">Support Portal</a>
+                </div>
+            </div>
+
+            @livewire('support.my-tickets', ['identityId' => $identity->getKey()])
+        @else
+            <h1 class="h4 mb-3">Access your tickets</h1>
+            <p class="mb-3">Use the magic link we emailed to you when you created a ticket. If you already opened that link on this device, your tickets will appear here automatically.</p>
+            <div class="d-flex gap-2">
+                <a class="btn btn-primary" href="{{ route('support.index') }}">Back to Support</a>
+                <a class="btn btn-outline-secondary" href="{{ route('support.new') }}">Submit a ticket</a>
+            </div>
+        @endif
     </div>
-</x-app-layout>
+</x-guest-layout>

--- a/resources/views/pages/support/index.blade.php
+++ b/resources/views/pages/support/index.blade.php
@@ -8,8 +8,8 @@ name('support.index');
 
 <x-guest-layout>
     <div class="container mx-auto py-4">
-        <h1 class="h4 mb-3">Support</h1>
-        <p class="text-body-secondary">Submit a request or review your existing tickets.</p>
+        <h1 class="h4 mb-3">Support Portal</h1>
+        <p class="text-body-secondary">Submit a request or review your customer-facing tickets.</p>
         <div class="d-flex gap-2">
             <a class="btn btn-primary" href="{{ route('support.new') }}">Submit a ticket</a>
             <a class="btn btn-outline-secondary" href="{{ route('support.access.request') }}">Access my tickets</a>

--- a/resources/views/pages/support/my.blade.php
+++ b/resources/views/pages/support/my.blade.php
@@ -9,7 +9,7 @@ middleware(['support.identity']);
 
 <x-guest-layout>
     <div class="container mx-auto py-4">
-        <h1 class="h4 mb-3">My tickets</h1>
+        <h1 class="h4 mb-3">My support tickets</h1>
         @livewire('support.my-tickets')
     </div>
 </x-guest-layout>

--- a/resources/views/pages/support/new.blade.php
+++ b/resources/views/pages/support/new.blade.php
@@ -8,7 +8,7 @@ name('support.new');
 
 <x-guest-layout>
     <div class="container mx-auto py-4">
-        <h1 class="h4 mb-3">Submit a ticket</h1>
+        <h1 class="h4 mb-3">Submit a support ticket</h1>
         <div class="alert alert-warning small">
             {{ app(\App\Settings\SupportSettings::class)->public_warning_text }}
         </div>

--- a/tests/Feature/SupportAccessPageTest.php
+++ b/tests/Feature/SupportAccessPageTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\SupportIdentity;
+use App\Models\Ticket;
+use App\Models\TicketPriority;
+use App\Models\TicketStatus;
+use App\Models\TicketType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SupportAccessPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_access_page_shows_ticket_list_when_support_cookie_is_present(): void
+    {
+        $identity = SupportIdentity::query()->create([
+            'email_encrypted' => 'jamie@example.com',
+            'email_hash' => hash('sha256', 'jamie@example.com'),
+            'token' => (string) str()->ulid(),
+        ]);
+
+        Ticket::query()->create([
+            'organization_id' => null,
+            'service_product_id' => null,
+            'project_id' => null,
+            'submitter_name' => 'Jamie Customer',
+            'submitter_email' => 'jamie@example.com',
+            'email_hash' => $identity->email_hash,
+            'subject' => 'Portal login is failing',
+            'body' => 'The customer portal rejects my sign-in every time.',
+            'status_id' => TicketStatus::query()->where('name', 'New')->value('id'),
+            'priority_id' => TicketPriority::query()->where('name', 'Medium')->value('id'),
+            'type_id' => TicketType::query()->where('name', 'Question')->value('id'),
+            'access_token' => (string) str()->ulid(),
+            'via' => 'public',
+        ]);
+
+        $this->withCookie('support_identity', $identity->getKey())
+            ->get(route('support.access.request'))
+            ->assertOk()
+            ->assertSee('My support tickets')
+            ->assertSee('Portal login is failing');
+    }
+
+    public function test_access_page_shows_guidance_when_support_cookie_is_missing(): void
+    {
+        $this->get(route('support.access.request'))
+            ->assertOk()
+            ->assertSee('Access your tickets')
+            ->assertSee('Use the magic link we emailed to you')
+            ->assertDontSee('My support tickets');
+    }
+}

--- a/tests/Feature/SupportNavigationTest.php
+++ b/tests/Feature/SupportNavigationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Role;
+use App\Models\User;
+use Database\Seeders\PermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class SupportNavigationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(PermissionSeeder::class);
+    }
+
+    public function test_authenticated_users_see_support_portal_links_in_navigation(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertOk()
+            ->assertSee('Support Portal')
+            ->assertSee('My Tickets')
+            ->assertSee('Submit Ticket')
+            ->assertDontSee('Support Triage');
+    }
+
+    public function test_staff_users_see_support_triage_alongside_portal_links(): void
+    {
+        $user = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+
+        app(PermissionRegistrar::class)->setPermissionsTeamId(null);
+
+        $role = Role::query()->create([
+            'name' => 'Support Navigation Admin',
+            'guard_name' => 'web',
+            'team_id' => null,
+        ]);
+        $role->givePermissionTo('is-super-admin');
+        $user->assignRole($role);
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertOk()
+            ->assertSee('Support Portal')
+            ->assertSee('My Tickets')
+            ->assertSee('Submit Ticket')
+            ->assertSee('Support Triage');
+    }
+}

--- a/tests/Feature/SupportWorkflowTest.php
+++ b/tests/Feature/SupportWorkflowTest.php
@@ -176,6 +176,55 @@ class SupportWorkflowTest extends TestCase
         $this->assertTrue($ticket->isResolved());
     }
 
+    public function test_customer_reply_uses_full_product_sla_settings_when_product_relation_is_partially_loaded(): void
+    {
+        $start = CarbonImmutable::parse('2026-03-20 09:00:00');
+        CarbonImmutable::setTestNow($start);
+
+        $organization = Organization::factory()->create();
+        $project = Project::factory()->create([
+            'organization_id' => $organization->getKey(),
+            'lead_id' => User::factory()->create()->getKey(),
+        ]);
+        $product = ServiceProduct::query()->create([
+            'organization_id' => $organization->getKey(),
+            'key' => 'PORTAL',
+            'name' => 'Portal',
+            'default_project_id' => $project->getKey(),
+            'next_response_target_minutes' => 180,
+        ]);
+
+        $ticket = Ticket::query()->create([
+            'organization_id' => $organization->getKey(),
+            'service_product_id' => $product->getKey(),
+            'project_id' => $project->getKey(),
+            'submitter_name' => 'Morgan Customer',
+            'submitter_email' => 'morgan@example.com',
+            'email_hash' => hash('sha256', 'morgan@example.com'),
+            'subject' => 'Need help with triage',
+            'body' => 'Please investigate the queue delay on the support board.',
+            'status_id' => TicketStatus::query()->where('name', 'New')->value('id'),
+            'priority_id' => TicketPriority::query()->where('name', 'Medium')->value('id'),
+            'type_id' => TicketType::query()->where('name', 'Question')->value('id'),
+            'first_responded_at' => $start->addMinutes(20),
+            'access_token' => (string) str()->ulid(),
+            'via' => 'public',
+        ]);
+
+        $ticket = Ticket::query()
+            ->with('product:id,name')
+            ->findOrFail($ticket->getKey());
+
+        $this->assertArrayNotHasKey('next_response_target_minutes', $ticket->product->getAttributes());
+
+        CarbonImmutable::setTestNow($start->addHours(2));
+        app(TicketWorkflowService::class)->recordCustomerReply($ticket);
+        $ticket->refresh();
+
+        $this->assertSame($start->addHours(2)->toDateTimeString(), $ticket->last_customer_reply_at?->toDateTimeString());
+        $this->assertSame($start->addHours(5)->toDateTimeString(), $ticket->next_response_due_at?->toDateTimeString());
+    }
+
     public function test_staff_triage_shows_breached_sla_badges(): void
     {
         $start = CarbonImmutable::parse('2026-03-20 08:00:00');

--- a/tests/Feature/SupportWorkflowTest.php
+++ b/tests/Feature/SupportWorkflowTest.php
@@ -1,0 +1,307 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Livewire\Staff\Support\Triage;
+use App\Livewire\Support\NewTicket;
+use App\Models\Issue;
+use App\Models\IssuePriority;
+use App\Models\IssueStatus;
+use App\Models\IssueType;
+use App\Models\Organization;
+use App\Models\Project;
+use App\Models\Role;
+use App\Models\ServiceProduct;
+use App\Models\Ticket;
+use App\Models\TicketPriority;
+use App\Models\TicketStatus;
+use App\Models\TicketType;
+use App\Models\User;
+use App\Services\Support\TicketWorkflowService;
+use Carbon\CarbonImmutable;
+use Database\Seeders\IssueEnumsSeeder;
+use Database\Seeders\PermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class SupportWorkflowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(PermissionSeeder::class);
+        $this->seed(IssueEnumsSeeder::class);
+    }
+
+    protected function tearDown(): void
+    {
+        CarbonImmutable::setTestNow(null);
+
+        parent::tearDown();
+    }
+
+    public function test_new_ticket_submission_applies_slas_and_auto_creates_a_linked_issue(): void
+    {
+        $now = CarbonImmutable::parse('2026-03-20 10:00:00');
+        CarbonImmutable::setTestNow($now);
+
+        $organization = Organization::factory()->create();
+        $lead = User::factory()->create();
+        $project = Project::factory()->create([
+            'organization_id' => $organization->getKey(),
+            'lead_id' => $lead->getKey(),
+        ]);
+        $this->configureProjectIssueDefaults($project);
+
+        $bugType = TicketType::query()->where('name', 'Bug')->sole();
+
+        $product = ServiceProduct::query()->create([
+            'organization_id' => $organization->getKey(),
+            'key' => 'PORTAL',
+            'name' => 'Customer Portal',
+            'default_project_id' => $project->getKey(),
+            'first_response_target_minutes' => 60,
+            'resolve_target_minutes' => 1440,
+            'auto_create_issue_for_ticket_type_id' => $bugType->getKey(),
+            'auto_create_issue_project_id' => $project->getKey(),
+        ]);
+
+        Livewire::test(NewTicket::class)
+            ->set('productId', $product->getKey())
+            ->set('typeId', $bugType->getKey())
+            ->set('name', 'Jamie Customer')
+            ->set('email', 'jamie@example.com')
+            ->set('subject', 'Portal crashes on submit')
+            ->set('body', 'Open the support form, choose a product, click submit, and the page freezes.')
+            ->call('submit');
+
+        $ticket = Ticket::query()->with('issues')->sole();
+        $issue = Issue::query()->sole();
+
+        $this->assertSame((string) $product->getKey(), (string) $ticket->service_product_id);
+        $this->assertSame($bugType->getKey(), $ticket->type_id);
+        $this->assertSame($project->getKey(), $ticket->project_id);
+        $this->assertSame($now->addHour()->toDateTimeString(), $ticket->first_response_due_at?->toDateTimeString());
+        $this->assertSame($now->addDay()->toDateTimeString(), $ticket->resolve_due_at?->toDateTimeString());
+        $this->assertSame($now->toDateTimeString(), $ticket->last_customer_reply_at?->toDateTimeString());
+        $this->assertSame($project->getKey(), $issue->project_id);
+        $this->assertTrue($ticket->issues->contains($issue));
+        $this->assertDatabaseHas('ticket_issue_links', [
+            'ticket_id' => $ticket->getKey(),
+            'issue_id' => $issue->getKey(),
+        ]);
+    }
+
+    public function test_ticket_workflow_tracks_first_response_next_response_and_resolution_clocks(): void
+    {
+        $start = CarbonImmutable::parse('2026-03-20 09:00:00');
+        CarbonImmutable::setTestNow($start);
+
+        $organization = Organization::factory()->create();
+        $project = Project::factory()->create([
+            'organization_id' => $organization->getKey(),
+            'lead_id' => User::factory()->create()->getKey(),
+        ]);
+        $product = ServiceProduct::query()->create([
+            'organization_id' => $organization->getKey(),
+            'key' => 'OPS',
+            'name' => 'Ops Console',
+            'default_project_id' => $project->getKey(),
+            'first_response_target_minutes' => 30,
+            'next_response_target_minutes' => 180,
+            'resolve_target_minutes' => 1440,
+        ]);
+
+        $ticket = Ticket::query()->create([
+            'organization_id' => $organization->getKey(),
+            'service_product_id' => $product->getKey(),
+            'project_id' => $project->getKey(),
+            'submitter_name' => 'Morgan Customer',
+            'submitter_email' => 'morgan@example.com',
+            'email_hash' => hash('sha256', 'morgan@example.com'),
+            'subject' => 'Need help with triage',
+            'body' => 'Please investigate the queue delay on the support board.',
+            'status_id' => TicketStatus::query()->where('name', 'New')->value('id'),
+            'priority_id' => TicketPriority::query()->where('name', 'Medium')->value('id'),
+            'type_id' => TicketType::query()->where('name', 'Question')->value('id'),
+            'access_token' => (string) str()->ulid(),
+            'via' => 'public',
+        ]);
+
+        $workflow = app(TicketWorkflowService::class);
+
+        $workflow->initialize($ticket);
+        $ticket->refresh();
+
+        $this->assertSame($start->addMinutes(30)->toDateTimeString(), $ticket->first_response_due_at?->toDateTimeString());
+        $this->assertSame($start->addDay()->toDateTimeString(), $ticket->resolve_due_at?->toDateTimeString());
+
+        CarbonImmutable::setTestNow($start->addMinutes(20));
+        $workflow->recordStaffReply($ticket);
+        $ticket->refresh();
+
+        $this->assertSame($start->addMinutes(20)->toDateTimeString(), $ticket->first_responded_at?->toDateTimeString());
+        $this->assertNull($ticket->next_response_due_at);
+
+        CarbonImmutable::setTestNow($start->addHours(2));
+        $workflow->recordCustomerReply($ticket);
+        $ticket->refresh();
+
+        $this->assertSame($start->addHours(2)->toDateTimeString(), $ticket->last_customer_reply_at?->toDateTimeString());
+        $this->assertSame($start->addHours(5)->toDateTimeString(), $ticket->next_response_due_at?->toDateTimeString());
+
+        $ticket->update([
+            'status_id' => TicketStatus::query()->where('name', 'Resolved')->value('id'),
+        ]);
+        $ticket->unsetRelation('status');
+        $ticket->load('status');
+
+        CarbonImmutable::setTestNow($start->addHours(3));
+        $workflow->syncResolutionState($ticket);
+        $ticket->refresh();
+
+        $this->assertSame($start->addHours(3)->toDateTimeString(), $ticket->resolved_at?->toDateTimeString());
+        $this->assertNull($ticket->next_response_due_at);
+        $this->assertTrue($ticket->isResolved());
+    }
+
+    public function test_staff_triage_shows_breached_sla_badges(): void
+    {
+        $start = CarbonImmutable::parse('2026-03-20 08:00:00');
+        CarbonImmutable::setTestNow($start);
+
+        $organization = Organization::factory()->create();
+        $project = Project::factory()->create([
+            'organization_id' => $organization->getKey(),
+            'lead_id' => User::factory()->create()->getKey(),
+        ]);
+        $product = ServiceProduct::query()->create([
+            'organization_id' => $organization->getKey(),
+            'key' => 'HELP',
+            'name' => 'Help Center',
+            'default_project_id' => $project->getKey(),
+            'first_response_target_minutes' => 60,
+        ]);
+
+        $ticket = Ticket::query()->create([
+            'organization_id' => $organization->getKey(),
+            'service_product_id' => $product->getKey(),
+            'project_id' => $project->getKey(),
+            'submitter_name' => 'Casey Customer',
+            'submitter_email' => 'casey@example.com',
+            'email_hash' => hash('sha256', 'casey@example.com'),
+            'subject' => 'Overdue response',
+            'body' => 'This ticket should show a breached first response timer.',
+            'status_id' => TicketStatus::query()->where('name', 'New')->value('id'),
+            'priority_id' => TicketPriority::query()->where('name', 'High')->value('id'),
+            'type_id' => TicketType::query()->where('name', 'Question')->value('id'),
+            'access_token' => (string) str()->ulid(),
+            'via' => 'public',
+        ]);
+
+        app(TicketWorkflowService::class)->initialize($ticket);
+
+        $staff = User::factory()->create([
+            'email_verified_at' => now(),
+        ]);
+        app(PermissionRegistrar::class)->setPermissionsTeamId(null);
+
+        $role = Role::query()->create([
+            'name' => 'Support Super Admin',
+            'guard_name' => 'web',
+            'team_id' => null,
+        ]);
+        $role->givePermissionTo('is-super-admin');
+        $staff->assignRole($role);
+
+        CarbonImmutable::setTestNow($start->addHours(2));
+
+        Livewire::actingAs($staff)
+            ->test(Triage::class)
+            ->assertSee($ticket->key)
+            ->assertSee('First response')
+            ->assertSee('Overdue');
+    }
+
+    private function configureProjectIssueDefaults(Project $project): void
+    {
+        $taskType = IssueType::query()->where('name', 'Task')->sole();
+        $bugType = IssueType::query()->where('name', 'Bug')->sole();
+        $todoStatus = IssueStatus::query()->where('name', 'To Do')->sole();
+        $doneStatus = IssueStatus::query()->where('name', 'Done')->sole();
+        $mediumPriority = IssuePriority::query()->where('name', 'Medium')->sole();
+        $highPriority = IssuePriority::query()->where('name', 'High')->sole();
+
+        DB::table('project_issue_types')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'project_id' => $project->getKey(),
+                'issue_type_id' => $taskType->getKey(),
+                'order' => 10,
+                'is_default' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'project_id' => $project->getKey(),
+                'issue_type_id' => $bugType->getKey(),
+                'order' => 20,
+                'is_default' => false,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        DB::table('project_issue_statuses')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'project_id' => $project->getKey(),
+                'issue_status_id' => $todoStatus->getKey(),
+                'order' => 10,
+                'is_initial' => true,
+                'is_default_done' => false,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'project_id' => $project->getKey(),
+                'issue_status_id' => $doneStatus->getKey(),
+                'order' => 90,
+                'is_initial' => false,
+                'is_default_done' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        DB::table('project_issue_priorities')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'project_id' => $project->getKey(),
+                'issue_priority_id' => $mediumPriority->getKey(),
+                'order' => 10,
+                'is_default' => true,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'project_id' => $project->getKey(),
+                'issue_priority_id' => $highPriority->getKey(),
+                'order' => 20,
+                'is_default' => false,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/SupportWorkflowTest.php
+++ b/tests/Feature/SupportWorkflowTest.php
@@ -84,6 +84,7 @@ class SupportWorkflowTest extends TestCase
 
         $ticket = Ticket::query()->with('issues')->sole();
         $issue = Issue::query()->sole();
+        $workflow = app(TicketWorkflowService::class);
 
         $this->assertSame((string) $product->getKey(), (string) $ticket->service_product_id);
         $this->assertSame($bugType->getKey(), $ticket->type_id);
@@ -97,6 +98,9 @@ class SupportWorkflowTest extends TestCase
             'ticket_id' => $ticket->getKey(),
             'issue_id' => $issue->getKey(),
         ]);
+
+        $this->assertNull($workflow->maybeAutoCreateIssue($ticket->fresh(['product.defaultProject', 'project'])));
+        $this->assertDatabaseCount('issues', 1);
     }
 
     public function test_ticket_workflow_tracks_first_response_next_response_and_resolution_clocks(): void


### PR DESCRIPTION
Added support for SLA timers (`first_response`, `next_response`, `resolve`) in service products and tickets with related migrations and Livewire updates. Introduced automatic issue creation for tickets linked to specific types and projects. Updated UI and workflow services to display SLAs, manage SLA state, and handle auto-create logic seamlessly. Included comprehensive backend and UI tests.

## Summary by Sourcery

Introduce SLA-driven ticket workflows and automatic issue creation for configured service products and ticket types.

New Features:
- Add configurable first, next, and resolve SLA timers on service products that are applied to tickets and surfaced in staff views and triage lists.
- Provide automatic issue creation and linking for tickets when their product and type match configured automation rules.
- Enhance the public ticket submission form with ticket type selection, contextual templates, and richer product routing information.

Enhancements:
- Track ticket workflow timestamps and resolution state on the Ticket model and expose derived SLA window metadata for UI consumption.
- Wire staff and customer replies, status changes, and ticket conversions through a centralized workflow service to keep SLA clocks and resolution fields in sync.
- Extend service product create/edit flows to manage SLA targets and automation settings, including an optional project override for auto-created issues.

Tests:
- Add feature tests covering SLA application on new tickets, SLA clock progression through staff and customer replies, and SLA breach indicators in the staff triage view.