### PR TITLE
Add Sentry integration with alert rule options and webhook handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -126,3 +126,11 @@ SELF_UPDATER_VERSION_INSTALLED=0.1.0
 SELF_UPDATER_REPO_VENDOR=crimsonstrife
 SELF_UPDATER_REPO_NAME=forge
 SELF_UPDATER_PACKAGE_FILE_NAME=forge-release.zip
+
+# Sentry internal integration. Org slug, client id, client secret, and
+# auth token are configured in the Filament "Connectors & Sync" page
+# (stored encrypted in the database, not here).
+SENTRY_INTEGRATION_API_BASE=https://sentry.io/api/0
+SENTRY_INTEGRATION_QUEUE=
+SENTRY_INTEGRATION_SYSTEM_USER_EMAIL=forge-system+sentry@forge.local
+SENTRY_INTEGRATION_SYSTEM_USER_NAME="Sentry Integration"

--- a/app/Filament/Pages/ConnectorsAndSyncSettings.php
+++ b/app/Filament/Pages/ConnectorsAndSyncSettings.php
@@ -2,19 +2,26 @@
 
 namespace App\Filament\Pages;
 
-use App\Settings\GithubSettings;
+use App\Integrations\Sentry\Services\SentryClient;
+use App\Models\IssuePriority;
+use App\Models\IssueType;
+use App\Models\Project;
 use App\Settings\GiteaSettings;
+use App\Settings\GithubSettings;
+use App\Settings\SentrySettings;
 use App\Settings\SyncSettings;
 use Filament\Actions\Action;
+use Filament\Forms\Components\Placeholder;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Components\Toggle;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
-use Filament\Schemas\Schema;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Http;
 
@@ -23,7 +30,9 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
     use InteractsWithForms;
 
     protected static string|null|\BackedEnum $navigationIcon = 'heroicon-o-cog-6-tooth';
+
     protected static string|null|\UnitEnum $navigationGroup = 'Administration';
+
     protected static ?string $navigationLabel = 'Connectors & Sync';
 
     protected static ?string $slug = 'connectors-and-sync-settings';
@@ -36,8 +45,9 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
     public function mount(): void
     {
         $github = app(GithubSettings::class);
-        $gitea  = app(GiteaSettings::class);
-        $sync   = app(SyncSettings::class);
+        $gitea = app(GiteaSettings::class);
+        $sync = app(SyncSettings::class);
+        $sentry = app(SentrySettings::class);
 
         $this->data = [
             'github_enabled' => $github->enabled,
@@ -53,6 +63,14 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
             'sync_auto_transition' => $sync->auto_transition_on_pr_merge,
             'sync_link_keyword_fix' => $sync->link_keyword_fix,
             'sync_link_keyword_close' => $sync->link_keyword_close,
+            'sentry_enabled' => $sentry->enabled,
+            'sentry_org_slug' => $sentry->org_slug,
+            'sentry_client_id' => $sentry->client_id,
+            'sentry_api_base' => $sentry->api_base,
+            'sentry_default_project_id' => $sentry->default_project_id,
+            'sentry_default_issue_type_id' => $sentry->default_issue_type_id,
+            'sentry_default_priority_id' => $sentry->default_priority_id,
+            'sentry_installation_uuid' => $sentry->installation_uuid,
         ];
     }
 
@@ -98,6 +116,30 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
                         TextInput::make('sync_link_keyword_fix')->label('Commit keyword for fix')->default('Fixes')->required(),
                         TextInput::make('sync_link_keyword_close')->label('Commit keyword for close')->default('Closes')->required(),
                     ])->columns(2),
+
+                    Section::make('Sentry')
+                        ->description('Internal Sentry integration. Create the integration in your Sentry org, then paste the Client ID, Client Secret, and Auth Token here. See resources/integrations/sentry/schema.json for the UI schema to paste into Sentry.')
+                        ->schema([
+                            Toggle::make('sentry_enabled')->label('Enabled'),
+                            TextInput::make('sentry_org_slug')->label('Sentry org slug')->placeholder('acme'),
+                            TextInput::make('sentry_client_id')->label('Client ID'),
+                            TextInput::make('sentry_client_secret')->label('Client Secret')->password()->revealable()
+                                ->dehydrated(fn ($s) => filled($s)),
+                            TextInput::make('sentry_auth_token')->label('Auth Token')->password()->revealable()
+                                ->dehydrated(fn ($s) => filled($s)),
+                            TextInput::make('sentry_api_base')->label('API Base')->default('https://sentry.io/api/0')->required(),
+                            Select::make('sentry_default_project_id')->label('Default Forge project')
+                                ->options(fn () => Project::query()->orderBy('name')->pluck('name', 'id')->all())
+                                ->searchable()->preload()->nullable(),
+                            Select::make('sentry_default_issue_type_id')->label('Default issue type')
+                                ->options(fn () => IssueType::query()->orderBy('name')->pluck('name', 'id')->all())
+                                ->searchable()->preload()->nullable(),
+                            Select::make('sentry_default_priority_id')->label('Default priority')
+                                ->options(fn () => IssuePriority::query()->orderBy('name')->pluck('name', 'id')->all())
+                                ->searchable()->preload()->nullable(),
+                            Placeholder::make('sentry_installation_uuid_display')->label('Installation UUID')
+                                ->content(fn () => $this->data['sentry_installation_uuid'] ?? 'Not yet captured'),
+                        ])->columns(2),
                 ]),
             ]);
     }
@@ -112,6 +154,9 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
             Action::make('testGitea')->label('Test Gitea')
                 ->visible(fn () => (bool) ($this->data['gitea_enabled'] ?? false))
                 ->action(fn () => $this->testGitea()),
+            Action::make('testSentry')->label('Test Sentry')
+                ->visible(fn () => (bool) ($this->data['sentry_enabled'] ?? false))
+                ->action(fn () => $this->testSentry()),
         ];
     }
 
@@ -157,7 +202,42 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
         $sync->link_keyword_close = (string) ($this->data['sync_link_keyword_close'] ?? 'Closes');
         $sync->save();
 
+        $sentry = app(SentrySettings::class);
+        $sentry->enabled = (bool) ($this->data['sentry_enabled'] ?? false);
+        $sentry->org_slug = (string) ($this->data['sentry_org_slug'] ?? '');
+        $sentry->client_id = (string) ($this->data['sentry_client_id'] ?? '');
+        if (filled($this->data['sentry_client_secret'] ?? null)) {
+            $sentry->client_secret = (string) $this->data['sentry_client_secret'];
+        }
+        if (filled($this->data['sentry_auth_token'] ?? null)) {
+            $sentry->auth_token = (string) $this->data['sentry_auth_token'];
+        }
+        $sentry->api_base = (string) ($this->data['sentry_api_base'] ?? 'https://sentry.io/api/0');
+        $sentry->default_project_id = $this->data['sentry_default_project_id'] ?: null;
+        $sentry->default_issue_type_id = $this->data['sentry_default_issue_type_id'] ? (int) $this->data['sentry_default_issue_type_id'] : null;
+        $sentry->default_priority_id = $this->data['sentry_default_priority_id'] ? (int) $this->data['sentry_default_priority_id'] : null;
+        $sentry->save();
+
         Notification::make()->title('Settings saved')->success()->send();
