### PR TITLE
Integrate Crucible repository support: add branch and pull request cr…

### DIFF
--- a/app/Http/Controllers/Api/V1/SystemIssueController.php
+++ b/app/Http/Controllers/Api/V1/SystemIssueController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\IssueResource;
+use App\Models\Issue;
+use App\Models\Project;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Issue listing for machine-to-machine (client credentials) callers.
+ *
+ * Returns issues for a given project, scoped to the Forge user identified
+ * by `for_forge_user_id`. Protected by `client` middleware (Passport).
+ */
+final class SystemIssueController extends Controller
+{
+    public function index(Request $request, Project $project): AnonymousResourceCollection
+    {
+        $user = $this->resolveScopedUser($request);
+
+        abort_if(! $user, Response::HTTP_FORBIDDEN, 'Missing or invalid for_forge_user_id.');
+        abort_unless(
+            Project::query()->visibleTo($user)->whereKey($project->getKey())->exists(),
+            Response::HTTP_NOT_FOUND
+        );
+
+        $q = (string) $request->string('q');
+        $status = (string) $request->string('status');
+        $perPage = min((int) $request->integer('per_page', 25), 100);
+
+        $query = $project->issues()
+            ->with(['status', 'priority', 'type', 'assignee'])
+            ->when($q !== '', fn ($qb) => $qb->where('summary', 'like', "%{$q}%"))
+            ->when($status === 'open', fn ($qb) => $qb->whereHas('status', fn ($sq) => $sq->where('is_done', false)))
+            ->when($status === 'closed', fn ($qb) => $qb->whereHas('status', fn ($sq) => $sq->where('is_done', true)))
+            ->orderByDesc('created_at');
+
+        return IssueResource::collection($query->paginate($perPage));
+    }
+
+    private function resolveScopedUser(Request $request): ?User
+    {
+        $forUserId = $request->string('for_forge_user_id')->toString();
+
+        if ($forUserId === '') {
+            $forUserId = $request->string('for_user')->toString();
+        }
+
+        if ($forUserId === '') {
+            return null;
+        }
+
+        return User::find($forUserId);
+    }
+}

--- a/app/Http/Controllers/Api/V1/SystemOrganizationController.php
+++ b/app/Http/Controllers/Api/V1/SystemOrganizationController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Organization listing for machine-to-machine (client credentials) callers.
+ *
+ * Returns organizations visible to the user identified by `for_forge_user_id`.
+ * Protected by the `client` middleware (Passport client credentials).
+ */
+final class SystemOrganizationController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $user = $this->resolveScopedUser($request);
+
+        if (! $user) {
+            return response()->json(['data' => []]);
+        }
+
+        $q = (string) $request->string('q');
+
+        $orgs = Organization::query()
+            ->visibleTo($user)
+            ->when($q !== '', fn ($qb) => $qb->where('name', 'like', "%{$q}%"))
+            ->orderBy('name')
+            ->get();
+
+        $data = $orgs->map(fn (Organization $org) => [
+            'id' => (string) $org->id,
+            'name' => $org->name,
+            'slug' => $org->slug,
+            'crucible_org_id' => $org->crucible_org_id,
+            'crucible_org_slug' => $org->crucible_org_slug,
+        ]);
+
+        return response()->json(['data' => $data->values()]);
+    }
+
+    public function show(Request $request, Organization $organization): JsonResponse
+    {
+        $user = $this->resolveScopedUser($request);
+
+        abort_if(! $user, Response::HTTP_NOT_FOUND);
+        abort_unless($organization->isAccessibleBy($user), Response::HTTP_NOT_FOUND);
+
+        return response()->json(['data' => [
+            'id' => (string) $organization->id,
+            'name' => $organization->name,
+            'slug' => $organization->slug,
+            'crucible_org_id' => $organization->crucible_org_id,
+            'crucible_org_slug' => $organization->crucible_org_slug,
+        ]]);
+    }
+
+    private function resolveScopedUser(Request $request): ?User
+    {
+        $forUserId = $request->string('for_forge_user_id')->toString();
+
+        if ($forUserId === '') {
+            $forUserId = $request->string('for_user')->toString();
+        }
+
+        if ($forUserId === '') {
+            return null;
+        }
+
+        return User::find($forUserId);
+    }
+}

