### PR TITLE
Add 2FA challenge route and disable Fortify views in config

### DIFF
--- a/app/Console/Commands/SyncRepositoryIssues.php
+++ b/app/Console/Commands/SyncRepositoryIssues.php
@@ -38,6 +38,12 @@ final class SyncRepositoryIssues extends Command
             return self::INVALID;
         }
 
+        if (! $link->repository->supportsIssueSync()) {
+            $this->warn($this->unsupportedProviderMessage($link));
+
+            return self::SUCCESS;
+        }
+
         $ok = $this->syncLink($link);
 
         return $ok ? self::SUCCESS : self::FAILURE;
@@ -49,24 +55,45 @@ final class SyncRepositoryIssues extends Command
     private function handleAll(): int
     {
         $with = ['project', 'repository', 'repository.statusMappings'];
+        $supportedProviders = Repository::issueSyncProviders();
+        $baseQuery = ProjectRepository::query()->whereHas('repository');
 
-        $total = ProjectRepository::query()
-            ->whereHas('repository')
+        $unsupportedTotal = (clone $baseQuery)
+            ->whereHas('repository', fn ($query) => $query->whereNotIn('provider', $supportedProviders))
             ->count();
 
+        $total = (clone $baseQuery)
+            ->whereHas('repository', fn ($query) => $query->whereIn('provider', $supportedProviders))
+            ->count();
+
+        if ($unsupportedTotal > 0) {
+            $this->warn(sprintf(
+                'Skipping %d linked repositor%s that %s not support issue sync.',
+                $unsupportedTotal,
+                $unsupportedTotal === 1 ? 'y' : 'ies',
+                $unsupportedTotal === 1 ? 'does' : 'do'
+            ));
+            $this->newLine();
+        }
+
         if ($total === 0) {
-            $this->warn('No project-repository links found.');
+            $this->warn('No issue-sync repository links found.');
 
             return self::SUCCESS;
         }
 
-        $this->info("Syncing all linked repositories ({$total})…");
+        $this->info("Syncing all issue-sync repository links ({$total})…");
         $this->newLine();
 
         $failures = 0;
 
         // Stream results to keep memory usage low.
-        foreach (ProjectRepository::query()->with($with)->whereHas('repository')->cursor() as $link) {
+        foreach (
+            ProjectRepository::query()
+                ->with($with)
+                ->whereHas('repository', fn ($query) => $query->whereIn('provider', $supportedProviders))
+                ->cursor() as $link
+        ) {
             /** @var ProjectRepository $link */
             try {
                 $ok = $this->syncLink($link);
@@ -104,6 +131,12 @@ final class SyncRepositoryIssues extends Command
      */
     private function syncLink(ProjectRepository $link): bool
     {
+        if (! $link->repository->supportsIssueSync()) {
+            $this->warn($this->unsupportedProviderMessage($link));
+
+            return true;
+        }
+
         $this->line(sprintf(
             '<info>Syncing</info> %s/%s (%s) <comment>→</comment> Project %s',
             $link->repository->owner,
@@ -143,6 +176,15 @@ final class SyncRepositoryIssues extends Command
         $this->info('Sync complete.');
 
         return true;
+    }
+
+    private function unsupportedProviderMessage(ProjectRepository $link): string
+    {
+        return sprintf(
+            'Skipping %s (%s): this provider does not support issue sync.',
+            $link->repository->displayPath(),
+            $link->repository->provider
+        );
     }
 
     /**

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -5,16 +5,15 @@ namespace App\Models;
 use App\Traits\HasRecordShares;
 use App\Traits\IsPermissible;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
 class Repository extends BaseModel
 {
+    use HasRecordShares;
     use HasUuids;
     use IsPermissible;
-    use HasRecordShares;
 
     protected $fillable = [
         'provider',
@@ -27,7 +26,9 @@ class Repository extends BaseModel
     ];
 
     protected $keyType = 'string';
+
     public $incrementing = false;
+
     protected $casts = [
         'meta' => 'array',
         'id' => 'string',
@@ -62,7 +63,17 @@ class Repository extends BaseModel
 
     public function supportsIssueSync(): bool
     {
-        return strtolower((string) $this->provider) === 'github';
+        return in_array(strtolower((string) $this->provider), self::issueSyncProviders(), true);
+    }
+
+    /**
+     * Providers that support importing issues into Forge.
+     *
+     * @return list<string>
+     */
+    public static function issueSyncProviders(): array
+    {
+        return ['github'];
     }
 
     public function supportsVcsLinks(): bool
@@ -81,21 +92,21 @@ class Repository extends BaseModel
             $org = (string) Arr::get($this->meta, 'organization_name', $this->owner);
             $repo = (string) Arr::get($this->meta, 'repository_name', $this->name);
 
-            return trim($org . '/' . $repo, '/');
+            return trim($org.'/'.$repo, '/');
         }
 
-        return trim($this->owner . '/' . $this->name, '/');
+        return trim($this->owner.'/'.$this->name, '/');
     }
 
     public function slugPath(): string
     {
-        return trim($this->owner . '/' . $this->name, '/');
+        return trim($this->owner.'/'.$this->name, '/');
     }
 
     public function externalUrl(): ?string
     {
         return match (strtolower((string) $this->provider)) {
-            'github' => 'https://' . ($this->host ?: 'github.com') . '/' . $this->slugPath(),
+            'github' => 'https://'.($this->host ?: 'github.com').'/'.$this->slugPath(),
             'crucible' => Arr::get($this->meta, 'web_url'),
             default => null,
         };

--- a/tests/Feature/SyncRepositoryIssuesCommandTest.php
+++ b/tests/Feature/SyncRepositoryIssuesCommandTest.php
@@ -42,7 +42,37 @@ class SyncRepositoryIssuesCommandTest extends TestCase
         $this->assertStringContainsString('Error: The provider token has expired.', $output);
     }
 
-    private function makeLink(string $status, ?string $message): ProjectRepository
+    public function test_repo_sync_all_skips_unsupported_providers_without_failing_the_schedule(): void
+    {
+        $githubLink = $this->makeLink('ok', 'Provider returned 0 issues. Closed-only repositories are treated as advisory.');
+        $this->makeLink('error', 'Forge issue import is not supported for Crucible repositories.', provider: 'crucible');
+
+        Bus::shouldReceive('dispatchSync')->once()->andReturnNull();
+
+        $exitCode = Artisan::call('repo:sync', ['--all' => true]);
+        $output = Artisan::output();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('Skipping 1 linked repository that does not support issue sync.', $output);
+        $this->assertStringContainsString('Syncing all issue-sync repository links (1)…', $output);
+        $this->assertStringContainsString($githubLink->repository->slugPath(), $output);
+    }
+
+    public function test_repo_sync_link_skips_unsupported_provider_without_failure(): void
+    {
+        $link = $this->makeLink('error', 'Forge issue import is not supported for Crucible repositories.', provider: 'crucible');
+
+        Bus::shouldReceive('dispatchSync')->never();
+
+        $exitCode = Artisan::call('repo:sync', ['--link' => $link->id]);
+        $output = Artisan::output();
+
+        $this->assertSame(0, $exitCode);
+        $this->assertStringContainsString('Skipping octo-org/', $output);
+        $this->assertStringContainsString('this provider does not support issue sync.', $output);
+    }
+
+    private function makeLink(string $status, ?string $message, string $provider = 'github'): ProjectRepository
     {
         $project = Project::factory()->create([
             'name' => 'Repo Sync '.Str::random(8),
@@ -50,8 +80,8 @@ class SyncRepositoryIssuesCommandTest extends TestCase
         ]);
 
         $repository = Repository::query()->create([
-            'provider' => 'github',
-            'host' => 'github.com',
+            'provider' => $provider,
+            'host' => $provider === 'crucible' ? 'crucible.example.test' : 'github.com',
             'owner' => 'octo-org',
             'name' => 'repo-'.Str::lower(Str::random(8)),
         ]);


### PR DESCRIPTION
## Summary by Sourcery

Handle repository issue sync only for providers that support it and skip unsupported providers without failing the command.

Bug Fixes:
- Prevent the repository issue sync command from failing when encountering repositories whose providers do not support issue sync.

Enhancements:
- Limit bulk issue sync to repositories from providers that support issue sync and surface counts and warnings for skipped repositories.
- Centralize the list of providers that support issue sync in the Repository model and reuse it in capability checks.

Tests:
- Add feature tests to verify unsupported providers are skipped in both single-link and bulk repo sync without dispatching jobs or failing the command.