### PR TITLE
bugfixes

### DIFF
--- a/app/Console/Commands/DeleteExpiredBans.php
+++ b/app/Console/Commands/DeleteExpiredBans.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Mchev\Banhammer\Banhammer;
+use PDOException;
+use Throwable;
+
+final class DeleteExpiredBans extends Command
+{
+    public const TRANSIENT_FAILURE_LOG_CACHE_KEY = 'banhammer:expired-ban-cleanup:transient-db-dns-warning';
+
+    private const TRANSIENT_FAILURE_LOG_THROTTLE_MINUTES = 30;
+
+    protected $signature = 'bans:delete-expired';
+
+    protected $description = 'Soft-delete expired ban records';
+
+    public function handle(): int
+    {
+        try {
+            Banhammer::unbanExpired();
+        } catch (PDOException $exception) {
+            if (! $this->isTransientDatabaseNameResolutionFailure($exception)) {
+                throw $exception;
+            }
+
+            if ($this->shouldLogTransientFailure()) {
+                Log::warning('Expired ban cleanup skipped because the database host could not be resolved.', [
+                    'connection' => $exception instanceof QueryException
+                        ? $exception->getConnectionName()
+                        : config('database.default'),
+                    'database' => config('database.connections.'.config('database.default').'.database'),
+                    'host' => config('database.connections.'.config('database.default').'.host'),
+                    'port' => config('database.connections.'.config('database.default').'.port'),
+                    'exception' => $exception::class,
+                    'code' => $exception->getCode(),
+                    'previous_code' => $exception->getPrevious()?->getCode(),
+                    'error' => $exception->getPrevious()?->getMessage() ?: $exception->getMessage(),
+                    'suppressed_for_minutes' => self::TRANSIENT_FAILURE_LOG_THROTTLE_MINUTES,
+                ]);
+            }
+
+            $this->warn('Skipped expired ban cleanup: temporary database DNS resolution failure.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info('Expired bans have been deleted.');
+
+        return self::SUCCESS;
+    }
+
+    private function isTransientDatabaseNameResolutionFailure(PDOException $exception): bool
+    {
+        $message = Str::lower(implode(' ', array_filter([
+            $exception->getMessage(),
+            $exception->getPrevious()?->getMessage(),
+        ])));
+
+        $isMySqlConnectionError = in_array('2002', [
+            (string) $exception->getCode(),
+            (string) $exception->getPrevious()?->getCode(),
+        ], true) || Str::contains($message, 'sqlstate[hy000] [2002]');
+
+        if (! $isMySqlConnectionError) {
+            return false;
+        }
+
+        return Str::contains($message, [
+            'php_network_getaddresses',
+            'getaddrinfo',
+            'temporary failure in name resolution',
+            'could not translate host name',
+        ]);
+    }
+
+    private function shouldLogTransientFailure(): bool
+    {
+        try {
+            return Cache::store('file')->add(
+                self::TRANSIENT_FAILURE_LOG_CACHE_KEY,
+                true,
+                now()->addMinutes(self::TRANSIENT_FAILURE_LOG_THROTTLE_MINUTES),
+            );
+        } catch (Throwable) {
+            return true;
+        }
+    }
+}

--- a/app/Filament/Resources/Projects/Schemas/ProjectForm.php
+++ b/app/Filament/Resources/Projects/Schemas/ProjectForm.php
@@ -3,21 +3,14 @@
 namespace App\Filament\Resources\Projects\Schemas;
 
 use App\Enums\ProjectStage;
+use App\Support\Keys\ProjectKeyGenerator;
 use Exception;
-use Filament\Actions\BulkActionGroup;
-use Filament\Actions\DeleteBulkAction;
-use Filament\Actions\EditAction;
-use Filament\Actions\ViewAction;
-use Filament\Schemas\Components\Utilities\Set;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Table;
-use App\Models\Project;
 use Filament\Forms;
-use Filament\Tables;
-use Filament\Resources\Resource;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
+use Illuminate\Support\Str;
 
 class ProjectForm
 {
@@ -34,16 +27,16 @@ class ProjectForm
                             ->required()->maxLength(120)
                             ->live(onBlur: true)
                             ->afterStateUpdated(
-                                fn ($state, Set $set) => $set('key', app(\App\Support\Keys\ProjectKeyGenerator::class)->suggest((string) $state, 3))
+                                fn ($state, Set $set) => $set('key', app(ProjectKeyGenerator::class)->suggest((string) $state, 3))
                             ),
                         Forms\Components\TextInput::make('key')
                             ->required()
                             ->unique(ignoreRecord: true)
-                            ->rule('alpha_num:ascii|min:2|max:10|unique:projects,key')
+                            ->rules(['alpha_num:ascii', 'min:2'])
                             ->maxLength(10)
                             ->regex('/^[A-Z0-9]{2,10}$/')
                             ->helperText('2–10 uppercase A–Z/0–9')
-                            ->formatStateUsing(fn ($state) => \Illuminate\Support\Str::upper($state)),
+                            ->formatStateUsing(fn ($state) => Str::upper($state)),
                         Forms\Components\Textarea::make('description')->rows(4)->columnSpanFull(),
                         Forms\Components\Select::make('stage')
                             ->options(collect(ProjectStage::cases())->mapWithKeys(fn ($c) => [$c->value => ucfirst($c->value)])->all())
@@ -70,7 +63,7 @@ class ProjectForm
                                 Forms\Components\TextInput::make('origin')
                                     ->label('Origin')
                                     ->required()
-                                    ->placeholder('https://example.com')
+                                    ->placeholder('https://example.com'),
                             ])
                             ->addActionLabel('Add origin')
                             ->visible(fn ($get) => $get('public_tracker_enabled') === true)
@@ -80,6 +73,7 @@ class ProjectForm
                                 if (is_array($state) && (count($state) === 0 || is_string(array_values($state)[0]))) {
                                     return collect($state)->map(fn ($item) => ['origin' => $item])->all();
                                 }
+
                                 return $state;
                             })
                             ->dehydrateStateUsing(function ($state) {
@@ -87,6 +81,7 @@ class ProjectForm
                                 if (is_array($state) && (count($state) === 0 || is_array(array_values($state)[0]))) {
                                     return collect($state)->pluck('origin')->filter()->values()->all();
                                 }
+
                                 return $state;
                             }),
                     ])->columns(2),

