### PR TITLE
Introduce resilient session handling and adjust Redis setup for TLS s…

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use App\Models\PermissionSet;
 use App\Models\PersonalAccessToken;
 use App\Models\Project;
 use App\Models\Role;
+use App\Session\ResilientSessionManager;
 use App\Observers\CommentObserver;
 use App\Observers\IssueObserver;
 use App\Observers\PermissionSetObserver;
@@ -17,9 +18,12 @@ use App\Observers\RoleObserver;
 use Dedoc\Scramble\Scramble;
 use Dedoc\Scramble\Support\Generator\OpenApi;
 use Dedoc\Scramble\Support\Generator\SecurityScheme;
+use Illuminate\Contracts\Cache\Factory as CacheFactory;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\Session\SessionManager;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
@@ -37,6 +41,28 @@ class AppServiceProvider extends ServiceProvider
         if (class_exists(TelescopeServiceProvider::class) && $this->app->environment('local')) {
             $this->app->register(TelescopeServiceProvider::class);
         }
+
+        $this->app->singleton(ResilientSessionManager::class, function ($app) {
+            return new ResilientSessionManager($app);
+        });
+
+        $this->app->singleton(SessionManager::class, function ($app) {
+            return $app->make(ResilientSessionManager::class);
+        });
+
+        $this->app->singleton('session', function ($app) {
+            return $app->make(ResilientSessionManager::class);
+        });
+
+        $this->app->singleton('session.store', function ($app) {
+            return $app->make('session')->driver();
+        });
+
+        $this->app->singleton(StartSession::class, function ($app) {
+            return new StartSession($app->make(SessionManager::class), function () use ($app) {
+                return $app->make(CacheFactory::class);
+            });
+        });
 
         $this->app->bind(RepositoryProviderInterface::class, GitHubRepositoryProvider::class);
     }

--- a/app/Session/Concerns/RecoversCorruptSessionPayloads.php
+++ b/app/Session/Concerns/RecoversCorruptSessionPayloads.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Session\Concerns;
+
+use Throwable;
+
+trait RecoversCorruptSessionPayloads
+{
+    /**
+     * Read the session payload, dropping corrupted or incompatible payloads.
+     */
+    protected function readFromHandler()
+    {
+        try {
+            return parent::readFromHandler();
+        } catch (Throwable $exception) {
+            report($exception);
+
+            try {
+                $this->handler->destroy($this->getId());
+            } catch (Throwable $destroyException) {
+                report($destroyException);
+            }
+
+            // Force a fresh session identifier so the broken payload is not reused.
+            $this->setId(null);
+
+            return [];
+        }
+    }
+}

--- a/app/Session/ResilientEncryptedStore.php
+++ b/app/Session/ResilientEncryptedStore.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Session;
+
+use App\Session\Concerns\RecoversCorruptSessionPayloads;
+use Illuminate\Session\EncryptedStore;
+
+class ResilientEncryptedStore extends EncryptedStore
+{
+    use RecoversCorruptSessionPayloads;
+}

--- a/app/Session/ResilientSessionManager.php
+++ b/app/Session/ResilientSessionManager.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Session;
+
+use Illuminate\Session\SessionManager;
+
+class ResilientSessionManager extends SessionManager
+{
+    /**
+     * Build the session instance.
+     *
+     * @param  \SessionHandlerInterface  $handler
+     */
+    protected function buildSession($handler)
+    {
+        return $this->config->get('session.encrypt')
+            ? $this->buildEncryptedSession($handler)
+            : new ResilientStore(
+                $this->config->get('session.cookie'),
+                $handler,
+                $id = null,
+                $this->config->get('session.serialization', 'php')
+            );
+    }
+
+    /**
+     * Build the encrypted session instance.
+     *
+     * @param  \SessionHandlerInterface  $handler
+     */
+    protected function buildEncryptedSession($handler)
+    {
+        return new ResilientEncryptedStore(
+            $this->config->get('session.cookie'),
+            $handler,
+            $this->container['encrypter'],
+            $id = null,
+            $this->config->get('session.serialization', 'php'),
+        );
+    }
+}

