### PR TITLE
Refactor `HealthServiceProvider` to avoid serializing closures in `Qu…

### DIFF
--- a/app/Providers/HealthServiceProvider.php
+++ b/app/Providers/HealthServiceProvider.php
@@ -3,7 +3,6 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Spatie\Health\Facades\Health;
 use Spatie\Health\Checks\Checks\CacheCheck;
 use Spatie\Health\Checks\Checks\DatabaseCheck;
 use Spatie\Health\Checks\Checks\DebugModeCheck;
@@ -12,16 +11,15 @@ use Spatie\Health\Checks\Checks\QueueCheck;
 use Spatie\Health\Checks\Checks\RedisCheck;
 use Spatie\Health\Checks\Checks\ScheduleCheck;
 use Spatie\Health\Checks\Checks\UsedDiskSpaceCheck;
+use Spatie\Health\Facades\Health;
 
 class HealthServiceProvider extends ServiceProvider
 {
-    public function register(): void
-    {
-    }
+    public function register(): void {}
 
     public function boot(): void
     {
-        Health::checks([
+        $checks = [
             DatabaseCheck::new(),
             CacheCheck::new(),
             EnvironmentCheck::new(),
@@ -30,14 +28,18 @@ class HealthServiceProvider extends ServiceProvider
                 ->warnWhenUsedSpaceIsAbovePercentage(75)
                 ->failWhenUsedSpaceIsAbovePercentage(90),
 
-            // Only check queues if not using the sync driver locally.
-            QueueCheck::new()->unless(fn () => config('queue.default') === 'sync'),
-
             // Only add if Redis is configured in your app.
-            //RedisCheck::new()->if(fn () => config('database.redis.default.host') !== null),
+            // RedisCheck::new()->if(fn () => config('database.redis.default.host') !== null),
 
             // Optional but useful if you rely on the scheduler.
             ScheduleCheck::new(),
-        ]);
+        ];
+
+        // Avoid serializing a deferred run-condition closure into HealthQueueJob.
+        if (config('queue.default') !== 'sync') {
+            $checks[] = QueueCheck::new();
+        }
+
+        Health::checks($checks);
     }
 }

--- a/tests/Feature/HealthServiceProviderTest.php
+++ b/tests/Feature/HealthServiceProviderTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Providers\HealthServiceProvider;
+use Spatie\Health\Checks\Checks\QueueCheck;
+use Spatie\Health\Facades\Health;
+use Spatie\Health\Jobs\HealthQueueJob;
+use Tests\TestCase;
+
+class HealthServiceProviderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Health::clearChecks();
+    }
+
+    public function test_health_service_provider_skips_queue_check_when_using_sync_driver(): void
+    {
+        config()->set('queue.default', 'sync');
+
+        $this->bootHealthServiceProvider();
+
+        $this->assertFalse(
+            Health::registeredChecks()->contains(fn ($check) => $check instanceof QueueCheck)
+        );
+    }
+
+    public function test_health_service_provider_registers_serializable_queue_check_for_async_drivers(): void
+    {
+        config()->set('queue.default', 'database');
+
+        $this->bootHealthServiceProvider();
+
+        $queueCheck = Health::registeredChecks()->sole(
+            fn ($check) => $check instanceof QueueCheck
+        );
+
+        $restored = unserialize(serialize(new HealthQueueJob($queueCheck)));
+
+        $this->assertInstanceOf(HealthQueueJob::class, $restored);
+    }
+
+    protected function bootHealthServiceProvider(): void
+    {
+        (new HealthServiceProvider($this->app))->boot();
+    }
+}


### PR DESCRIPTION
…eueCheck`, adjust queue logic, and add tests for sync/async driver behavior.

## Summary by Sourcery

Refactor the health check registration to avoid serializing non-serializable closures in the queued health job and add coverage for queue driver-specific behavior.

Bug Fixes:
- Prevent serialization errors in HealthQueueJob by only registering QueueCheck when using non-sync queue drivers.

Tests:
- Add feature tests verifying that QueueCheck is skipped for the sync driver and is serializable for asynchronous queue drivers.