--- a/app/Filament/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Resources/Users/Schemas/UserForm.php
@@ -44,7 +44,9 @@ final class UserForm
                             ->revealable()
                             ->dehydrated(fn ($state) => filled($state))
                             ->required(fn (?object $record) => $record === null)
-                            ->rule(fn (?object $record) => $record ? 'nullable|confirmed|min:8' : 'required|confirmed|min:8')
+                            ->rules(fn (?object $record) => $record
+                                ? ['nullable', 'confirmed', 'min:8']
+                                : ['required', 'confirmed', 'min:8'])
                             ->mutateDehydratedStateUsing(fn (string $state) => Hash::make($state)),
 
                         TextInput::make('password_confirmation')

--- a/config/ban.php
+++ b/config/ban.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\Ban;
+
 return [
 
     /*
@@ -23,7 +25,7 @@ return [
     |
      */
 
-    'model' => \App\Models\Ban::class,
+    'model' => Ban::class,
 
     /*
     |--------------------------------------------------------------------------
@@ -91,5 +93,28 @@ return [
     |
     */
     'cache_duration' => 120, // Duration in minutes
+
+    /*
+    |--------------------------------------------------------------------------
+    | Package Scheduler
+    |--------------------------------------------------------------------------
+    |
+    | Keep Banhammer's raw auto-scheduler disabled so Forge can schedule its
+    | own wrapper command with transient database DNS handling.
+    |
+    */
+    'scheduler_enabled' => false,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Expired Ban Cleanup Schedule
+    |--------------------------------------------------------------------------
+    |
+    | Forge schedules the expired ban cleanup itself so transient network/DNS
+    | failures can be logged gracefully without masking real query failures.
+    |
+    */
+    'automated_cleanup_enabled' => env('BANHAMMER_SCHEDULER_ENABLED', true),
+    'automated_cleanup_periodicity' => env('BANHAMMER_SCHEDULER_PERIODICITY', 'everyMinute'),
 
 ];

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Console\Commands\CheckForAppUpdate;
+use App\Console\Commands\DeleteExpiredBans;
 use App\Console\Commands\RecalcIssueRollups;
 use App\Console\Commands\ReverbHealthCheck;
 use App\Console\Commands\SendIssueNotificationDigests;
@@ -19,6 +20,17 @@ use Spatie\Health\Commands\RunHealthChecksCommand;
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+if (config('ban.automated_cleanup_enabled', true)) {
+    $scheduledExpiredBanCleanup = Schedule::command(DeleteExpiredBans::class);
+    $periodicity = config('ban.automated_cleanup_periodicity', 'everyMinute');
+
+    if (is_string($periodicity) && method_exists($scheduledExpiredBanCleanup, $periodicity)) {
+        $scheduledExpiredBanCleanup->{$periodicity}();
+    } else {
+        $scheduledExpiredBanCleanup->everyMinute();
+    }
+}
 
 Schedule::command(CheckForAppUpdate::class)
     ->dailyAt('09:00');