--- a/app/Livewire/Projects/ConnectRepository.php
+++ b/app/Livewire/Projects/ConnectRepository.php
@@ -227,10 +227,22 @@ final class ConnectRepository extends Component
             ]);
         }
 
-        if (($remote['forge_project_id'] ?? '') !== (string) $this->project->id) {
-            throw ValidationException::withMessages([
-                'provider' => 'This Crucible repository is not linked to this Forge project in Crucible yet. Link it from Crucible first, then connect it here.',
-            ]);
+        // Register the Forge integration on Crucible's side if not already linked.
+        $existingProjectId = $remote['forge_project_id'] ?? '';
+        if ($existingProjectId !== (string) $this->project->id) {
+            try {
+                $service->registerForgeIntegration(
+                    trim($this->owner),
+                    trim($this->name),
+                    (string) $this->project->id,
+                    $this->project->name,
+                    (string) auth()->id(),
+                );
+            } catch (\Throwable $e) {
+                throw ValidationException::withMessages([
+                    'provider' => 'Could not register the integration on Crucible: ' . $e->getMessage(),
+                ]);
+            }
         }
 
         $repo = Repository::query()->updateOrCreate(
@@ -248,9 +260,9 @@ final class ConnectRepository extends Component
                     'repository_name' => $remote['name'] ?? $remote['slug'],
                     'repository_slug' => $remote['slug'],
                     'web_url' => $remote['web_url'] ?? null,
-                    'forge_project_id' => $remote['forge_project_id'] ?? null,
-                    'forge_project_name' => $remote['forge_project_name'] ?? null,
-                    'forge_url' => $remote['forge_url'] ?? null,
+                    'forge_project_id' => (string) $this->project->id,
+                    'forge_project_name' => $this->project->name,
+                    'forge_url' => config('app.url'),
                     'visibility' => $remote['visibility'] ?? null,
                     'vcs_type' => $remote['vcs_type'] ?? null,
                 ],

--- a/app/Models/Organization.php
+++ b/app/Models/Organization.php
@@ -31,7 +31,7 @@ class Organization extends BaseModel
     protected $casts = ['id' => 'string'];
 
     /** @var array<int, string> */
-    protected $fillable = ['name', 'slug'];
+    protected $fillable = ['name', 'slug', 'crucible_org_id', 'crucible_org_slug'];
 
     public function projects(): HasMany
     {

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -72,7 +72,7 @@ class Repository extends BaseModel
 
     public function supportsVcsCreation(): bool
     {
-        return strtolower((string) $this->provider) === 'github';
+        return in_array(strtolower((string) $this->provider), ['github', 'crucible'], true);
     }
 
     public function displayPath(): string

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -63,6 +63,7 @@ class AuthServiceProvider extends ServiceProvider
             'codex:read'        => 'Read Codex workspaces and pages on your behalf',
             // Forge API token scopes (used by Jetstream PATs)
             'projects:read'     => 'Read projects',
+            'organizations:read' => 'Read organizations',
             'issues:read'       => 'Read issues',
             'issues:write'      => 'Create and update issues',
             'comments:write'    => 'Post comments',

--- a/app/Providers/CrucibleRepositoryProvider.php
+++ b/app/Providers/CrucibleRepositoryProvider.php
@@ -5,7 +5,6 @@ namespace App\Providers;
 use App\Contracts\RepositoryProviderInterface;
 use App\Models\Repository;
 use App\Services\CrucibleService;
-use RuntimeException;
 
 final class CrucibleRepositoryProvider implements RepositoryProviderInterface
 {
@@ -40,7 +39,7 @@ final class CrucibleRepositoryProvider implements RepositoryProviderInterface
 
     public function createBranch(Repository $repository, string $token, string $newBranch, ?string $fromRef = null): array
     {
-        throw new RuntimeException('Create branch is not available from Forge for Crucible repositories yet.');
+        return $this->crucible->createBranch($repository, $newBranch, $fromRef, $token);
     }
 
     public function createPullRequest(
@@ -51,7 +50,7 @@ final class CrucibleRepositoryProvider implements RepositoryProviderInterface
         string $base,
         ?string $body = null
     ): array {
-        throw new RuntimeException('Open pull request is not available from Forge for Crucible repositories yet.');
+        return $this->crucible->createPullRequest($repository, $title, $head, $base, $body, $token);
     }
 
     public function getDefaultBranch(Repository $repository, string $token): string

--- a/app/Services/CrucibleService.php
+++ b/app/Services/CrucibleService.php
@@ -166,6 +166,134 @@ final class CrucibleService
     }
 
     /**
+     * Create a branch on a Crucible repository.
+     *
+     * @return array{name: string, url: string|null}
+     */
+    public function createBranch(Repository $repository, string $branchName, ?string $fromRef, string $forForgeUserId, ?string $forgeIssueKey = null): array
+    {
+        if (! $this->isConfigured()) {
+            throw new RuntimeException('Crucible integration is not configured.');
+        }
+
+        $url = sprintf(
+            '%s/api/v1/%s/%s/branches',
+            $this->baseUrl(),
+            rawurlencode((string) $repository->owner),
+            rawurlencode((string) $repository->name),
+        );
+
+        $payload = array_filter([
+            'name' => $branchName,
+            'from_ref' => $fromRef,
+            'forge_issue_key' => $forgeIssueKey,
+            'for_forge_user_id' => $forForgeUserId,
+        ], static fn (mixed $v): bool => $v !== null && $v !== '');
+
+        $response = $this->client()->post($url, $payload);
+
+        if ($response->failed()) {
+            throw new RuntimeException(
+                'Crucible branch creation failed (HTTP ' . $response->status() . '): '
+                . substr((string) $response->body(), 0, 300)
+            );
+        }
+
+        $data = $response->json('data') ?? $response->json();
+
+        return [
+            'name' => (string) ($data['name'] ?? $branchName),
+            'url' => $data['url'] ?? null,
+        ];
+    }
+
+    /**
+     * Create a pull request on a Crucible repository.
+     *
+     * @return array{number: int|null, title: string, state: string, url: string|null}
+     */
+    public function createPullRequest(Repository $repository, string $title, string $head, string $base, ?string $body, string $forForgeUserId, ?string $forgeIssueKey = null): array
+    {
+        if (! $this->isConfigured()) {
+            throw new RuntimeException('Crucible integration is not configured.');
+        }
+
+        $url = sprintf(
+            '%s/api/v1/%s/%s/pull-requests',
+            $this->baseUrl(),
+            rawurlencode((string) $repository->owner),
+            rawurlencode((string) $repository->name),
+        );
+
+        $payload = array_filter([
+            'title' => $title,
+            'head' => $head,
+            'base' => $base,
+            'body' => $body,
+            'forge_issue_key' => $forgeIssueKey,
+            'for_forge_user_id' => $forForgeUserId,
+        ], static fn (mixed $v): bool => $v !== null && $v !== '');
+
+        $response = $this->client()->post($url, $payload);
+
+        if ($response->failed()) {
+            throw new RuntimeException(
+                'Crucible pull request creation failed (HTTP ' . $response->status() . '): '
+                . substr((string) $response->body(), 0, 300)
+            );
+        }
+
+        $data = $response->json('data') ?? $response->json();
+
+        return [
+            'number' => isset($data['number']) ? (int) $data['number'] : null,
+            'title' => (string) ($data['title'] ?? $title),
+            'state' => (string) ($data['state'] ?? 'open'),
+            'url' => $data['url'] ?? null,
+        ];
+    }
+
+    /**
+     * Register a Forge integration on a Crucible repository.
+     *
+     * Calls Crucible's POST /{org}/{repo}/forge-integration endpoint to create
+     * or update the ForgeIntegration record, removing the need to configure the
+     * link from the Crucible side first.
+     *
+     * @return array{id: string, api_token: string|null}|null
+     */
+    public function registerForgeIntegration(string $organizationSlug, string $repositorySlug, string $forgeProjectId, string $forgeProjectName, string $forForgeUserId): ?array
+    {
+        if (! $this->isConfigured()) {
+            return null;
+        }
+
+        $url = sprintf(
+            '%s/api/v1/%s/%s/forge-integration',
+            $this->baseUrl(),
+            rawurlencode($organizationSlug),
+            rawurlencode($repositorySlug),
+        );
+
+        $response = $this->client()
+            ->post($url, array_filter([
+                'forge_project_id' => $forgeProjectId,
+                'forge_project_name' => $forgeProjectName,
+                'forge_url' => config('app.url'),
+                'for_forge_user_id' => $forForgeUserId,
+            ]));
+
+        if ($response->failed()) {
+            throw new RuntimeException(
+                'Crucible integration registration failed (HTTP ' . $response->status() . '): '
+                . substr((string) $response->body(), 0, 300)
+            );
+        }
+
+        return $response->json('data');
+    }
+
+    /**
      * @return array<string, mixed>
      */
     private function fetchIndexPage(int $page = 1, string $query = '', string $forForgeUserId = ''): array

--- a/database/migrations/2026_04_10_100000_add_crucible_org_fields_to_organizations_table.php
+++ b/database/migrations/2026_04_10_100000_add_crucible_org_fields_to_organizations_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->string('crucible_org_id')->nullable()->unique()->after('slug');
+            $table->string('crucible_org_slug')->nullable()->after('crucible_org_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('organizations', function (Blueprint $table) {
+            $table->dropUnique(['crucible_org_id']);
+            $table->dropColumn(['crucible_org_id', 'crucible_org_slug']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Http\Controllers\Api\V1;
+use App\Http\Controllers\Api\V1\SystemIssueController;
+use App\Http\Controllers\Api\V1\SystemOrganizationController;
 use App\Http\Controllers\Api\V1\SystemProjectController;
 use App\Http\Controllers\Webhooks\GitHubWebhookController;
 use Illuminate\Http\Request;
@@ -41,6 +43,10 @@ Route::prefix('v1')->name('api.v1.')->group(function () {
 Route::prefix('v1/system')->name('api.v1.system.')->middleware(['client:projects:read', 'throttle:api'])->group(function (): void {
     Route::get('projects', [SystemProjectController::class, 'index'])->name('projects.index');
     Route::get('projects/{project}', [SystemProjectController::class, 'show'])->name('projects.show');
+    Route::get('projects/{project}/issues', [SystemIssueController::class, 'index'])->name('projects.issues.index');
+
+    Route::get('organizations', [SystemOrganizationController::class, 'index'])->name('organizations.index');
+    Route::get('organizations/{organization}', [SystemOrganizationController::class, 'show'])->name('organizations.show');
 });
 
 /*


### PR DESCRIPTION
…eation, organization visibility APIs, Forge integration registration, and related database/migration updates.

## Summary by Sourcery

Integrate Crucible repositories more deeply by enabling branch and pull request creation, auto-registering Forge integrations, and exposing organization and issue data via new system APIs.

New Features:
- Allow creating branches and pull requests on Crucible repositories from Forge.
- Automatically register Crucible Forge integrations when connecting a Crucible repository to a project.
- Expose machine-to-machine API endpoints for listing organizations and fetching organization details, including Crucible metadata.
- Expose machine-to-machine API endpoint for listing project issues filtered and scoped to a specific Forge user.
- Allow repositories backed by Crucible to support VCS resource creation similar to GitHub.

Enhancements:
- Persist Crucible organization identifiers on Organization records via new database fields and migration.
- Adjust Crucible repository linking to always store Forge project linkage details from Forge rather than relying on remote values.
- Add an OAuth scope description for reading organizations through the API.