### PR TITLE
Add `ScheduleCheckHeartbeatCommand` to scheduler, implement test for …

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Facades\Schedule;
 use Spatie\Health\Checks\Checks\QueueCheck;
 use Spatie\Health\Commands\DispatchQueueCheckJobsCommand;
 use Spatie\Health\Commands\RunHealthChecksCommand;
+use Spatie\Health\Commands\ScheduleCheckHeartbeatCommand;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
@@ -48,6 +49,10 @@ Schedule::command(RecalcIssueRollups::class)
 
 Schedule::command(ReverbHealthCheck::class)
     ->everyFiveMinutes();
+
+// Record the scheduler heartbeat before running health checks that depend on it.
+Schedule::command(ScheduleCheckHeartbeatCommand::class)
+    ->everyMinute();
 
 Schedule::command(RunHealthChecksCommand::class)
     ->everyMinute();

--- a/tests/Feature/ConsoleScheduleTest.php
+++ b/tests/Feature/ConsoleScheduleTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Schedule;
+use Spatie\Health\Commands\ScheduleCheckHeartbeatCommand;
+use Tests\TestCase;
+
+class ConsoleScheduleTest extends TestCase
+{
+    public function test_schedule_health_heartbeat_runs_every_minute(): void
+    {
+        $event = collect(app(Schedule::class)->events())->first(
+            fn (Event $event) => str_contains((string) $event->command, ScheduleCheckHeartbeatCommand::class)
+                || str_contains((string) $event->command, 'health:schedule-check-heartbeat')
+        );
+
+        $this->assertNotNull($event);
+        $this->assertSame('* * * * *', $event->expression);
+    }
+}


### PR DESCRIPTION
…cron expression

## Summary by Sourcery

Add a scheduler entry for the health check heartbeat command and verify its cron schedule.

New Features:
- Schedule the ScheduleCheckHeartbeatCommand to run every minute in the application console scheduler.

Tests:
- Add a feature test to assert that the health heartbeat scheduler event is registered with a once-per-minute cron expression.