### PR TITLE
Add `TeamMemberManager` Livewire component, improve team role managem…

### DIFF
--- a/app/Livewire/Teams/TeamMemberManager.php
+++ b/app/Livewire/Teams/TeamMemberManager.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Livewire\Teams;
+
+use Laravel\Jetstream\Http\Livewire\TeamMemberManager as JetstreamTeamMemberManager;
+use Laravel\Jetstream\Jetstream;
+
+class TeamMemberManager extends JetstreamTeamMemberManager
+{
+    /**
+     * Allow the given user's role to be managed, even if their membership role is missing.
+     *
+     * @param  int  $userId
+     */
+    public function manageRole($userId): void
+    {
+        $this->currentlyManagingRole = true;
+        $this->managingRoleFor = Jetstream::findUserByIdOrFail($userId);
+        $this->currentRole = $this->managingRoleFor->teamRole($this->team)?->key ?? $this->defaultRoleKey();
+    }
+
+    public function roleName(?string $roleKey): ?string
+    {
+        if ($roleKey === null || $roleKey === '') {
+            return null;
+        }
+
+        return Jetstream::findRole($roleKey)?->name;
+    }
+
+    protected function defaultRoleKey(): string
+    {
+        return (string) collect($this->roles)->first()?->key;
+    }
+}

--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -9,6 +9,7 @@ use App\Actions\Jetstream\DeleteUser;
 use App\Actions\Jetstream\InviteTeamMember;
 use App\Actions\Jetstream\RemoveTeamMember;
 use App\Actions\Jetstream\UpdateTeamName;
+use App\Livewire\Teams\TeamMemberManager;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Jetstream\Jetstream;
 use Livewire\Livewire;
@@ -31,6 +32,7 @@ class JetstreamServiceProvider extends ServiceProvider
         $this->configurePermissions();
         Livewire::component('profile.update-profile-information-form', \App\Livewire\Profile\UpdateProfileInformationForm::class);
         Livewire::component('api.api-token-manager', \App\Livewire\ApiTokenManager::class);
+        Livewire::component('teams.team-member-manager', TeamMemberManager::class);
 
         Jetstream::createTeamsUsing(CreateTeam::class);
         Jetstream::updateTeamNamesUsing(UpdateTeamName::class);

--- a/resources/views/teams/team-member-manager.blade.php
+++ b/resources/views/teams/team-member-manager.blade.php
@@ -23,7 +23,7 @@
                     @if (count($this->roles) > 0)
                         <div class="col-12">
                             <label class="form-label">{{ __('Role') }}</label>
-                            @error('role') <div class="text-danger small mb-1">{{ $message }}</div> @enderror>
+                            @error('role') <div class="text-danger small mb-1">{{ $message }}</div> @enderror
 
                             <div class="list-group">
                                 @foreach ($this->roles as $role)
@@ -104,6 +104,7 @@
 
                 <div class="d-grid gap-2">
                     @foreach ($team->users->sortBy('name') as $user)
+                        @php($roleName = $this->roleName($user->membership->role))
                         <div class="d-flex align-items-center justify-content-between border rounded px-3 py-2">
                             <div class="d-flex align-items-center gap-2">
                                 <x-avatar :src="$user->profile_photo_url" :name="$user->name" preset="sm" />
@@ -114,11 +115,11 @@
                                 @if (Gate::check('updateTeamMember', $team) && Laravel\Jetstream\Jetstream::hasRoles())
                                     <button type="button" class="btn btn-link p-0"
                                             wire:click="manageRole('{{ $user->id }}')">
-                                        {{ Laravel\Jetstream\Jetstream::findRole($user->membership->role)->name }}
+                                        {{ $roleName ?? __('Assign role') }}
                                     </button>
                                 @elseif (Laravel\Jetstream\Jetstream::hasRoles())
                                     <div class="text-body-secondary small">
-                                        {{ Laravel\Jetstream\Jetstream::findRole($user->membership->role)->name }}
+                                        {{ $roleName ?? __('No role assigned') }}
                                     </div>
                                 @endif
 

--- a/tests/Feature/JetstreamTeamMembershipTest.php
+++ b/tests/Feature/JetstreamTeamMembershipTest.php
@@ -3,11 +3,14 @@
 namespace Tests\Feature;
 
 use App\Actions\Jetstream\AddTeamMember;
+use App\Livewire\Teams\TeamMemberManager;
 use App\Models\Team;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Laravel\Jetstream\Jetstream;
+use Livewire\Livewire;
 use Tests\TestCase;
 
 class JetstreamTeamMembershipTest extends TestCase
@@ -31,5 +34,39 @@ class JetstreamTeamMembershipTest extends TestCase
             ->value('id');
 
         $this->assertTrue(Str::isUuid($membershipId));
+    }
+
+    public function test_team_member_manager_renders_members_with_missing_roles(): void
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::factory()->create([
+            'user_id' => $owner->getKey(),
+            'personal_team' => false,
+        ]);
+
+        $team->users()->attach($member, ['role' => null]);
+
+        Livewire::actingAs($owner)
+            ->test(TeamMemberManager::class, ['team' => $team])
+            ->assertSee('Assign role');
+    }
+
+    public function test_manage_role_defaults_to_the_first_configured_role_when_membership_role_is_missing(): void
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::factory()->create([
+            'user_id' => $owner->getKey(),
+            'personal_team' => false,
+        ]);
+
+        $team->users()->attach($member, ['role' => null]);
+
+        Livewire::actingAs($owner)
+            ->test(TeamMemberManager::class, ['team' => $team])
+            ->call('manageRole', $member->getKey())
+            ->assertSet('currentlyManagingRole', true)
+            ->assertSet('currentRole', collect(Jetstream::$roles)->keys()->first());
     }
 }


### PR DESCRIPTION
…ent, and test missing role handling

## Summary by Sourcery

Introduce a custom TeamMemberManager Livewire component to make team role management resilient to missing membership roles and wire it into Jetstream.

Bug Fixes:
- Handle team members with missing or null membership roles without errors and display appropriate fallback labels in the team member list.

Enhancements:
- Override role management to default to the first configured role when a member’s role is missing.
- Register the new TeamMemberManager Livewire component in the Jetstream service provider and adjust the team member manager view to use safe role name resolution and clearer messaging.

Tests:
- Add feature tests ensuring the team member manager renders members with missing roles and defaults managed roles to the first configured role.