### PR TITLE
Add UUID support to `Membership` model and test team membership UUID …

### DIFF
--- a/app/Models/Membership.php
+++ b/app/Models/Membership.php
@@ -2,14 +2,24 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Laravel\Jetstream\Membership as JetstreamMembership;
 
 class Membership extends JetstreamMembership
 {
+    use HasUuids;
+
     /**
      * Indicates if the IDs are auto-incrementing.
      *
      * @var bool
      */
     public $incrementing = false;
+
+    /**
+     * The data type of the primary key ID.
+     *
+     * @var string
+     */
+    protected $keyType = 'string';
 }

--- a/tests/Feature/JetstreamTeamMembershipTest.php
+++ b/tests/Feature/JetstreamTeamMembershipTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\Jetstream\AddTeamMember;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class JetstreamTeamMembershipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_adding_a_team_member_generates_a_team_user_uuid(): void
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::factory()->create([
+            'user_id' => $owner->getKey(),
+            'personal_team' => false,
+        ]);
+
+        app(AddTeamMember::class)->add($owner, $team, $member->email, 'collaborator');
+
+        $membershipId = DB::table('team_user')
+            ->where('team_id', $team->getKey())
+            ->where('user_id', $member->getKey())
+            ->value('id');
+
+        $this->assertTrue(Str::isUuid($membershipId));
+    }
+}


### PR DESCRIPTION
…generation

## Summary by Sourcery

Add UUID-based primary key support to team membership records and verify UUID generation for team_user entries.

New Features:
- Enable UUID primary keys on the Membership model for team-user relationships.

Tests:
- Add a feature test to ensure adding a team member creates a UUID id in the team_user pivot table.