+    }
+
+    private function testSentry(): void
+    {
+        $client = app(SentryClient::class);
+
+        if (! $client->isConfigured()) {
+            Notification::make()->title('Sentry not configured')->warning()->send();
+
+            return;
+        }
+
+        try {
+            $client->ping()
+                ? Notification::make()->title('Sentry OK')->success()->send()
+                : Notification::make()->title('Sentry ping failed')->danger()->send();
+        } catch (\Throwable $e) {
+            Notification::make()->title('Sentry error')->body($e->getMessage())->danger()->send();
+        }
     }
 
     /**
@@ -169,11 +249,13 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
 
         if (! $s->enabled) {
             Notification::make()->title('GitHub disabled')->warning()->send();
+
             return;
         }
 
         if (! filled($s->personal_access_token)) {
             Notification::make()->title('Missing GitHub token')->danger()->send();
+
             return;
         }
 
@@ -197,11 +279,13 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
 
         if (! $s->enabled) {
             Notification::make()->title('Gitea disabled')->warning()->send();
+
             return;
         }
 
         if (! filled($s->personal_access_token) || ! filled($s->base_url)) {
             Notification::make()->title('Missing Gitea token or base URL')->danger()->send();
+
             return;
         }
 

--- a/app/Http/Controllers/Sentry/AlertRuleOptionsController.php
+++ b/app/Http/Controllers/Sentry/AlertRuleOptionsController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Sentry;
+
+use App\Models\IssuePriority;
+use App\Models\IssueType;
+use App\Models\Project;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+
+final class AlertRuleOptionsController extends Controller
+{
+    public function projects(Request $request): JsonResponse
+    {
+        $q = $this->query($request);
+
+        $rows = Project::query()
+            ->when($q !== '', fn ($b) => $b->where('name', 'like', '%'.$q.'%'))
+            ->orderBy('name')
+            ->limit(50)
+            ->get(['id', 'name'])
+            ->map(static fn (Project $p): array => [(string) $p->id, (string) $p->name])
+            ->all();
+
+        return new JsonResponse(['choices' => $rows]);
+    }
+
+    public function issueTypes(Request $request): JsonResponse
+    {
+        $q = $this->query($request);
+
+        $rows = IssueType::query()
+            ->when($q !== '', fn ($b) => $b->where('name', 'like', '%'.$q.'%'))
+            ->orderBy('name')
+            ->limit(50)
+            ->get(['id', 'name'])
+            ->map(static fn (IssueType $t): array => [(string) $t->id, (string) $t->name])
+            ->all();
+
+        return new JsonResponse(['choices' => $rows]);
+    }
+
+    public function priorities(Request $request): JsonResponse
+    {
+        $q = $this->query($request);
+
+        $rows = IssuePriority::query()
+            ->when($q !== '', fn ($b) => $b->where('name', 'like', '%'.$q.'%'))
+            ->orderBy('order')
+            ->orderBy('name')
+            ->limit(50)
+            ->get(['id', 'name'])
+            ->map(static fn (IssuePriority $p): array => [(string) $p->id, (string) $p->name])
+            ->all();
+
+        return new JsonResponse(['choices' => $rows]);
+    }
+
+    private function query(Request $request): string
+    {
+        return trim((string) ($request->query('query', '') ?: ''));
+    }
+}

--- a/app/Http/Middleware/VerifySentryHookSignature.php
+++ b/app/Http/Middleware/VerifySentryHookSignature.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Integrations\Sentry\Support\SentryRequestSignature;
 use App\Settings\SentrySettings;
 use Closure;
 use Illuminate\Http\Request;
@@ -23,19 +24,17 @@ final class VerifySentryHookSignature
             return response('Sentry integration disabled', 403);
         }
 
-        $secret = (string) ($settings->client_secret ?? '');
-        if ($secret === '') {
+        if (filled($settings->client_secret ?? null) === false) {
             return response('Sentry integration missing client secret', 403);
         }
 
-        $provided = (string) $request->header('Sentry-Hook-Signature', '');
+        $provided = (string) $request->header(SentryRequestSignature::HEADER, '');
         if ($provided === '') {
-            return response('Missing Sentry-Hook-Signature', 401);
+            return response('Missing '.SentryRequestSignature::HEADER, 401);
         }
 
-        $expected = hash_hmac('sha256', $request->getContent(), $secret);
-        if (! hash_equals($expected, $provided)) {
-            return response('Invalid Sentry-Hook-Signature', 401);
+        if (! SentryRequestSignature::verify($request, $provided)) {
+            return response('Invalid '.SentryRequestSignature::HEADER, 401);
         }
 
         return $next($request);

--- a/app/Http/Middleware/VerifySentryHookSignature.php
+++ b/app/Http/Middleware/VerifySentryHookSignature.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Settings\SentrySettings;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Used by the alert-rule options endpoints, which Sentry signs the same way
+ * as webhooks (HMAC-SHA256 of the raw body using the integration's client
+ * secret). The Spatie webhook-client config handles signing for /webhooks/sentry;
+ * this middleware applies the same check to GET option lookups.
+ */
+final class VerifySentryHookSignature
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $settings = app(SentrySettings::class);
+
+        if (! $settings->enabled) {
+            return response('Sentry integration disabled', 403);
+        }
+
+        $secret = (string) ($settings->client_secret ?? '');
+        if ($secret === '') {
+            return response('Sentry integration missing client secret', 403);
+        }
+
+        $provided = (string) $request->header('Sentry-Hook-Signature', '');
+        if ($provided === '') {
+            return response('Missing Sentry-Hook-Signature', 401);
+        }
+
+        $expected = hash_hmac('sha256', $request->getContent(), $secret);
+        if (! hash_equals($expected, $provided)) {
+            return response('Invalid Sentry-Hook-Signature', 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Integrations/Sentry/Jobs/SyncCommentToSentryJob.php
+++ b/app/Integrations/Sentry/Jobs/SyncCommentToSentryJob.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Integrations\Sentry\Jobs;
+
+use App\Integrations\Sentry\Services\SentryClient;
+use App\Models\Comment;
+use App\Models\IssueExternalRef;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+final class SyncCommentToSentryJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public readonly string $commentId)
+    {
+        $queue = config('sentry-integration.queue');
+        if (is_string($queue) && $queue !== '') {
+            $this->onQueue($queue);
+        }
+    }
+
+    public function handle(SentryClient $client): void
+    {
+        if (! $client->isConfigured()) {
+            return;
+        }
+
+        /** @var Comment|null $comment */
+        $comment = Comment::query()->find($this->commentId);
+        if (! $comment instanceof Comment) {
+            return;
+        }
+
+        $issueId = (string) ($comment->commentable_id ?? $comment->issue_id ?? '');
+        if ($issueId === '') {
+            return;
+        }
+
+        $ref = IssueExternalRef::query()
+            ->where('provider', 'sentry')
+            ->where('issue_id', $issueId)
+            ->first();
+
+        if (! $ref instanceof IssueExternalRef) {
+            return;
+        }
+
+        $sentryId = (string) $ref->external_issue_id;
+        if ($sentryId === '') {
+            return;
+        }
+
+        $author = $comment->user_id ? User::query()->find($comment->user_id) : null;
+        $name = $author instanceof User ? $author->name : 'a Forge user';
+
+        $client->postComment(
+            $sentryId,
+            sprintf('%s via Forge: %s', $name, strip_tags((string) $comment->body)),
+        );
+    }
+}

--- a/app/Integrations/Sentry/Jobs/SyncIssueStatusToSentryJob.php
+++ b/app/Integrations/Sentry/Jobs/SyncIssueStatusToSentryJob.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Integrations\Sentry\Jobs;
+
+use App\Integrations\Sentry\Services\SentryClient;
+use App\Models\Issue;
+use App\Models\IssueExternalRef;
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+final class SyncIssueStatusToSentryJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly string $issueId,
+        public readonly bool $resolve,
+        public readonly ?string $actorId = null,
+    ) {
+        $queue = config('sentry-integration.queue');
+        if (is_string($queue) && $queue !== '') {
+            $this->onQueue($queue);
+        }
+    }
+
+    public function handle(SentryClient $client): void
+    {
+        if (! $client->isConfigured()) {
+            return;
+        }
+
+        /** @var Issue|null $issue */
+        $issue = Issue::query()->find($this->issueId);
+        if (! $issue instanceof Issue) {
+            return;
+        }
+
+        $ref = IssueExternalRef::query()
+            ->where('provider', 'sentry')
+            ->where('issue_id', $this->issueId)
+            ->first();
+
+        if (! $ref instanceof IssueExternalRef) {
+            return;
+        }
+
+        $sentryId = (string) $ref->external_issue_id;
+        if ($sentryId === '') {
+            return;
+        }
+
+        if ($this->resolve) {
+            $client->resolveIssue($sentryId);
+            $client->postComment(
+                $sentryId,
+                $this->provenanceLine('Resolved', $issue),
+            );
+
+            $ref->state = 'closed';
+            $ref->save();
+
+            return;
+        }
+
+        $client->unresolveIssue($sentryId);
+        $client->postComment(
+            $sentryId,
+            $this->provenanceLine('Reopened', $issue),
+        );
+
+        $ref->state = 'open';
+        $ref->save();
+    }
+
+    private function provenanceLine(string $verb, Issue $issue): string
+    {
+        $actor = $this->actorId ? User::query()->find($this->actorId) : null;
+        $name = $actor instanceof User ? $actor->name : 'a Forge user';
+        $key = (string) ($issue->key ?? $issue->id);
+
+        return sprintf('%s by %s via Forge — issue %s.', $verb, $name, $key);
+    }
+}

--- a/app/Integrations/Sentry/Observers/SentryCommentObserver.php
+++ b/app/Integrations/Sentry/Observers/SentryCommentObserver.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Integrations\Sentry\Observers;
+
+use App\Integrations\Sentry\Jobs\SyncCommentToSentryJob;
+use App\Integrations\Sentry\Support\SentrySyncContext;
+use App\Models\Comment;
+use App\Models\Issue;
+use App\Models\IssueExternalRef;
+use App\Settings\SentrySettings;
+
+final class SentryCommentObserver
+{
+    public function created(Comment $comment): void
+    {
+        if (SentrySyncContext::isActive()) {
+            return;
+        }
+
+        if (! app(SentrySettings::class)->enabled) {
+            return;
+        }
+
+        if ($comment->commentable_type !== Issue::class) {
+            return;
+        }
+
+        $issueId = (string) ($comment->commentable_id ?? $comment->issue_id ?? '');
+        if ($issueId === '') {
+            return;
+        }
+
+        $hasLink = IssueExternalRef::query()
+            ->where('provider', 'sentry')
+            ->where('issue_id', $issueId)
+            ->exists();
+
+        if (! $hasLink) {
+            return;
+        }
+
+        SyncCommentToSentryJob::dispatch((string) $comment->id)->afterCommit();
+    }
+}

--- a/app/Integrations/Sentry/Observers/SentryIssueObserver.php
+++ b/app/Integrations/Sentry/Observers/SentryIssueObserver.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Integrations\Sentry\Observers;
+
+use App\Integrations\Sentry\Jobs\SyncIssueStatusToSentryJob;
+use App\Integrations\Sentry\Support\SentrySyncContext;
+use App\Models\Issue;
+use App\Models\IssueExternalRef;
+use App\Models\IssueStatus;
+use App\Settings\SentrySettings;
+use Illuminate\Support\Facades\Auth;
+
+final class SentryIssueObserver
+{
+    public function updated(Issue $issue): void
+    {
+        if (SentrySyncContext::isActive()) {
+            return;
+        }
+
+        if (! $issue->wasChanged('issue_status_id')) {
+            return;
+        }
+
+        if (! app(SentrySettings::class)->enabled) {
+            return;
+        }
+
+        $hasLink = IssueExternalRef::query()
+            ->where('provider', 'sentry')
+            ->where('issue_id', $issue->id)
+            ->exists();
+
+        if (! $hasLink) {
+            return;
+        }
+
+        $fromDone = $this->isDone((int) ($issue->getOriginal('issue_status_id') ?? 0));
+        $toDone = $this->isDone((int) $issue->issue_status_id);
+
+        if ($fromDone === $toDone) {
+            return;
+        }
+
+        SyncIssueStatusToSentryJob::dispatch(
+            issueId: (string) $issue->id,
+            resolve: $toDone,
+            actorId: Auth::id() ? (string) Auth::id() : null,
+        )->afterCommit();
+    }
+
+    private function isDone(int $statusId): bool
+    {
+        if ($statusId === 0) {
+            return false;
+        }
+        $status = IssueStatus::query()->find($statusId);
+
+        return $status instanceof IssueStatus && (bool) $status->is_done;
+    }
+}