--- a/tests/Feature/DeleteExpiredBansCommandTest.php
+++ b/tests/Feature/DeleteExpiredBansCommandTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Console\Commands\DeleteExpiredBans;
+use Illuminate\Console\Command;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use PDOException;
+use Tests\TestCase;
+
+final class DeleteExpiredBansCommandTest extends TestCase
+{
+    public function test_it_logs_transient_database_name_resolution_failures_without_failing(): void
+    {
+        Cache::store('file')->forget(DeleteExpiredBans::TRANSIENT_FAILURE_LOG_CACHE_KEY);
+        Log::spy();
+
+        ExpiredBanCleanupTestModel::$deleteAttempts = 0;
+        ExpiredBanCleanupTestModel::$exception = self::queryException(
+            'SQLSTATE[HY000] [2002] php_network_getaddresses: getaddrinfo for dbaas-db-1505749-do-user-6423046-0.h.db.ondigitalocean.com failed: Temporary failure in name resolution',
+            2002,
+        );
+
+        config(['ban.model' => ExpiredBanCleanupTestModel::class]);
+
+        $this->artisan('bans:delete-expired')
+            ->expectsOutput('Skipped expired ban cleanup: temporary database DNS resolution failure.')
+            ->assertExitCode(Command::SUCCESS);
+
+        $this->artisan('bans:delete-expired')
+            ->expectsOutput('Skipped expired ban cleanup: temporary database DNS resolution failure.')
+            ->assertExitCode(Command::SUCCESS);
+
+        self::assertSame(2, ExpiredBanCleanupTestModel::$deleteAttempts);
+
+        Log::shouldHaveReceived('warning')
+            ->once()
+            ->withArgs(static function (string $message, array $context): bool {
+                return $message === 'Expired ban cleanup skipped because the database host could not be resolved.'
+                    && $context['connection'] === 'mysql'
+                    && $context['exception'] === QueryException::class
+                    && $context['code'] === 2002
+                    && $context['previous_code'] === 2002
+                    && $context['suppressed_for_minutes'] === 30;
+            });
+    }
+
+    public function test_it_rethrows_non_transient_database_failures(): void
+    {
+        ExpiredBanCleanupTestModel::$deleteAttempts = 0;
+        ExpiredBanCleanupTestModel::$exception = self::queryException(
+            'SQLSTATE[42S22]: Column not found: 1054 Unknown column "missing_column" in "where clause"',
+            1054,
+        );
+
+        config(['ban.model' => ExpiredBanCleanupTestModel::class]);
+
+        $this->expectException(QueryException::class);
+
+        app(DeleteExpiredBans::class)->handle();
+    }
+
+    private static function queryException(string $message, int $code): QueryException
+    {
+        return new QueryException(
+            'mysql',
+            'update `bans` set `deleted_at` = ? where `expired_at` is not null',
+            ['2026-04-04 17:37:53'],
+            new PDOException($message, $code),
+            [
+                'driver' => 'mysql',
+                'host' => 'dbaas-db-1505749-do-user-6423046-0.h.db.ondigitalocean.com',
+                'port' => 25060,
+                'database' => 'forge_db',
+            ],
+        );
+    }
+}
+
+final class ExpiredBanCleanupTestModel
+{
+    public static int $deleteAttempts = 0;
+
+    public static PDOException $exception;
+
+    public static function expired(): object
+    {
+        return new class
+        {
+            public function delete(): void
+            {
+                ExpiredBanCleanupTestModel::$deleteAttempts++;
+
+                throw ExpiredBanCleanupTestModel::$exception;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Add a scheduled command and configuration to safely clean up expired bans while improving validation rule definitions and form helpers.

New Features:
- Introduce a DeleteExpiredBans console command to soft-delete expired bans with graceful handling of transient database DNS failures.
- Add configuration flags and schedule wiring to control automated expired-ban cleanup via Laravel's scheduler.

Bug Fixes:
- Adjust project and user form validation rules to use array-based rule definitions for better Filament compatibility and uniqueness handling.

Enhancements:
- Simplify Ban model configuration and key/slug handling using imported classes and helper utilities for improved readability.

Tests:
- Add feature tests covering the DeleteExpiredBans command behavior for transient and non-transient database failures.