--- a/app/Session/ResilientStore.php
+++ b/app/Session/ResilientStore.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Session;
+
+use App\Session\Concerns\RecoversCorruptSessionPayloads;
+use Illuminate\Session\Store;
+
+class ResilientStore extends Store
+{
+    use RecoversCorruptSessionPayloads;
+}

--- a/config/database.php
+++ b/config/database.php
@@ -143,7 +143,10 @@ return [
 
     'redis' => [
 
-        'client' => env('REDIS_CLIENT', 'phpredis'),
+        // DigitalOcean Managed Valkey requires TLS with phpredis.
+        'client' => env('REDIS_SCHEME', 'tls') === 'tls'
+            ? 'phpredis'
+            : env('REDIS_CLIENT', 'phpredis'),
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),

--- a/tests/Feature/RedisAndSessionResilienceTest.php
+++ b/tests/Feature/RedisAndSessionResilienceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Session\ResilientStore;
+use SessionHandlerInterface;
+use Tests\TestCase;
+
+class RedisAndSessionResilienceTest extends TestCase
+{
+    public function test_tls_redis_defaults_to_phpredis_client(): void
+    {
+        $this->assertSame('phpredis', config('database.redis.client'));
+    }
+
+    public function test_corrupt_session_payloads_are_dropped_instead_of_crashing(): void
+    {
+        $initialSessionId = str_repeat('a', 40);
+        $handler = new CorruptPayloadSessionHandler($this->corruptTypedPropertySessionPayload());
+        $store = new ResilientStore('forge_session', $handler, $initialSessionId);
+
+        $store->start();
+
+        $this->assertNull($store->get('test'));
+        $this->assertContains($initialSessionId, $handler->destroyedSessionIds);
+        $this->assertNotSame($initialSessionId, $store->getId());
+        $this->assertTrue($store->has('_token'));
+    }
+
+    private function corruptTypedPropertySessionPayload(): string
+    {
+        $serializedObject = sprintf(
+            'O:%d:"%s":1:{s:5:"value";N;}',
+            strlen(CorruptTypedStringHolder::class),
+            CorruptTypedStringHolder::class
+        );
+
+        return sprintf('a:1:{s:4:"test";%s}', $serializedObject);
+    }
+}
+
+class CorruptTypedStringHolder
+{
+    public string $value;
+}
+
+class CorruptPayloadSessionHandler implements SessionHandlerInterface
+{
+    /**
+     * @param  list<string>  $destroyedSessionIds
+     */
+    public function __construct(
+        private readonly string $payload,
+        public array $destroyedSessionIds = [],
+    ) {}
+
+    public function open($savePath, $sessionName): bool
+    {
+        return true;
+    }
+
+    public function close(): bool
+    {
+        return true;
+    }
+
+    public function read($id): string
+    {
+        return $this->payload;
+    }
+
+    public function write($id, $data): bool
+    {
+        return true;
+    }
+
+    public function destroy($id): bool
+    {
+        $this->destroyedSessionIds[] = $id;
+
+        return true;
+    }
+
+    public function gc($max_lifetime): int|false
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
…upport

- Add `ResilientSessionManager`, `ResilientStore`, and `ResilientEncryptedStore` to prevent crashes from corrupt session payloads.
- Use `RecoversCorruptSessionPayloads` trait to drop invalid payloads and reset session IDs.
- Enhance Redis configuration to default to `phpredis` for TLS connections (`REDIS_SCHEME` check).
- Update `AppServiceProvider` to use resilient session classes.
- Include tests for session resilience and TLS Redis configuration.

## Summary by Sourcery

Introduce resilient Laravel session handling and adjust Redis configuration defaults for TLS deployments.

New Features:
- Add resilient session manager and store implementations that recover gracefully from corrupt or incompatible session payloads.

Enhancements:
- Bind the application session services to use resilient session classes via the service container.
- Adjust Redis configuration so TLS (`REDIS_SCHEME=tls`) defaults to the `phpredis` client, suitable for managed Valkey/Redis setups.

Tests:
- Add feature tests covering TLS Redis client defaulting and resilience when encountering corrupt session payloads.