### PR TITLE
Deprecate `AppHealthServiceProvider` in favor of `HealthServiceProvid…

### DIFF
--- a/app/Providers/AppHealthServiceProvider.php
+++ b/app/Providers/AppHealthServiceProvider.php
@@ -3,53 +3,18 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Spatie\CpuLoadHealthCheck\CpuLoadCheck;
-use Spatie\Health\Checks\Checks\CacheCheck;
-use Spatie\Health\Checks\Checks\DatabaseCheck;
-use Spatie\Health\Checks\Checks\OptimizedAppCheck;
-use Spatie\Health\Checks\Checks\QueueCheck;
-use Spatie\Health\Checks\Checks\UsedDiskSpaceCheck;
-use Spatie\Health\Facades\Health;
-use Spatie\SecurityAdvisoriesHealthCheck\SecurityAdvisoriesCheck;
 
 class AppHealthServiceProvider extends ServiceProvider
 {
-    /**
-     * Register services.
-     */
     public function register(): void
     {
         //
     }
 
-    /**
-     * Bootstrap services.
-     */
     public function boot(): void
     {
-        $this->app->booted(function (): void {
-            Health::checks([
-                CacheCheck::new()
-                    ->everyFifteenMinutes()
-                    ->name('Cache Check'),
-                OptimizedAppCheck::new()
-                    ->everyThirtyMinutes()
-                    ->name('Check Optimization'),
-                UsedDiskSpaceCheck::new()
-                    ->daily()
-                    ->name('Check Used DiskSpace'),
-                DatabaseCheck::new()
-                    ->name('Check Database Connection')
-                    ->everyMinute(),
-                QueueCheck::new()
-                    ->everyFiveMinutes()
-                    ->name('Check Job Queue'),
-                CpuLoadCheck::new()
-                    ->failWhenLoadIsHigherInTheLast5Minutes(2.0)
-                    ->failWhenLoadIsHigherInTheLast15Minutes(1.5),
-                SecurityAdvisoriesCheck::new()
-                    ->daily(),
-            ]);
-        });
+        // Deprecated in favor of HealthServiceProvider. Keeping this class as a
+        // no-op avoids duplicate health checks if a stale provider manifest or
+        // cached bootstrap file still attempts to load it during deployment.
     }
 }

--- a/tests/Feature/HealthServiceProviderTest.php
+++ b/tests/Feature/HealthServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Providers\AppHealthServiceProvider;
 use App\Providers\HealthServiceProvider;
 use Spatie\Health\Checks\Checks\QueueCheck;
 use Spatie\Health\Checks\Checks\ScheduleCheck;
@@ -57,6 +58,17 @@ class HealthServiceProviderTest extends TestCase
         );
 
         $this->assertSame('file', $scheduleCheck->getCacheStoreName());
+    }
+
+    public function test_legacy_app_health_service_provider_does_not_register_duplicate_checks(): void
+    {
+        (new AppHealthServiceProvider($this->app))->boot();
+
+        $this->assertCount(0, Health::registeredChecks());
+
+        $this->bootHealthServiceProvider();
+
+        $this->assertCount(7, Health::registeredChecks());
     }
 
     protected function bootHealthServiceProvider(): void


### PR DESCRIPTION
…er` to prevent duplicate health checks, and add a test to ensure legacy provider does not register checks.

## Summary by Sourcery

Tests:
- Add a feature test ensuring the legacy AppHealthServiceProvider does not register any health checks while HealthServiceProvider continues to register the expected checks.