### PR TITLE
Update middleware alias in bootstrap to use `CheckToken` instead of `…

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -26,7 +26,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'ingest.key'        => VerifyIngestKey::class,
             'auth.registration' => EnsureRegistrationIsEnabled::class,
             // Validates client credentials tokens (machine-to-machine OAuth2)
-            'client'            => \Laravel\Passport\Http\Middleware\CheckClientCredentials::class,
+            'client'            => \Laravel\Passport\Http\Middleware\CheckToken::class,
         ]);
         $middleware->group('api', [
             EnsureFrontendRequestsAreStateful::class,


### PR DESCRIPTION
…CheckClientCredentials`

## Summary by Sourcery

Enhancements:
- Align the 'client' middleware alias with Laravel Passport's CheckToken middleware for token validation.