--- a/app/Integrations/Sentry/Services/SentryClient.php
+++ b/app/Integrations/Sentry/Services/SentryClient.php
@@ -11,7 +11,9 @@ use RuntimeException;
 
 final class SentryClient
 {
-    public function __construct(private readonly SentrySettings $settings) {}
+    public function __construct(private readonly SentrySettings $settings)
+    {
+    }
 
     public function isConfigured(): bool
     {

--- a/app/Integrations/Sentry/Services/SentryClient.php
+++ b/app/Integrations/Sentry/Services/SentryClient.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Integrations\Sentry\Services;
+
+use App\Settings\SentrySettings;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+
+final class SentryClient
+{
+    public function __construct(private readonly SentrySettings $settings) {}
+
+    public function isConfigured(): bool
+    {
+        return $this->settings->enabled && filled($this->settings->auth_token);
+    }
+
+    /**
+     * @throws ConnectionException
+     */
+    public function resolveIssue(string $sentryIssueId): void
+    {
+        $this->putIssueStatus($sentryIssueId, 'resolved');
+    }
+
+    /**
+     * @throws ConnectionException
+     */
+    public function unresolveIssue(string $sentryIssueId): void
+    {
+        $this->putIssueStatus($sentryIssueId, 'unresolved');
+    }
+
+    /**
+     * @throws ConnectionException
+     */
+    public function postComment(string $sentryIssueId, string $body): void
+    {
+        $this->ensureConfigured();
+
+        $resp = $this->client()->post(
+            "/issues/{$sentryIssueId}/comments/",
+            ['text' => $body],
+        );
+
+        $this->assertOk($resp, 'post comment');
+    }
+
+    /**
+     * @throws ConnectionException
+     */
+    public function ping(): bool
+    {
+        if (! $this->isConfigured()) {
+            return false;
+        }
+
+        return $this->client()->get('/')->successful();
+    }
+
+    /**
+     * @throws ConnectionException
+     */
+    private function putIssueStatus(string $sentryIssueId, string $status): void
+    {
+        $this->ensureConfigured();
+
+        $resp = $this->client()->put(
+            "/issues/{$sentryIssueId}/",
+            ['status' => $status],
+        );
+
+        $this->assertOk($resp, "set status={$status}");
+    }
+
+    private function client(): PendingRequest
+    {
+        return Http::withToken($this->settings->auth_token ?? '')
+            ->baseUrl($this->settings->api_base ?: (string) config('sentry-integration.api_base'))
+            ->asJson()
+            ->acceptJson()
+            ->timeout(10);
+    }
+
+    private function ensureConfigured(): void
+    {
+        if (! $this->isConfigured()) {
+            throw new RuntimeException('Sentry integration is not enabled or missing an auth token.');
+        }
+    }
+
+    private function assertOk(Response $resp, string $what): void
+    {
+        if (! $resp->successful()) {
+            throw new RuntimeException(sprintf(
+                'Sentry %s failed: HTTP %d %s',
+                $what,
+                $resp->status(),
+                $this->maskToken(mb_strimwidth((string) $resp->body(), 0, 500)),
+            ));
+        }
+    }
+
+    private function maskToken(string $msg): string
+    {
+        $token = (string) ($this->settings->auth_token ?? '');
+        if ($token === '') {
+            return $msg;
+        }
+
+        return str_replace($token, '***', $msg);
+    }
+}

--- a/app/Integrations/Sentry/Services/SentryInstallationService.php
+++ b/app/Integrations/Sentry/Services/SentryInstallationService.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Integrations\Sentry\Services;
+
+use App\Settings\SentrySettings;
+
+final class SentryInstallationService
+{
+    public function __construct(private readonly SentrySettings $settings) {}
+
+    /**
+     * Handle the 'installation' resource. Action is 'created' or 'deleted'.
+     *
+     * @param  array<string,mixed>  $payload
+     */
+    public function handle(array $payload): void
+    {
+        $action = (string) ($payload['action'] ?? '');
+        $uuid = (string) ($payload['installation']['uuid'] ?? '');
+
+        if ($action === 'created' && $uuid !== '') {
+            $this->settings->installation_uuid = $uuid;
+            $this->settings->save();
+
+            return;
+        }
+
+        if ($action === 'deleted') {
+            $this->settings->installation_uuid = null;
+            $this->settings->save();
+        }
+    }
+}

--- a/app/Integrations/Sentry/Services/SentryInstallationService.php
+++ b/app/Integrations/Sentry/Services/SentryInstallationService.php
@@ -6,7 +6,9 @@ use App\Settings\SentrySettings;
 
 final class SentryInstallationService
 {
-    public function __construct(private readonly SentrySettings $settings) {}
+    public function __construct(private readonly SentrySettings $settings)
+    {
+    }
 
     /**
      * Handle the 'installation' resource. Action is 'created' or 'deleted'.

--- a/app/Integrations/Sentry/Services/SentryIssueSyncService.php
+++ b/app/Integrations/Sentry/Services/SentryIssueSyncService.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace App\Integrations\Sentry\Services;
+
+use App\Models\Issue;
+use App\Models\IssueExternalRef;
+use App\Models\IssueStatus;
+use App\Models\Project;
+use App\Models\User;
+use App\Settings\SentrySettings;
+use Illuminate\Support\Facades\Log;
+
+final class SentryIssueSyncService
+{
+    public function __construct(private readonly SentrySettings $settings) {}
+
+    /**
+     * Inbound from an alert-rule-action firing (resource = 'event_alert').
+     *
+     * @param  array<string,mixed>  $payload
+     */
+    public function upsertFromAlert(array $payload): void
+    {
+        $data = (array) ($payload['data'] ?? []);
+        $issueData = (array) ($data['event']['issue_id'] ?? null) ?: (array) ($data['issue'] ?? []);
+        $sentryId = $this->extractSentryIssueId($payload);
+        $title = (string) ($data['issue']['title'] ?? $data['event']['title'] ?? '(no title)');
+        $culprit = (string) ($data['issue']['culprit'] ?? $data['event']['culprit'] ?? '');
+        $level = (string) ($data['issue']['level'] ?? $data['event']['level'] ?? '');
+        $webUrl = (string) ($data['issue']['web_url'] ?? $data['issue']['permalink'] ?? $data['event']['web_url'] ?? '');
+        $project = $this->resolveProject($data);
+
+        if ($sentryId === '' || ! $project instanceof Project) {
+            Log::warning('Sentry alert webhook missing issue id or project — skipping', [
+                'sentry_id' => $sentryId,
+                'project_routed' => $project?->id,
+            ]);
+
+            return;
+        }
+
+        $ref = IssueExternalRef::query()
+            ->where('provider', 'sentry')
+            ->where('external_issue_id', $sentryId)
+            ->first();
+
+        if ($ref instanceof IssueExternalRef) {
+            $ref->update([
+                'state' => 'open',
+                'payload' => $payload,
+                'url' => $webUrl !== '' ? $webUrl : $ref->url,
+            ]);
+
+            return;
+        }
+
+        $issue = new Issue;
+        $issue->project_id = (string) $project->id;
+        $issue->issue_type_id = $this->settings->default_issue_type_id;
+        $issue->issue_priority_id = $this->settings->default_priority_id;
+        $issue->issue_status_id = $this->firstOpenStatusId($project);
+        $issue->reporter_id = $this->systemUserId();
+        $issue->summary = mb_strimwidth($title, 0, 255, '…');
+        $issue->description = $this->buildDescription($title, $culprit, $level, $webUrl);
+        $issue->save();
+
+        IssueExternalRef::query()->create([
+            'issue_id' => $issue->id,
+            'provider' => 'sentry',
+            'external_issue_id' => $sentryId,
+            'state' => 'open',
+            'url' => $webUrl !== '' ? $webUrl : null,
+            'payload' => $payload,
+        ]);
+    }
+
+    /**
+     * Inbound from the 'issue' resource (status changed on the Sentry side).
+     *
+     * @param  array<string,mixed>  $payload
+     */
+    public function syncStatus(array $payload): void
+    {
+        $action = (string) ($payload['action'] ?? '');
+        $sentryId = $this->extractSentryIssueId($payload);
+
+        if ($sentryId === '') {
+            return;
+        }
+
+        $ref = IssueExternalRef::query()
+            ->where('provider', 'sentry')
+            ->where('external_issue_id', $sentryId)
+            ->first();
+
+        if (! $ref instanceof IssueExternalRef) {
+            return;
+        }
+
+        /** @var Issue|null $issue */
+        $issue = Issue::query()->find($ref->issue_id);
+        if (! $issue instanceof Issue) {
+            return;
+        }
+
+        $project = $issue->project;
+
+        if (in_array($action, ['resolved', 'archived', 'ignored'], true)) {
+            $issue->issue_status_id = $this->firstDoneStatusId($project) ?? $issue->issue_status_id;
+            if (empty($issue->closed_at)) {
+                $issue->closed_at = now();
+            }
+            $ref->state = 'closed';
+        } elseif ($action === 'unresolved') {
+            $issue->issue_status_id = $this->firstOpenStatusId($project) ?? $issue->issue_status_id;
+            $issue->closed_at = null;
+            $ref->state = 'open';
+        }
+
+        $issue->save();
+        $ref->payload = $payload;
+        $ref->save();
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function extractSentryIssueId(array $payload): string
+    {
+        $data = (array) ($payload['data'] ?? []);
+
+        return (string) (
+            $data['issue']['id']
+            ?? $data['event']['issue_id']
+            ?? $data['issue_id']
+            ?? $payload['issue']['id']
+            ?? ''
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $data
+     */
+    private function resolveProject(array $data): ?Project
+    {
+        $forgeProjectId = (string) (
+            $data['issue_alert']['settings']['forge_project_id']
+            ?? $data['settings']['forge_project_id']
+            ?? ''
+        );
+
+        if ($forgeProjectId !== '') {
+            $project = Project::query()->find($forgeProjectId);
+            if ($project instanceof Project) {
+                return $project;
+            }
+        }
+
+        if ($this->settings->default_project_id) {
+            return Project::query()->find($this->settings->default_project_id);
+        }
+
+        return null;
+    }
+
+    private function firstOpenStatusId(?Project $project): ?int
+    {
+        return $this->firstStatusIdMatching($project, isDone: false);
+    }
+
+    private function firstDoneStatusId(?Project $project): ?int
+    {
+        return $this->firstStatusIdMatching($project, isDone: true);
+    }
+
+    private function firstStatusIdMatching(?Project $project, bool $isDone): ?int
+    {
+        if ($project instanceof Project) {
+            $scoped = $project->issueStatuses()
+                ->where('issue_statuses.is_done', $isDone)
+                ->orderBy('issue_statuses.order')
+                ->value('issue_statuses.id');
+            if ($scoped !== null) {
+                return (int) $scoped;
+            }
+        }
+
+        $value = IssueStatus::query()
+            ->where('is_done', $isDone)
+            ->orderBy('order')
+            ->value('id');
+
+        return $value !== null ? (int) $value : null;
+    }
+
+    private function systemUserId(): ?string
+    {
+        $email = (string) config('sentry-integration.system_user_email');
+        if ($email === '') {
+            return null;
+        }
+
+        return User::query()->where('email', $email)->value('id');
+    }
+
+    private function buildDescription(string $title, string $culprit, string $level, string $webUrl): string
+    {
+        $parts = ['**Sentry alert**', '', $title];
+
+        if ($culprit !== '') {
+            $parts[] = '';
+            $parts[] = 'Culprit: '.$culprit;
+        }
+        if ($level !== '') {
+            $parts[] = 'Level: '.$level;
+        }
+        if ($webUrl !== '') {
+            $parts[] = '';
+            $parts[] = 'Open in Sentry: '.$webUrl;
+        }
+
+        return implode("\n", $parts);
+    }
+}

--- a/app/Integrations/Sentry/Services/SentryIssueSyncService.php
+++ b/app/Integrations/Sentry/Services/SentryIssueSyncService.php
@@ -24,7 +24,6 @@ final class SentryIssueSyncService
     public function upsertFromAlert(array $payload): void
     {
         $data = (array) ($payload['data'] ?? []);
-        $issueData = (array) ($data['event']['issue_id'] ?? null) ?: (array) ($data['issue'] ?? []);
         $sentryId = $this->extractSentryIssueId($payload);
         $title = (string) ($data['issue']['title'] ?? $data['event']['title'] ?? '(no title)');
         $culprit = (string) ($data['issue']['culprit'] ?? $data['event']['culprit'] ?? '');

--- a/app/Integrations/Sentry/Services/SentryIssueSyncService.php
+++ b/app/Integrations/Sentry/Services/SentryIssueSyncService.php
@@ -12,7 +12,9 @@ use Illuminate\Support\Facades\Log;
 
 final class SentryIssueSyncService
 {
-    public function __construct(private readonly SentrySettings $settings) {}
+    public function __construct(private readonly SentrySettings $settings)
+    {
+    }
 
     /**
      * Inbound from an alert-rule-action firing (resource = 'event_alert').
@@ -54,7 +56,7 @@ final class SentryIssueSyncService
             return;
         }
 
-        $issue = new Issue;
+        $issue = new Issue();
         $issue->project_id = (string) $project->id;
         $issue->issue_type_id = $this->settings->default_issue_type_id;
         $issue->issue_priority_id = $this->settings->default_priority_id;

--- a/app/Integrations/Sentry/Support/SentryHeaders.php
+++ b/app/Integrations/Sentry/Support/SentryHeaders.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Integrations\Sentry\Support;
+
+/**
+ * Header bag helpers for Sentry webhook payloads.
+ *
+ * Spatie's WebhookCall lowercases header keys when storing (Symfony Request
+ * headers are lowercased on `->all()`). We normalize defensively at read time
+ * so changes to webhook-client's `store_headers` casing can't silently null
+ * our values.
+ */
+final class SentryHeaders
+{
+    /**
+     * @param  array<string,mixed>  $headers
+     * @return array<string,array<int,string>>
+     */
+    public static function normalize(array $headers): array
+    {
+        $out = [];
+        foreach ($headers as $name => $value) {
+            $key = strtolower((string) $name);
+            $out[$key] = is_array($value) ? array_values($value) : [(string) $value];
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<string,mixed>  $headers
+     */
+    public static function value(array $headers, string $name): ?string
+    {
+        $key = strtolower($name);
+
+        if (isset($headers[$key])) {
+            return self::firstValue($headers[$key]);
+        }
+
+        foreach ($headers as $headerName => $headerValue) {
+            if (strtolower((string) $headerName) === $key) {
+                return self::firstValue($headerValue);
+            }
+        }
+
+        return null;
+    }
+
+    private static function firstValue(mixed $value): ?string
+    {
+        if (is_array($value)) {
+            return isset($value[0]) ? (string) $value[0] : null;
+        }
+
+        return is_string($value) ? $value : null;
+    }
+}

--- a/app/Integrations/Sentry/Support/SentryRequestSignature.php
+++ b/app/Integrations/Sentry/Support/SentryRequestSignature.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Integrations\Sentry\Support;
+
+use App\Settings\SentrySettings;
+use Illuminate\Http\Request;
+
+/**
+ * HMAC-SHA256 verification for Sentry-signed requests (webhook deliveries and
+ * alert-rule option lookups). Shared by SentrySignatureValidator (Spatie
+ * webhook profile) and the VerifySentryHookSignature middleware so the two
+ * paths cannot drift.
+ */
+final class SentryRequestSignature
+{
+    public const HEADER = 'Sentry-Hook-Signature';
+
+    public static function verify(Request $request, ?string $providedHeader = null): bool
+    {
+        $settings = app(SentrySettings::class);
+
+        if (! $settings->enabled) {
+            return false;
+        }
+
+        $secret = (string) ($settings->client_secret ?? '');
+        if ($secret === '') {
+            return false;
+        }
+
+        $provided = $providedHeader !== null
+            ? $providedHeader
+            : (string) $request->header(self::HEADER, '');
+        if ($provided === '') {
+            return false;
+        }
+
+        $expected = hash_hmac('sha256', $request->getContent(), $secret);
+
+        return hash_equals($expected, $provided);
+    }
+}

--- a/app/Integrations/Sentry/Support/SentrySyncContext.php
+++ b/app/Integrations/Sentry/Support/SentrySyncContext.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Integrations\Sentry\Support;
+
+/**
+ * Tracks whether the current request/job stack is mutating Forge models in
+ * response to a Sentry webhook. The Sentry observer consults this to avoid
+ * re-emitting outbound calls (Sentry → Forge → Sentry loop).
+ */
+final class SentrySyncContext
+{
+    private static int $depth = 0;
+
+    public static function push(): void
+    {
+        self::$depth++;
+    }
+
+    public static function pop(): void
+    {
+        if (self::$depth > 0) {
+            self::$depth--;
+        }
+    }
+
+    public static function isActive(): bool
+    {
+        return self::$depth > 0;
+    }
+
+    /**
+     * Run a callback inside the suppression scope.
+     *
+     * @template T
+     *
+     * @param  callable():T  $callback
+     * @return T
+     */
+    public static function run(callable $callback): mixed
+    {
+        self::push();
+        try {
+            return $callback();
+        } finally {
+            self::pop();
+        }
+    }
+}

--- a/app/Integrations/Sentry/Webhooks/ProcessSentryWebhookJob.php
+++ b/app/Integrations/Sentry/Webhooks/ProcessSentryWebhookJob.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Integrations\Sentry\Webhooks;
+
+use App\Integrations\Sentry\Support\SentrySyncContext;
+use App\Models\WebhookDelivery;
+use Illuminate\Support\Facades\Log;
+use Spatie\WebhookClient\Jobs\ProcessWebhookJob;
+use Throwable;
+
+final class ProcessSentryWebhookJob extends ProcessWebhookJob
+{
+    public function handle(SentryEventRouter $router): void
+    {
+        $resource = $this->headerValue('sentry-hook-resource');
+        $requestId = $this->headerValue('request-id');
+
+        $delivery = WebhookDelivery::query()->create([
+            'provider' => 'sentry',
+            'event_type' => $resource,
+            'signature' => $this->headerValue('sentry-hook-signature'),
+            'headers' => $this->webhookCall->headers ?? [],
+            'payload' => json_encode($this->webhookCall->payload ?? [], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+        ]);
+
+        try {
+            SentrySyncContext::run(function () use ($router, $resource): void {
+                $router->dispatch(
+                    resource: (string) $resource,
+                    payload: (array) ($this->webhookCall->payload ?? []),
+                    headers: (array) ($this->webhookCall->headers ?? []),
+                );
+            });
+
+            $delivery->update(['http_status' => 204]);
+        } catch (Throwable $e) {
+            $delivery->update([
+                'http_status' => 500,
+                'processing_error' => mb_strimwidth($e->getMessage(), 0, 8000),
+            ]);
+            Log::error('Sentry webhook processing failed', [
+                'request_id' => $requestId,
+                'resource' => $resource,
+                'webhook_id' => $this->webhookCall->id,
+                'exception' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+    }
+
+    private function headerValue(string $name): ?string
+    {
+        $headers = (array) ($this->webhookCall->headers ?? []);
+        $values = $headers[$name] ?? null;
+        if (is_array($values)) {
+            return (string) ($values[0] ?? '');
+        }
+
+        return is_string($values) ? $values : null;
+    }
+}

--- a/app/Integrations/Sentry/Webhooks/ProcessSentryWebhookJob.php
+++ b/app/Integrations/Sentry/Webhooks/ProcessSentryWebhookJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Integrations\Sentry\Webhooks;
 
+use App\Integrations\Sentry\Support\SentryHeaders;
 use App\Integrations\Sentry\Support\SentrySyncContext;
 use App\Models\WebhookDelivery;
 use Illuminate\Support\Facades\Log;
@@ -12,23 +13,25 @@ final class ProcessSentryWebhookJob extends ProcessWebhookJob
 {
     public function handle(SentryEventRouter $router): void
     {
-        $resource = $this->headerValue('sentry-hook-resource');
-        $requestId = $this->headerValue('request-id');
+        $headers = (array) ($this->webhookCall->headers ?? []);
+        $resource = SentryHeaders::value($headers, 'Sentry-Hook-Resource');
+        $requestId = SentryHeaders::value($headers, 'Request-ID');
+        $signature = SentryHeaders::value($headers, 'Sentry-Hook-Signature');
 
         $delivery = WebhookDelivery::query()->create([
             'provider' => 'sentry',
             'event_type' => $resource,
-            'signature' => $this->headerValue('sentry-hook-signature'),
-            'headers' => $this->webhookCall->headers ?? [],
+            'signature' => $signature,
+            'headers' => $headers,
             'payload' => json_encode($this->webhookCall->payload ?? [], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
         ]);
 
         try {
-            SentrySyncContext::run(function () use ($router, $resource): void {
+            SentrySyncContext::run(function () use ($router, $resource, $headers): void {
                 $router->dispatch(
                     resource: (string) $resource,
                     payload: (array) ($this->webhookCall->payload ?? []),
-                    headers: (array) ($this->webhookCall->headers ?? []),
+                    headers: $headers,
                 );
             });
 
@@ -46,16 +49,5 @@ final class ProcessSentryWebhookJob extends ProcessWebhookJob
             ]);
             throw $e;
         }
-    }
-
-    private function headerValue(string $name): ?string
-    {
-        $headers = (array) ($this->webhookCall->headers ?? []);
-        $values = $headers[$name] ?? null;
-        if (is_array($values)) {
-            return (string) ($values[0] ?? '');
-        }
-
-        return is_string($values) ? $values : null;
     }
 }

--- a/app/Integrations/Sentry/Webhooks/SentryEventRouter.php
+++ b/app/Integrations/Sentry/Webhooks/SentryEventRouter.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Integrations\Sentry\Webhooks;
+
+use App\Integrations\Sentry\Services\SentryInstallationService;
+use App\Integrations\Sentry\Services\SentryIssueSyncService;
+use Illuminate\Support\Facades\Log;
+
+final class SentryEventRouter
+{
+    public function __construct(
+        private readonly SentryIssueSyncService $issues,
+        private readonly SentryInstallationService $installations,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,array<int,string>>  $headers
+     */
+    public function dispatch(string $resource, array $payload, array $headers): void
+    {
+        match ($resource) {
+            'installation' => $this->installations->handle($payload),
+            'event_alert' => $this->issues->upsertFromAlert($payload),
+            'issue' => $this->issues->syncStatus($payload),
+            default => $this->logUnhandled($resource, $headers),
+        };
+    }
+
+    /**
+     * @param  array<string,array<int,string>>  $headers
+     */
+    private function logUnhandled(string $resource, array $headers): void
+    {
+        $requestId = $headers['request-id'][0] ?? null;
+        Log::info('Sentry webhook resource not handled', [
+            'resource' => $resource,
+            'request_id' => $requestId,
+        ]);
+    }
+}

--- a/app/Integrations/Sentry/Webhooks/SentryEventRouter.php
+++ b/app/Integrations/Sentry/Webhooks/SentryEventRouter.php
@@ -4,6 +4,7 @@ namespace App\Integrations\Sentry\Webhooks;
 
 use App\Integrations\Sentry\Services\SentryInstallationService;
 use App\Integrations\Sentry\Services\SentryIssueSyncService;
+use App\Integrations\Sentry\Support\SentryHeaders;
 use Illuminate\Support\Facades\Log;
 
 final class SentryEventRouter
@@ -16,7 +17,7 @@ final class SentryEventRouter
 
     /**
      * @param  array<string,mixed>  $payload
-     * @param  array<string,array<int,string>>  $headers
+     * @param  array<string,mixed>  $headers
      */
     public function dispatch(string $resource, array $payload, array $headers): void
     {
@@ -29,14 +30,13 @@ final class SentryEventRouter
     }
 
     /**
-     * @param  array<string,array<int,string>>  $headers
+     * @param  array<string,mixed>  $headers
      */
     private function logUnhandled(string $resource, array $headers): void
     {
-        $requestId = $headers['request-id'][0] ?? null;
         Log::info('Sentry webhook resource not handled', [
             'resource' => $resource,
-            'request_id' => $requestId,
+            'request_id' => SentryHeaders::value($headers, 'Request-ID'),
         ]);
     }
 }

--- a/app/Integrations/Sentry/Webhooks/SentryEventRouter.php
+++ b/app/Integrations/Sentry/Webhooks/SentryEventRouter.php
@@ -11,7 +11,8 @@ final class SentryEventRouter
     public function __construct(
         private readonly SentryIssueSyncService $issues,
         private readonly SentryInstallationService $installations,
-    ) {}
+    ) {
+    }
 
     /**
      * @param  array<string,mixed>  $payload

--- a/app/Integrations/Sentry/Webhooks/SentrySignatureValidator.php
+++ b/app/Integrations/Sentry/Webhooks/SentrySignatureValidator.php
@@ -2,7 +2,7 @@
 
 namespace App\Integrations\Sentry\Webhooks;
 
-use App\Settings\SentrySettings;
+use App\Integrations\Sentry\Support\SentryRequestSignature;
 use Illuminate\Http\Request;
 use Spatie\WebhookClient\SignatureValidator\SignatureValidator;
 use Spatie\WebhookClient\WebhookConfig;
@@ -11,24 +11,8 @@ final class SentrySignatureValidator implements SignatureValidator
 {
     public function isValid(Request $request, WebhookConfig $config): bool
     {
-        $settings = app(SentrySettings::class);
-
-        if (! $settings->enabled) {
-            return false;
-        }
-
-        $secret = (string) ($settings->client_secret ?? '');
-        if ($secret === '') {
-            return false;
-        }
-
         $provided = (string) $request->header($config->signatureHeaderName, '');
-        if ($provided === '') {
-            return false;
-        }
 
-        $expected = hash_hmac('sha256', $request->getContent(), $secret);
-
-        return hash_equals($expected, $provided);
+        return SentryRequestSignature::verify($request, $provided);
     }
 }

--- a/app/Integrations/Sentry/Webhooks/SentrySignatureValidator.php
+++ b/app/Integrations/Sentry/Webhooks/SentrySignatureValidator.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Integrations\Sentry\Webhooks;
+
+use App\Settings\SentrySettings;
+use Illuminate\Http\Request;
+use Spatie\WebhookClient\SignatureValidator\SignatureValidator;
+use Spatie\WebhookClient\WebhookConfig;
+
+final class SentrySignatureValidator implements SignatureValidator
+{
+    public function isValid(Request $request, WebhookConfig $config): bool
+    {
+        $settings = app(SentrySettings::class);
+
+        if (! $settings->enabled) {
+            return false;
+        }
+
+        $secret = (string) ($settings->client_secret ?? '');
+        if ($secret === '') {
+            return false;
+        }
+
+        $provided = (string) $request->header($config->signatureHeaderName, '');
+        if ($provided === '') {
+            return false;
+        }
+
+        $expected = hash_hmac('sha256', $request->getContent(), $secret);
+
+        return hash_equals($expected, $provided);
+    }
+}

--- a/app/Providers/SentryIntegrationServiceProvider.php
+++ b/app/Providers/SentryIntegrationServiceProvider.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Providers;
+
+use App\Integrations\Sentry\Observers\SentryCommentObserver;
+use App\Integrations\Sentry\Observers\SentryIssueObserver;
+use App\Models\Comment;
+use App\Models\Issue;
+use Illuminate\Support\ServiceProvider;
+
+class SentryIntegrationServiceProvider extends ServiceProvider
+{
+    public function boot(): void
+    {
+        Issue::observe(SentryIssueObserver::class);
+        Comment::observe(SentryCommentObserver::class);
+    }
+}

--- a/app/Settings/SentrySettings.php
+++ b/app/Settings/SentrySettings.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Settings;
+
+use Spatie\LaravelSettings\Settings;
+
+/**
+ * @phpstan-type SentrySettingsShape array{
+ *   enabled: bool,
+ *   org_slug: string,
+ *   client_id: string,
+ *   client_secret: string|null,
+ *   auth_token: string|null,
+ *   api_base: string,
+ *   default_project_id: string|null,
+ *   default_issue_type_id: int|null,
+ *   default_priority_id: int|null,
+ *   installation_uuid: string|null
+ * }
+ */
+final class SentrySettings extends Settings
+{
+    public bool $enabled;
+
+    public string $org_slug;
+
+    public string $client_id;
+
+    public ?string $client_secret;
+
+    public ?string $auth_token;
+
+    public string $api_base;
+
+    public ?string $default_project_id;
+
+    public ?int $default_issue_type_id;
+
+    public ?int $default_priority_id;
+
+    public ?string $installation_uuid;
+
+    public static function group(): string
+    {
+        return 'sentry';
+    }
+
+    public static function encrypted(): array
+    {
+        return [
+            'client_secret',
+            'auth_token',
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use App\Http\Middleware\EnsureRegistrationIsEnabled;
 use App\Http\Middleware\EnsureSupportIdentity;
 use App\Http\Middleware\SetPermissionsTeamContext;
 use App\Http\Middleware\VerifyIngestKey;
+use App\Http\Middleware\VerifySentryHookSignature;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -31,6 +32,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'feedback.identity' => EnsureFeedbackIdentity::class,
             'feedback.identity.optional' => EnsureOptionalFeedbackIdentity::class,
             'ingest.key' => VerifyIngestKey::class,
+            'sentry.hook' => VerifySentryHookSignature::class,
             'auth.registration' => EnsureRegistrationIsEnabled::class,
             // Validates client credentials tokens (machine-to-machine OAuth2)
             'client' => CheckToken::class,

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -12,6 +12,7 @@ use App\Providers\HorizonServiceProvider;
 use App\Providers\JetstreamServiceProvider;
 use App\Providers\ModelObserverServiceProvider;
 use App\Providers\RepositoryServiceProvider;
+use App\Providers\SentryIntegrationServiceProvider;
 use App\Providers\SoloModeServiceProvider;
 use App\Providers\TelescopeServiceProvider;
 use App\Providers\VoltServiceProvider;
@@ -33,6 +34,7 @@ return [
     JetstreamServiceProvider::class,
     ModelObserverServiceProvider::class,
     RepositoryServiceProvider::class,
+    SentryIntegrationServiceProvider::class,
     SoloModeServiceProvider::class,
     TelescopeServiceProvider::class,
     VoltServiceProvider::class,

--- a/config/sentry-integration.php
+++ b/config/sentry-integration.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Sentry Internal Integration
+    |--------------------------------------------------------------------------
+    |
+    | Runtime configuration for the Sentry internal integration. Secrets and
+    | per-tenant settings live in App\Settings\SentrySettings (DB-backed,
+    | encrypted). Only invariants live here.
+    |
+    */
+
+    'api_base' => env('SENTRY_INTEGRATION_API_BASE', 'https://sentry.io/api/0'),
+
+    'queue' => env('SENTRY_INTEGRATION_QUEUE', null),
+
+    'system_user_email' => env('SENTRY_INTEGRATION_SYSTEM_USER_EMAIL', 'forge-system+sentry@forge.local'),
+
+    'system_user_name' => env('SENTRY_INTEGRATION_SYSTEM_USER_NAME', 'Sentry Integration'),
+
+    /*
+     * Sentry webhooks must be acknowledged within 1 second. The signature
+     * validator + ProcessSentryWebhookJob are designed to push processing
+     * onto this queue connection and respond immediately.
+     */
+    'webhook_request_timeout_seconds' => 1,
+];

--- a/config/webhook-client.php
+++ b/config/webhook-client.php
@@ -3,74 +3,28 @@
 return [
     'configs' => [
         [
-            /*
-             * This package supports multiple webhook receiving endpoints. If you only have
-             * one endpoint receiving webhooks, you can use 'default'.
-             */
-            'name' => 'default',
-
-            /*
-             * We expect that every webhook call will be signed using a secret. This secret
-             * is used to verify that the payload has not been tampered with.
-             */
-            'signing_secret' => env('WEBHOOK_CLIENT_SECRET'),
-
-            /*
-             * The name of the header containing the signature.
-             */
-            'signature_header_name' => 'Signature',
-
-            /*
-             *  This class will verify that the content of the signature header is valid.
-             *
-             * It should implement \Spatie\WebhookClient\SignatureValidator\SignatureValidator
-             */
-            'signature_validator' => \Spatie\WebhookClient\SignatureValidator\DefaultSignatureValidator::class,
-
-            /*
-             * This class determines if the webhook call should be stored and processed.
-             */
+            'name' => 'sentry',
+            'signing_secret' => null,
+            'signature_header_name' => 'Sentry-Hook-Signature',
+            'signature_validator' => \App\Integrations\Sentry\Webhooks\SentrySignatureValidator::class,
             'webhook_profile' => \Spatie\WebhookClient\WebhookProfile\ProcessEverythingWebhookProfile::class,
-
-            /*
-             * This class determines the response on a valid webhook call.
-             */
             'webhook_response' => \Spatie\WebhookClient\WebhookResponse\DefaultRespondsTo::class,
-
-            /*
-             * The classname of the model to be used to store webhook calls. The class should
-             * be equal or extend Spatie\WebhookClient\Models\WebhookCall.
-             */
             'webhook_model' => \Spatie\WebhookClient\Models\WebhookCall::class,
-
-            /*
-             * In this array, you can pass the headers that should be stored on
-             * the webhook call model when a webhook comes in.
-             *
-             * To store all headers, set this value to `*`.
-             */
             'store_headers' => [
-
+                'Sentry-Hook-Resource',
+                'Sentry-Hook-Timestamp',
+                'Sentry-Hook-Signature',
+                'Request-ID',
+                'Content-Type',
             ],
-
-            /*
-             * The class name of the job that will process the webhook request.
-             *
-             * This should be set to a class that extends \Spatie\WebhookClient\Jobs\ProcessWebhookJob.
-             */
-            'process_webhook_job' => '',
+            'process_webhook_job' => \App\Integrations\Sentry\Webhooks\ProcessSentryWebhookJob::class,
         ],
     ],
 
     /*
      * The integer amount of days after which models should be deleted.
-     *
-     * It deletes all records after 30 days. Set to null if no models should be deleted.
      */
     'delete_after_days' => 30,
 
-    /*
-     * Should a unique token be added to the route name
-     */
     'add_unique_token_to_route_name' => false,
 ];

--- a/database/migrations/2026_06_02_000001_create_webhook_calls_table.php
+++ b/database/migrations/2026_06_02_000001_create_webhook_calls_table.php
@@ -4,8 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
-{
+return new class () extends Migration {
     public function up(): void
     {
         Schema::create('webhook_calls', function (Blueprint $table) {

--- a/database/migrations/2026_06_02_000001_create_webhook_calls_table.php
+++ b/database/migrations/2026_06_02_000001_create_webhook_calls_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('webhook_calls', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('url', 512);
+            $table->json('headers')->nullable();
+            $table->json('payload')->nullable();
+            $table->text('exception')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('webhook_calls');
+    }
+};

--- a/database/seeders/SentryIntegrationUserSeeder.php
+++ b/database/seeders/SentryIntegrationUserSeeder.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class SentryIntegrationUserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $email = (string) config('sentry-integration.system_user_email');
+        $name = (string) config('sentry-integration.system_user_name');
+
+        User::query()->firstOrCreate(
+            ['email' => $email],
+            [
+                'name' => $name,
+                'password' => Hash::make(Str::random(64)),
+                'email_verified_at' => now(),
+            ],
+        );
+    }
+}

--- a/database/settings/2026_06_02_000001_create_sentry_defaults.php
+++ b/database/settings/2026_06_02_000001_create_sentry_defaults.php
@@ -1,0 +1,34 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('sentry.enabled', false);
+        $this->migrator->add('sentry.org_slug', '');
+        $this->migrator->add('sentry.client_id', '');
+        $this->migrator->addEncrypted('sentry.client_secret', null);
+        $this->migrator->addEncrypted('sentry.auth_token', null);
+        $this->migrator->add('sentry.api_base', 'https://sentry.io/api/0');
+        $this->migrator->add('sentry.default_project_id', null);
+        $this->migrator->add('sentry.default_issue_type_id', null);
+        $this->migrator->add('sentry.default_priority_id', null);
+        $this->migrator->add('sentry.installation_uuid', null);
+    }
+
+    public function down(): void
+    {
+        $this->migrator->delete('sentry.enabled');
+        $this->migrator->delete('sentry.org_slug');
+        $this->migrator->delete('sentry.client_id');
+        $this->migrator->delete('sentry.client_secret');
+        $this->migrator->delete('sentry.auth_token');
+        $this->migrator->delete('sentry.api_base');
+        $this->migrator->delete('sentry.default_project_id');
+        $this->migrator->delete('sentry.default_issue_type_id');
+        $this->migrator->delete('sentry.default_priority_id');
+        $this->migrator->delete('sentry.installation_uuid');
+    }
+};

--- a/database/settings/2026_06_02_000001_create_sentry_defaults.php
+++ b/database/settings/2026_06_02_000001_create_sentry_defaults.php
@@ -2,8 +2,7 @@
 
 use Spatie\LaravelSettings\Migrations\SettingsMigration;
 
-return new class extends SettingsMigration
-{
+return new class () extends SettingsMigration {
     public function up(): void
     {
         $this->migrator->add('sentry.enabled', false);

--- a/resources/integrations/sentry/schema.json
+++ b/resources/integrations/sentry/schema.json
@@ -1,0 +1,35 @@
+{
+  "elements": [
+    {
+      "type": "alert-rule-action",
+      "title": "Send to Forge",
+      "settings": {
+        "type": "alert-rule-settings",
+        "uri": "/api/webhooks/sentry",
+        "required_fields": [
+          {
+            "type": "select",
+            "label": "Forge project",
+            "name": "forge_project_id",
+            "uri": "/api/sentry/options/projects",
+            "async": true
+          },
+          {
+            "type": "select",
+            "label": "Issue type",
+            "name": "forge_issue_type_id",
+            "uri": "/api/sentry/options/issue-types",
+            "async": true
+          },
+          {
+            "type": "select",
+            "label": "Priority",
+            "name": "forge_priority_id",
+            "uri": "/api/sentry/options/priorities",
+            "async": true
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\V1\Feedback\Admin;
 use App\Http\Controllers\Api\V1\SystemIssueController;
 use App\Http\Controllers\Api\V1\SystemOrganizationController;
 use App\Http\Controllers\Api\V1\SystemProjectController;
+use App\Http\Controllers\Sentry\AlertRuleOptionsController;
 use App\Http\Controllers\Webhooks\GitHubWebhookController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -16,6 +17,17 @@ Route::get('/user', static function (Request $request) {
 
 Route::post('/webhooks/github', [GitHubWebhookController::class, 'handle'])
     ->name('webhooks.github');
+
+Route::webhooks('/webhooks/sentry', 'sentry');
+
+Route::prefix('sentry/options')
+    ->name('sentry.options.')
+    ->middleware('sentry.hook')
+    ->group(function (): void {
+        Route::get('projects', [AlertRuleOptionsController::class, 'projects'])->name('projects');
+        Route::get('issue-types', [AlertRuleOptionsController::class, 'issueTypes'])->name('issue-types');
+        Route::get('priorities', [AlertRuleOptionsController::class, 'priorities'])->name('priorities');
+    });
 
 Route::prefix('v1')->name('api.v1.')->group(function () {
     // Public (throttled) ingest; optionally protect with 'ingest.key' later.

--- a/tests/Feature/Integrations/Sentry/AlertRuleOptionsTest.php
+++ b/tests/Feature/Integrations/Sentry/AlertRuleOptionsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Feature\Integrations\Sentry;
+
+use App\Models\Project;
+use App\Settings\SentrySettings;
+use Database\Seeders\IssueEnumsSeeder;
+use Database\Seeders\PermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AlertRuleOptionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $clientSecret = 'sentry-shh-secret';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(PermissionSeeder::class);
+        $this->seed(IssueEnumsSeeder::class);
+
+        $s = app(SentrySettings::class);
+        $s->enabled = true;
+        $s->org_slug = 'acme';
+        $s->client_id = 'cid';
+        $s->client_secret = $this->clientSecret;
+        $s->auth_token = 'tok';
+        $s->api_base = 'https://sentry.io/api/0';
+        $s->save();
+    }
+
+    public function test_projects_endpoint_returns_choices_when_signed(): void
+    {
+        Project::factory()->count(2)->create();
+
+        $sig = hash_hmac('sha256', '', $this->clientSecret);
+        $response = $this->call('GET', '/api/sentry/options/projects', [], [], [], [
+            'HTTP_SENTRY_HOOK_SIGNATURE' => $sig,
+        ]);
+
+        $response->assertOk();
+        $json = $response->json();
+        $this->assertArrayHasKey('choices', $json);
+        $this->assertCount(2, $json['choices']);
+        $this->assertCount(2, $json['choices'][0], 'each choice should be [id, label]');
+    }
+
+    public function test_issue_types_endpoint_returns_seeded_types(): void
+    {
+        $sig = hash_hmac('sha256', '', $this->clientSecret);
+        $response = $this->call('GET', '/api/sentry/options/issue-types', [], [], [], [
+            'HTTP_SENTRY_HOOK_SIGNATURE' => $sig,
+        ]);
+
+        $response->assertOk();
+        $labels = array_column($response->json('choices'), 1);
+        $this->assertContains('Bug', $labels);
+        $this->assertContains('Task', $labels);
+    }
+
+    public function test_priorities_endpoint_returns_seeded_priorities(): void
+    {
+        $sig = hash_hmac('sha256', '', $this->clientSecret);
+        $response = $this->call('GET', '/api/sentry/options/priorities', [], [], [], [
+            'HTTP_SENTRY_HOOK_SIGNATURE' => $sig,
+        ]);
+
+        $response->assertOk();
+        $labels = array_column($response->json('choices'), 1);
+        $this->assertContains('High', $labels);
+        $this->assertContains('Low', $labels);
+    }
+
+    public function test_endpoint_rejects_request_with_bad_signature(): void
+    {
+        $response = $this->call('GET', '/api/sentry/options/projects', [], [], [], [
+            'HTTP_SENTRY_HOOK_SIGNATURE' => 'bogus',
+        ]);
+
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_endpoint_rejects_when_integration_disabled(): void
+    {
+        $s = app(SentrySettings::class);
+        $s->enabled = false;
+        $s->save();
+
+        $sig = hash_hmac('sha256', '', $this->clientSecret);
+        $response = $this->call('GET', '/api/sentry/options/projects', [], [], [], [
+            'HTTP_SENTRY_HOOK_SIGNATURE' => $sig,
+        ]);
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+}

--- a/tests/Feature/Integrations/Sentry/InboundWebhookTest.php
+++ b/tests/Feature/Integrations/Sentry/InboundWebhookTest.php
@@ -71,7 +71,9 @@ class InboundWebhookTest extends TestCase
         $response = $this->call(
             'POST',
             '/api/webhooks/sentry',
-            [], [], [],
+            [],
+            [],
+            [],
             [
                 'CONTENT_TYPE' => 'application/json',
                 'HTTP_SENTRY_HOOK_RESOURCE' => 'event_alert',
@@ -122,7 +124,9 @@ class InboundWebhookTest extends TestCase
         $response = $this->call(
             'POST',
             '/api/webhooks/sentry',
-            [], [], [],
+            [],
+            [],
+            [],
             [
                 'CONTENT_TYPE' => 'application/json',
                 'HTTP_SENTRY_HOOK_RESOURCE' => 'event_alert',
@@ -151,7 +155,9 @@ class InboundWebhookTest extends TestCase
         $response = $this->call(
             'POST',
             '/api/webhooks/sentry',
-            [], [], [],
+            [],
+            [],
+            [],
             [
                 'CONTENT_TYPE' => 'application/json',
                 'HTTP_SENTRY_HOOK_RESOURCE' => 'installation',

--- a/tests/Feature/Integrations/Sentry/InboundWebhookTest.php
+++ b/tests/Feature/Integrations/Sentry/InboundWebhookTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Feature\Integrations\Sentry;
+
+use App\Models\Issue;
+use App\Models\IssueExternalRef;
+use App\Models\IssuePriority;
+use App\Models\IssueType;
+use App\Models\Project;
+use App\Models\WebhookDelivery;
+use App\Settings\SentrySettings;
+use Database\Seeders\IssueEnumsSeeder;
+use Database\Seeders\PermissionSeeder;
+use Database\Seeders\SentryIntegrationUserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class InboundWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $clientSecret = 'sentry-shh-secret';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(PermissionSeeder::class);
+        $this->seed(IssueEnumsSeeder::class);
+        $this->seed(SentryIntegrationUserSeeder::class);
+
+        $settings = app(SentrySettings::class);
+        $settings->enabled = true;
+        $settings->org_slug = 'acme';
+        $settings->client_id = 'cid';
+        $settings->client_secret = $this->clientSecret;
+        $settings->auth_token = 'tok';
+        $settings->api_base = 'https://sentry.io/api/0';
+        $settings->save();
+    }
+
+    public function test_signed_event_alert_creates_forge_issue_and_external_ref(): void
+    {
+        $project = Project::factory()->create();
+        $type = IssueType::query()->where('key', 'BUG')->first();
+        $prio = IssuePriority::query()->where('key', 'HIGH')->first();
+
+        $s = app(SentrySettings::class);
+        $s->default_project_id = (string) $project->id;
+        $s->default_issue_type_id = $type->id;
+        $s->default_priority_id = $prio->id;
+        $s->save();
+
+        $payload = [
+            'action' => 'triggered',
+            'data' => [
+                'issue' => [
+                    'id' => '900001',
+                    'title' => 'TypeError in checkout',
+                    'culprit' => 'App\\Checkout::pay',
+                    'level' => 'error',
+                    'web_url' => 'https://sentry.io/issues/900001/',
+                ],
+            ],
+            'installation' => ['uuid' => 'uuid-1'],
+            'actor' => ['type' => 'application', 'id' => 'sentry', 'name' => 'Sentry'],
+        ];
+        $body = json_encode($payload, JSON_UNESCAPED_SLASHES);
+        $sig = hash_hmac('sha256', $body, $this->clientSecret);
+
+        $response = $this->call(
+            'POST',
+            '/api/webhooks/sentry',
+            [], [], [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_SENTRY_HOOK_RESOURCE' => 'event_alert',
+                'HTTP_SENTRY_HOOK_SIGNATURE' => $sig,
+                'HTTP_SENTRY_HOOK_TIMESTAMP' => (string) now()->getTimestamp(),
+                'HTTP_REQUEST_ID' => 'req-1',
+            ],
+            $body,
+        );
+
+        $this->assertLessThan(400, $response->getStatusCode(), 'expected 2xx, got: '.$response->getStatusCode().' body='.$response->getContent());
+
+        $this->assertDatabaseHas('webhook_deliveries', [
+            'provider' => 'sentry',
+            'event_type' => 'event_alert',
+        ]);
+        $delivery = WebhookDelivery::query()->where('provider', 'sentry')->first();
+        $this->assertSame(204, (int) $delivery->http_status);
+        $this->assertNull($delivery->processing_error);
+
+        $ref = IssueExternalRef::query()
+            ->where('provider', 'sentry')
+            ->where('external_issue_id', '900001')
+            ->first();
+
+        $this->assertNotNull($ref);
+        $this->assertSame('https://sentry.io/issues/900001/', $ref->url);
+
+        $issue = Issue::query()->find($ref->issue_id);
+        $this->assertNotNull($issue);
+        $this->assertSame((string) $project->id, (string) $issue->project_id);
+        $this->assertStringContainsString('TypeError in checkout', (string) $issue->summary);
+    }
+
+    public function test_invalid_signature_is_rejected_and_no_issue_created(): void
+    {
+        $project = Project::factory()->create();
+        $s = app(SentrySettings::class);
+        $s->default_project_id = (string) $project->id;
+        $s->save();
+
+        $payload = [
+            'action' => 'triggered',
+            'data' => ['issue' => ['id' => '900002', 'title' => 't']],
+        ];
+        $body = json_encode($payload);
+
+        $response = $this->call(
+            'POST',
+            '/api/webhooks/sentry',
+            [], [], [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_SENTRY_HOOK_RESOURCE' => 'event_alert',
+                'HTTP_SENTRY_HOOK_SIGNATURE' => 'wrong-signature-here',
+            ],
+            $body,
+        );
+
+        $this->assertGreaterThanOrEqual(400, $response->getStatusCode(), 'expected 4xx/5xx for bad sig');
+        $this->assertDatabaseMissing('issue_external_refs', [
+            'provider' => 'sentry',
+            'external_issue_id' => '900002',
+        ]);
+    }
+
+    public function test_installation_created_captures_uuid_on_settings(): void
+    {
+        $payload = [
+            'action' => 'created',
+            'installation' => ['uuid' => 'install-uuid-xyz'],
+            'data' => [],
+        ];
+        $body = json_encode($payload);
+        $sig = hash_hmac('sha256', $body, $this->clientSecret);
+
+        $response = $this->call(
+            'POST',
+            '/api/webhooks/sentry',
+            [], [], [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_SENTRY_HOOK_RESOURCE' => 'installation',
+                'HTTP_SENTRY_HOOK_SIGNATURE' => $sig,
+            ],
+            $body,
+        );
+
+        $this->assertLessThan(400, $response->getStatusCode());
+        $this->assertSame('install-uuid-xyz', app(SentrySettings::class)->refresh()->installation_uuid);
+    }
+}

--- a/tests/Feature/Integrations/Sentry/OutboundSyncTest.php
+++ b/tests/Feature/Integrations/Sentry/OutboundSyncTest.php
@@ -35,8 +35,7 @@ class OutboundSyncTest extends TestCase
         // RefreshDatabase wraps each test in a transaction that never commits.
         // ->afterCommit() jobs would never dispatch. Swap the txn manager on
         // the active connection so callbacks fire immediately.
-        $immediate = new class extends DatabaseTransactionsManager
-        {
+        $immediate = new class () extends DatabaseTransactionsManager {
             public function addCallback($callback)
             {
                 $callback();

--- a/tests/Feature/Integrations/Sentry/OutboundSyncTest.php
+++ b/tests/Feature/Integrations/Sentry/OutboundSyncTest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace Tests\Feature\Integrations\Sentry;
+
+use App\Integrations\Sentry\Jobs\SyncCommentToSentryJob;
+use App\Integrations\Sentry\Jobs\SyncIssueStatusToSentryJob;
+use App\Integrations\Sentry\Services\SentryClient;
+use App\Integrations\Sentry\Support\SentrySyncContext;
+use App\Models\Comment;
+use App\Models\Issue;
+use App\Models\IssueExternalRef;
+use App\Models\IssuePriority;
+use App\Models\IssueStatus;
+use App\Models\IssueType;
+use App\Models\Project;
+use App\Models\User;
+use App\Settings\SentrySettings;
+use Database\Seeders\IssueEnumsSeeder;
+use Database\Seeders\PermissionSeeder;
+use Illuminate\Database\DatabaseTransactionsManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class OutboundSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // RefreshDatabase wraps each test in a transaction that never commits.
+        // ->afterCommit() jobs would never dispatch. Swap the txn manager on
+        // the active connection so callbacks fire immediately.
+        $immediate = new class extends DatabaseTransactionsManager
+        {
+            public function addCallback($callback)
+            {
+                $callback();
+
+                return null;
+            }
+        };
+        $this->app->instance('db.transactions', $immediate);
+        DB::connection()->setTransactionManager($immediate);
+
+        $this->seed(PermissionSeeder::class);
+        $this->seed(IssueEnumsSeeder::class);
+
+        $settings = app(SentrySettings::class);
+        $settings->enabled = true;
+        $settings->org_slug = 'acme';
+        $settings->client_id = 'cid';
+        $settings->client_secret = 'cs';
+        $settings->auth_token = 'tok';
+        $settings->api_base = 'https://sentry.io/api/0';
+        $settings->save();
+    }
+
+    public function test_status_transition_to_done_dispatches_resolve_job(): void
+    {
+        Bus::fake();
+
+        $issue = $this->makeLinkedIssue();
+        $done = IssueStatus::query()->where('is_done', true)->orderBy('order')->first();
+
+        $issue->issue_status_id = $done->id;
+        $issue->save();
+
+        Bus::assertDispatched(SyncIssueStatusToSentryJob::class, function (SyncIssueStatusToSentryJob $job) use ($issue) {
+            return $job->issueId === $issue->id && $job->resolve === true;
+        });
+    }
+
+    public function test_status_transition_off_done_dispatches_unresolve_job(): void
+    {
+        Bus::fake([SyncIssueStatusToSentryJob::class]);
+
+        $issue = $this->makeLinkedIssue();
+        $done = IssueStatus::query()->where('is_done', true)->orderBy('order')->first();
+        $open = IssueStatus::query()->where('is_done', false)->orderBy('order')->first();
+
+        $issue->issue_status_id = $done->id;
+        $issue->save();
+        Bus::assertDispatched(SyncIssueStatusToSentryJob::class, fn ($j) => $j->resolve === true);
+
+        $issue->issue_status_id = $open->id;
+        $issue->save();
+        Bus::assertDispatched(SyncIssueStatusToSentryJob::class, fn ($j) => $j->resolve === false);
+    }
+
+    public function test_no_job_dispatched_when_issue_not_linked_to_sentry(): void
+    {
+        Bus::fake([SyncIssueStatusToSentryJob::class]);
+
+        $issue = $this->makeIssue();
+        $done = IssueStatus::query()->where('is_done', true)->orderBy('order')->first();
+
+        $issue->issue_status_id = $done->id;
+        $issue->save();
+
+        Bus::assertNotDispatched(SyncIssueStatusToSentryJob::class);
+    }
+
+    public function test_no_job_dispatched_when_sentry_sync_context_active(): void
+    {
+        Bus::fake([SyncIssueStatusToSentryJob::class]);
+
+        $issue = $this->makeLinkedIssue();
+        $done = IssueStatus::query()->where('is_done', true)->orderBy('order')->first();
+
+        SentrySyncContext::run(function () use ($issue, $done) {
+            $issue->issue_status_id = $done->id;
+            $issue->save();
+        });
+
+        Bus::assertNotDispatched(SyncIssueStatusToSentryJob::class);
+    }
+
+    public function test_comment_on_linked_issue_dispatches_comment_job(): void
+    {
+        Bus::fake([SyncCommentToSentryJob::class]);
+
+        $issue = $this->makeLinkedIssue();
+        $user = User::factory()->create();
+
+        $comment = new Comment([
+            'body' => 'looking at it',
+            'user_id' => $user->id,
+        ]);
+        $comment->commentable_type = Issue::class;
+        $comment->commentable_id = $issue->id;
+        $comment->save();
+
+        Bus::assertDispatched(SyncCommentToSentryJob::class, function (SyncCommentToSentryJob $j) use ($comment) {
+            return $j->commentId === $comment->id;
+        });
+    }
+
+    public function test_sentry_client_calls_resolve_endpoint(): void
+    {
+        Http::fake([
+            'sentry.io/api/0/issues/12345/' => Http::response('', 200),
+            'sentry.io/api/0/issues/12345/comments/' => Http::response('', 201),
+        ]);
+
+        app(SentryClient::class)->resolveIssue('12345');
+        app(SentryClient::class)->postComment('12345', 'hello');
+
+        Http::assertSent(function ($request) {
+            return $request->method() === 'PUT'
+                && str_ends_with($request->url(), '/issues/12345/')
+                && $request['status'] === 'resolved';
+        });
+        Http::assertSent(function ($request) {
+            return $request->method() === 'POST'
+                && str_ends_with($request->url(), '/issues/12345/comments/')
+                && $request['text'] === 'hello';
+        });
+    }
+
+    private function makeIssue(): Issue
+    {
+        $project = Project::factory()->create();
+        $type = IssueType::query()->where('key', 'TASK')->first();
+        $prio = IssuePriority::query()->where('key', 'MEDIUM')->first();
+        $open = IssueStatus::query()->where('is_done', false)->orderBy('order')->first();
+
+        return Issue::create([
+            'project_id' => $project->id,
+            'issue_type_id' => $type->id,
+            'issue_priority_id' => $prio->id,
+            'issue_status_id' => $open->id,
+            'reporter_id' => User::factory()->create()->id,
+            'summary' => 'demo',
+            'description' => 'demo',
+        ]);
+    }
+
+    private function makeLinkedIssue(): Issue
+    {
+        $issue = $this->makeIssue();
+
+        IssueExternalRef::create([
+            'issue_id' => $issue->id,
+            'provider' => 'sentry',
+            'external_issue_id' => '12345',
+            'state' => 'open',
+            'url' => 'https://sentry.io/issues/12345/',
+        ]);
+
+        return $issue;
+    }
+}

--- a/tests/Unit/Integrations/Sentry/SentryHeadersTest.php
+++ b/tests/Unit/Integrations/Sentry/SentryHeadersTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Unit\Integrations\Sentry;
+
+use App\Integrations\Sentry\Support\SentryHeaders;
+use PHPUnit\Framework\TestCase;
+
+class SentryHeadersTest extends TestCase
+{
+    public function test_value_is_case_insensitive_against_lowercase_storage(): void
+    {
+        $stored = [
+            'sentry-hook-resource' => ['issue'],
+            'request-id' => ['req-1'],
+        ];
+
+        $this->assertSame('issue', SentryHeaders::value($stored, 'Sentry-Hook-Resource'));
+        $this->assertSame('req-1', SentryHeaders::value($stored, 'Request-ID'));
+        $this->assertSame('issue', SentryHeaders::value($stored, 'sentry-hook-resource'));
+    }
+
+    public function test_value_handles_preserved_case_storage(): void
+    {
+        $stored = [
+            'Sentry-Hook-Resource' => ['installation'],
+            'Request-ID' => 'req-2',
+        ];
+
+        $this->assertSame('installation', SentryHeaders::value($stored, 'sentry-hook-resource'));
+        $this->assertSame('req-2', SentryHeaders::value($stored, 'request-id'));
+    }
+
+    public function test_value_returns_null_when_missing(): void
+    {
+        $this->assertNull(SentryHeaders::value([], 'Sentry-Hook-Resource'));
+    }
+
+    public function test_normalize_lowercases_keys_and_wraps_scalar_values(): void
+    {
+        $out = SentryHeaders::normalize([
+            'Sentry-Hook-Resource' => 'issue',
+            'Request-ID' => ['req-3'],
+        ]);
+
+        $this->assertSame(['issue'], $out['sentry-hook-resource']);
+        $this->assertSame(['req-3'], $out['request-id']);
+    }
+}

--- a/tests/Unit/Integrations/Sentry/SentrySignatureValidatorTest.php
+++ b/tests/Unit/Integrations/Sentry/SentrySignatureValidatorTest.php
@@ -30,7 +30,7 @@ class SentrySignatureValidatorTest extends TestCase
         $config = $this->makeConfig();
         $this->bindSettings(enabled: true, secret: $secret);
 
-        $this->assertTrue((new SentrySignatureValidator)->isValid($request, $config));
+        $this->assertTrue((new SentrySignatureValidator())->isValid($request, $config));
     }
 
     public function test_returns_false_when_body_is_tampered(): void
@@ -45,7 +45,7 @@ class SentrySignatureValidatorTest extends TestCase
         $config = $this->makeConfig();
         $this->bindSettings(enabled: true, secret: $secret);
 
-        $this->assertFalse((new SentrySignatureValidator)->isValid($request, $config));
+        $this->assertFalse((new SentrySignatureValidator())->isValid($request, $config));
     }
 
     public function test_returns_false_when_integration_disabled(): void
@@ -60,7 +60,7 @@ class SentrySignatureValidatorTest extends TestCase
         $config = $this->makeConfig();
         $this->bindSettings(enabled: false, secret: $secret);
 
-        $this->assertFalse((new SentrySignatureValidator)->isValid($request, $config));
+        $this->assertFalse((new SentrySignatureValidator())->isValid($request, $config));
     }
 
     public function test_returns_false_when_secret_empty(): void
@@ -72,7 +72,7 @@ class SentrySignatureValidatorTest extends TestCase
         $config = $this->makeConfig();
         $this->bindSettings(enabled: true, secret: '');
 
-        $this->assertFalse((new SentrySignatureValidator)->isValid($request, $config));
+        $this->assertFalse((new SentrySignatureValidator())->isValid($request, $config));
     }
 
     public function test_returns_false_when_header_missing(): void
@@ -82,7 +82,7 @@ class SentrySignatureValidatorTest extends TestCase
         $config = $this->makeConfig();
         $this->bindSettings(enabled: true, secret: 'shh');
 
-        $this->assertFalse((new SentrySignatureValidator)->isValid($request, $config));
+        $this->assertFalse((new SentrySignatureValidator())->isValid($request, $config));
     }
 
     private function makeConfig(): WebhookConfig
@@ -95,7 +95,7 @@ class SentrySignatureValidatorTest extends TestCase
 
     private function bindSettings(bool $enabled, string $secret): void
     {
-        $settings = new \stdClass;
+        $settings = new \stdClass();
         $settings->enabled = $enabled;
         $settings->client_secret = $secret;
 

--- a/tests/Unit/Integrations/Sentry/SentrySignatureValidatorTest.php
+++ b/tests/Unit/Integrations/Sentry/SentrySignatureValidatorTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Unit\Integrations\Sentry;
+
+use App\Integrations\Sentry\Webhooks\SentrySignatureValidator;
+use App\Settings\SentrySettings;
+use Illuminate\Container\Container;
+use Illuminate\Http\Request;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+use Spatie\WebhookClient\WebhookConfig;
+
+class SentrySignatureValidatorTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_returns_true_for_valid_hmac_sha256_signature(): void
+    {
+        $secret = 'shh-its-a-secret';
+        $body = '{"action":"created","installation":{"uuid":"abc"}}';
+        $sig = hash_hmac('sha256', $body, $secret);
+
+        $request = Request::create('/api/webhooks/sentry', 'POST', [], [], [], [], $body);
+        $request->headers->set('Sentry-Hook-Signature', $sig);
+
+        $config = $this->makeConfig();
+        $this->bindSettings(enabled: true, secret: $secret);
+
+        $this->assertTrue((new SentrySignatureValidator)->isValid($request, $config));
+    }
+
+    public function test_returns_false_when_body_is_tampered(): void
+    {
+        $secret = 'shh';
+        $body = '{"action":"created"}';
+        $sig = hash_hmac('sha256', $body, $secret);
+
+        $request = Request::create('/api/webhooks/sentry', 'POST', [], [], [], [], $body.'tampered');
+        $request->headers->set('Sentry-Hook-Signature', $sig);
+
+        $config = $this->makeConfig();
+        $this->bindSettings(enabled: true, secret: $secret);
+
+        $this->assertFalse((new SentrySignatureValidator)->isValid($request, $config));
+    }
+
+    public function test_returns_false_when_integration_disabled(): void
+    {
+        $secret = 'shh';
+        $body = '{}';
+        $sig = hash_hmac('sha256', $body, $secret);
+
+        $request = Request::create('/api/webhooks/sentry', 'POST', [], [], [], [], $body);
+        $request->headers->set('Sentry-Hook-Signature', $sig);
+
+        $config = $this->makeConfig();
+        $this->bindSettings(enabled: false, secret: $secret);
+
+        $this->assertFalse((new SentrySignatureValidator)->isValid($request, $config));
+    }
+
+    public function test_returns_false_when_secret_empty(): void
+    {
+        $body = '{}';
+        $request = Request::create('/api/webhooks/sentry', 'POST', [], [], [], [], $body);
+        $request->headers->set('Sentry-Hook-Signature', 'anything');
+
+        $config = $this->makeConfig();
+        $this->bindSettings(enabled: true, secret: '');
+
+        $this->assertFalse((new SentrySignatureValidator)->isValid($request, $config));
+    }
+
+    public function test_returns_false_when_header_missing(): void
+    {
+        $request = Request::create('/api/webhooks/sentry', 'POST', [], [], [], [], '{}');
+
+        $config = $this->makeConfig();
+        $this->bindSettings(enabled: true, secret: 'shh');
+
+        $this->assertFalse((new SentrySignatureValidator)->isValid($request, $config));
+    }
+
+    private function makeConfig(): WebhookConfig
+    {
+        $config = Mockery::mock(WebhookConfig::class);
+        $config->signatureHeaderName = 'Sentry-Hook-Signature';
+
+        return $config;
+    }
+
+    private function bindSettings(bool $enabled, string $secret): void
+    {
+        $settings = new \stdClass;
+        $settings->enabled = $enabled;
+        $settings->client_secret = $secret;
+
+        $container = Container::getInstance();
+        $container->instance(SentrySettings::class, $settings);
+    }
+}


### PR DESCRIPTION
- Introduce `SentrySettings` with encrypted DB-backed configuration.
- Add Sentry alert rule options endpoints (`projects`, `issue-types`, `priorities`) with signature validation.
- Implement Sentry issue and comment synchronization via observers and jobs.
- Update routes, middleware, and settings migrations for Sentry integration.
- Extend `ConnectorsAndSyncSettings` Filament page with Sentry settings management.
- Add Sentry integration feature tests and webhook signature validator unit tests.

## Summary by Sourcery

Add first-class Sentry integration with configuration, webhooks, and bidirectional issue/comment syncing.

New Features:
- Expose Sentry configuration alongside existing connectors, including defaults, installation UUID display, and a Sentry connectivity test action.
- Add Sentry alert rule options API endpoints for projects, issue types, and priorities secured by HMAC-signed requests.
- Introduce inbound Sentry webhook handling for installations, event alerts, and issue events with persisted delivery records and loop-prevention context.
- Implement outbound syncing of Forge issue status changes and comments to Sentry issues via queued jobs and a dedicated client service.

Enhancements:
- Register Sentry integration observers, middleware, and service provider wiring to hook into existing models and routing.
- Store Sentry integration settings in encrypted, DB-backed settings with an initial migration and supporting config and seeder utilities.

Tests:
- Add feature tests covering Sentry outbound sync behavior, inbound webhook handling, and alert rule options endpoints.
- Add unit tests for the Sentry webhook signature validator to verify HMAC handling and disabled/invalid scenarios.