### PR TITLE
fixes from dev

### DIFF
--- a/app/Filament/Resources/OAuthClients/Pages/CreateOAuthClient.php
+++ b/app/Filament/Resources/OAuthClients/Pages/CreateOAuthClient.php
@@ -22,7 +22,18 @@ class CreateOAuthClient extends CreateRecord
 
     protected function afterCreate(): void
     {
-        $secret = $this->record->secret;
+        $secret = $this->record->plainSecret;
+
+        if (! filled($secret)) {
+            \Filament\Notifications\Notification::make()
+                ->title('Client Created')
+                ->body('The client was created, but the plaintext secret is no longer available. Rotate the secret to generate a new one.')
+                ->danger()
+                ->persistent()
+                ->send();
+
+            return;
+        }
 
         \Filament\Notifications\Notification::make()
             ->title('Client Created — Copy Your Secret')

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -132,14 +132,14 @@ class Project extends BaseModel
 
     public function setting(string $key, mixed $default = null): mixed
     {
-        $merged = array_replace_recursive($this->defaultSettings(), $this->settings ?? []);
+        $merged = array_replace_recursive($this->defaultSettings(), $this->normalizedSettings());
 
         return Arr::get($merged, $key, $default);
     }
 
     public function setSetting(string $key, mixed $value): static
     {
-        $settings = $this->settings ?? [];
+        $settings = $this->normalizedSettings();
         Arr::set($settings, $key, $value);
         $this->settings = $settings;
 
@@ -148,9 +148,28 @@ class Project extends BaseModel
 
     public function updateSettings(array $values): static
     {
-        $this->settings = array_replace_recursive($this->settings ?? [], $values);
+        $this->settings = array_replace_recursive($this->normalizedSettings(), $values);
 
         return $this;
+    }
+
+    private function normalizedSettings(): array
+    {
+        $settings = $this->settings;
+
+        if (is_array($settings)) {
+            return $settings;
+        }
+
+        if (is_string($settings) && in_array($settings, ['story_points', 'estimate_minutes'], true)) {
+            return [
+                'issues' => [
+                    'estimate_unit' => $settings,
+                ],
+            ];
+        }
+
+        return [];
     }
 
     public function getActivitylogOptions(): LogOptions

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -54,6 +54,9 @@ class AuthServiceProvider extends ServiceProvider
         $this->register();
         $this->registerPolicies();
 
+        // Passport 13 expects the authorization response contract to be bound explicitly.
+        Passport::authorizationView('vendor.passport.authorize');
+
         //Passport::setClientUuids(true); No longer needed, this is now the default in newer Passport versions
         Passport::tokensExpireIn(now()->addDays(15));
         Passport::refreshTokensExpireIn(now()->addDays(30));

--- a/resources/views/vendor/passport/authorize.blade.php
+++ b/resources/views/vendor/passport/authorize.blade.php
@@ -67,7 +67,7 @@
                     </div>
 
                     <p class="text-body-secondary text-center mt-3 mb-0" style="font-size: 0.78rem;">
-                        {{ __('You are logged in as :name (:email)', ['name' => auth()->user()->name, 'email' => auth()->user()->email]) }}
+                        {{ __('You are logged in as :name (:email)', ['name' => $user->name, 'email' => $user->email]) }}
                     </p>
 
                 </div>

--- a/tests/Feature/PassportIntegrationTest.php
+++ b/tests/Feature/PassportIntegrationTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Filament\Resources\OAuthClients\Pages\CreateOAuthClient;
+use App\Models\Permission;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Filament\Notifications\Notification as FilamentNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Laravel\Passport\Client;
+use Laravel\Passport\Contracts\AuthorizationViewResponse;
+use Livewire\Livewire;
+use Spatie\Permission\PermissionRegistrar;
+use Tests\TestCase;
+
+class PassportIntegrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_passport_authorization_view_response_renders_the_custom_authorization_view(): void
+    {
+        $this->withoutVite();
+
+        $user = User::factory()->create();
+        $client = Client::query()->create([
+            'name' => 'Crucible SSO',
+            'secret' => 'top-secret-value',
+            'provider' => 'users',
+            'redirect' => 'https://crucible.test/oauth/callback',
+            'redirect_uris' => ['https://crucible.test/oauth/callback'],
+            'grant_types' => ['authorization_code', 'refresh_token'],
+            'revoked' => false,
+        ]);
+
+        $request = Request::create('/oauth/authorize', 'GET', ['state' => 'test-state']);
+
+        $response = app(AuthorizationViewResponse::class)
+            ->withParameters([
+                'client' => $client,
+                'user' => $user,
+                'scopes' => [],
+                'request' => $request,
+                'authToken' => 'test-auth-token',
+            ])
+            ->toResponse($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Authorization Request', $response->getContent());
+        $this->assertStringContainsString('Crucible SSO', $response->getContent());
+        $this->assertStringContainsString($user->email, $response->getContent());
+    }
+
+    public function test_creating_an_oauth_client_notifies_with_the_plaintext_secret(): void
+    {
+        $user = $this->makePanelUser();
+
+        Filament::setCurrentPanel('admin');
+
+        $component = Livewire::actingAs($user)
+            ->test(CreateOAuthClient::class)
+            ->fillForm([
+                'name' => 'Crucible SSO',
+                'redirect' => 'https://crucible.test/oauth/callback',
+                'revoked' => false,
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors()
+            ->assertRedirect();
+
+        $client = Client::query()->where('name', 'Crucible SSO')->firstOrFail();
+        $secret = $component->instance()->record->plainSecret;
+
+        $this->assertNotNull($secret);
+        $this->assertTrue(Hash::isHashed($client->getRawOriginal('secret')));
+        $this->assertTrue(Hash::check($secret, $client->getRawOriginal('secret')));
+
+        $component->assertNotified(
+            FilamentNotification::make()
+                ->title('Client Created — Copy Your Secret')
+                ->body("Client Secret: {$secret}\n\nThis secret will not be shown again. Store it securely in your Codex FORGE_CLIENT_SECRET environment variable.")
+                ->warning()
+                ->persistent()
+        );
+    }
+
+    private function makePanelUser(): User
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $user = User::factory()->create();
+        $team = Team::factory()->create([
+            'user_id' => $user->id,
+            'personal_team' => true,
+        ]);
+
+        $user->forceFill(['current_team_id' => $team->id])->save();
+
+        Permission::firstOrCreate([
+            'name' => 'is-super-admin',
+            'guard_name' => 'web',
+        ]);
+
+        app(PermissionRegistrar::class)->setPermissionsTeamId($team->id);
+        $user->givePermissionTo('is-super-admin');
+        app(PermissionRegistrar::class)->setPermissionsTeamId(null);
+
+        return $user;
+    }
+}

--- a/tests/Feature/ProjectBacklogTest.php
+++ b/tests/Feature/ProjectBacklogTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Livewire\Projects\ProjectBacklog;
 use App\Models\Issue;
 use App\Models\IssuePriority;
 use App\Models\IssueStatus;
@@ -91,6 +92,28 @@ class ProjectBacklogTest extends TestCase
             'id' => $sprint->id,
             'capacity' => 21,
         ]);
+    }
+
+    public function test_it_mounts_with_legacy_scalar_project_settings(): void
+    {
+        [, $project] = $this->projectContext();
+
+        DB::table('projects')
+            ->where('id', $project->id)
+            ->update(['settings' => json_encode('estimate_minutes')]);
+
+        $component = app(ProjectBacklog::class);
+        $component->project = $project->fresh();
+
+        $setPlanningUnit = \Closure::bind(function (): void {
+            $this->setPlanningUnit();
+        }, $component, ProjectBacklog::class);
+
+        $setPlanningUnit();
+
+        $this->assertSame('estimate_minutes', $component->planningUnit);
+        $this->assertSame('Estimated time', $component->planningUnitLabel);
+        $this->assertSame('min', $component->planningUnitShort);
     }
 
     /**

--- a/tests/Feature/ProjectSettingsTest.php
+++ b/tests/Feature/ProjectSettingsTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Project;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ProjectSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_normalizes_legacy_scalar_settings_when_reading_and_updating(): void
+    {
+        $project = Project::factory()->create();
+
+        DB::table('projects')
+            ->where('id', $project->id)
+            ->update(['settings' => json_encode('estimate_minutes')]);
+
+        $project = $project->fresh();
+
+        $this->assertSame('estimate_minutes', $project->setting('issues.estimate_unit'));
+
+        $project->updateSettings([
+            'sprints' => [
+                'velocity_target' => 21,
+            ],
+        ]);
+        $project->save();
+        $project->refresh();
+
+        $this->assertSame('estimate_minutes', $project->setting('issues.estimate_unit'));
+        $this->assertSame(21, $project->setting('sprints.velocity_target'));
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Normalize legacy project settings and improve OAuth/Passport integration behavior and coverage.

Bug Fixes:
- Ensure project settings methods handle legacy scalar settings by normalizing them to the current nested structure.
- Handle cases where an OAuth client secret plaintext value is not available by showing an appropriate notification instead of assuming it exists.
- Bind Laravel Passport's authorization view explicitly so the custom authorization page is correctly rendered.

Enhancements:
- Introduce a normalization helper on the Project model to provide a consistent settings array for reading and updating settings.
- Update OAuth client creation flow to use the plaintext secret value for user notifications.

Tests:
- Add feature tests covering normalization of legacy project settings when reading and updating.
- Add a backlog component test to verify mounting behavior with legacy scalar project settings.
- Add Passport integration tests for the custom authorization view and OAuth client creation notifications.