### PR TITLE
fixes for 401 errors on Sentry integration

### DIFF
--- a/app/Filament/Pages/ConnectorsAndSyncSettings.php
+++ b/app/Filament/Pages/ConnectorsAndSyncSettings.php
@@ -44,6 +44,11 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
 
     public function mount(): void
     {
+        $this->refreshData();
+    }
+
+    private function refreshData(): void
+    {
         $github = app(GithubSettings::class);
         $gitea = app(GiteaSettings::class);
         $sync = app(SyncSettings::class);
@@ -55,10 +60,16 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
             'github_client_id' => $github->client_id,
             'github_api_base' => $github->api_base,
             'github_web_base' => $github->web_base,
+            'github_client_secret_set' => filled($github->client_secret),
+            'github_webhook_secret_set' => filled($github->webhook_secret),
+            'github_personal_access_token_set' => filled($github->personal_access_token),
             'gitea_enabled' => $gitea->enabled,
             'gitea_base_url' => $gitea->base_url,
             'gitea_app_name' => $gitea->app_name,
             'gitea_client_id' => $gitea->client_id,
+            'gitea_client_secret_set' => filled($gitea->client_secret),
+            'gitea_webhook_secret_set' => filled($gitea->webhook_secret),
+            'gitea_personal_access_token_set' => filled($gitea->personal_access_token),
             'sync_allow_outbound' => $sync->allow_outbound_issue_updates,
             'sync_auto_transition' => $sync->auto_transition_on_pr_merge,
             'sync_link_keyword_fix' => $sync->link_keyword_fix,
@@ -71,7 +82,16 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
             'sentry_default_issue_type_id' => $sentry->default_issue_type_id,
             'sentry_default_priority_id' => $sentry->default_priority_id,
             'sentry_installation_uuid' => $sentry->installation_uuid,
+            'sentry_client_secret_set' => filled($sentry->client_secret),
+            'sentry_auth_token_set' => filled($sentry->auth_token),
         ];
+    }
+
+    private function storedBadge(string $dataKey): string
+    {
+        return ! empty($this->data[$dataKey])
+            ? 'Configured (leave blank to keep current value)'
+            : 'Not set';
     }
 
     /**
@@ -88,11 +108,14 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
                         TextInput::make('github_app_name')->label('App Name')->required(),
                         TextInput::make('github_client_id')->label('Client ID'),
                         TextInput::make('github_client_secret')->label('Client Secret')->password()->revealable()
-                            ->dehydrated(fn ($s) => filled($s)),
+                            ->dehydrated(fn ($s) => filled($s))
+                            ->helperText(fn () => $this->storedBadge('github_client_secret_set')),
                         TextInput::make('github_webhook_secret')->label('Webhook Secret')->password()->revealable()
-                            ->dehydrated(fn ($s) => filled($s)),
+                            ->dehydrated(fn ($s) => filled($s))
+                            ->helperText(fn () => $this->storedBadge('github_webhook_secret_set')),
                         TextInput::make('github_personal_access_token')->label('Personal Access Token')->password()->revealable()
-                            ->dehydrated(fn ($s) => filled($s)),
+                            ->dehydrated(fn ($s) => filled($s))
+                            ->helperText(fn () => $this->storedBadge('github_personal_access_token_set')),
                         TextInput::make('github_api_base')->label('API Base')->default('https://api.github.com')->required(),
                         TextInput::make('github_web_base')->label('Web Base')->default('https://github.com')->required(),
                     ])->columns(2),
@@ -103,11 +126,14 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
                         TextInput::make('gitea_app_name')->label('App Name')->required(),
                         TextInput::make('gitea_client_id')->label('Client ID'),
                         TextInput::make('gitea_client_secret')->label('Client Secret')->password()->revealable()
-                            ->dehydrated(fn ($s) => filled($s)),
+                            ->dehydrated(fn ($s) => filled($s))
+                            ->helperText(fn () => $this->storedBadge('gitea_client_secret_set')),
                         TextInput::make('gitea_webhook_secret')->label('Webhook Secret')->password()->revealable()
-                            ->dehydrated(fn ($s) => filled($s)),
+                            ->dehydrated(fn ($s) => filled($s))
+                            ->helperText(fn () => $this->storedBadge('gitea_webhook_secret_set')),
                         TextInput::make('gitea_personal_access_token')->label('Personal Access Token')->password()->revealable()
-                            ->dehydrated(fn ($s) => filled($s)),
+                            ->dehydrated(fn ($s) => filled($s))
+                            ->helperText(fn () => $this->storedBadge('gitea_personal_access_token_set')),
                     ])->columns(2),
 
                     Section::make('Sync Policy')->schema([
@@ -124,9 +150,11 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
                             TextInput::make('sentry_org_slug')->label('Sentry org slug')->placeholder('acme'),
                             TextInput::make('sentry_client_id')->label('Client ID'),
                             TextInput::make('sentry_client_secret')->label('Client Secret')->password()->revealable()
-                                ->dehydrated(fn ($s) => filled($s)),
+                                ->dehydrated(fn ($s) => filled($s))
+                                ->helperText(fn () => $this->storedBadge('sentry_client_secret_set')),
                             TextInput::make('sentry_auth_token')->label('Auth Token')->password()->revealable()
-                                ->dehydrated(fn ($s) => filled($s)),
+                                ->dehydrated(fn ($s) => filled($s))
+                                ->helperText(fn () => $this->storedBadge('sentry_auth_token_set')),
                             TextInput::make('sentry_api_base')->label('API Base')->default('https://sentry.io/api/0')->required(),
                             Select::make('sentry_default_project_id')->label('Default Forge project')
                                 ->options(fn () => Project::query()->orderBy('name')->pluck('name', 'id')->all())
@@ -217,6 +245,8 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
         $sentry->default_issue_type_id = $this->data['sentry_default_issue_type_id'] ? (int) $this->data['sentry_default_issue_type_id'] : null;
         $sentry->default_priority_id = $this->data['sentry_default_priority_id'] ? (int) $this->data['sentry_default_priority_id'] : null;
         $sentry->save();
+
+        $this->refreshData();
 
         Notification::make()->title('Settings saved')->success()->send();
     }

--- a/app/Http/Middleware/VerifySentryInstallation.php
+++ b/app/Http/Middleware/VerifySentryInstallation.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Settings\SentrySettings;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Auth for Sentry UI-component option lookups (e.g. /api/sentry/options/*).
+ *
+ * Sentry signs webhook deliveries (POSTs with a body) using HMAC-SHA256, but
+ * UI component select-option requests are GETs with no body. Instead, Sentry
+ * appends an `installationId` query parameter that identifies the installed
+ * integration. We validate that against the installation UUID Sentry sent us
+ * via the 'installation.created' webhook.
+ */
+final class VerifySentryInstallation
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $settings = app(SentrySettings::class);
+
+        if (! $settings->enabled) {
+            return response('Sentry integration disabled', 403);
+        }
+
+        $expected = (string) ($settings->installation_uuid ?? '');
+        if ($expected === '') {
+            return response('Sentry installation not yet recorded', 403);
+        }
+
+        $provided = (string) $request->query('installationId', '');
+        if ($provided === '') {
+            return response('Missing installationId', 401);
+        }
+
+        if (! hash_equals($expected, $provided)) {
+            return response('Unknown installationId', 401);
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -8,6 +8,7 @@ use App\Http\Middleware\EnsureSupportIdentity;
 use App\Http\Middleware\SetPermissionsTeamContext;
 use App\Http\Middleware\VerifyIngestKey;
 use App\Http\Middleware\VerifySentryHookSignature;
+use App\Http\Middleware\VerifySentryInstallation;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -33,6 +34,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'feedback.identity.optional' => EnsureOptionalFeedbackIdentity::class,
             'ingest.key' => VerifyIngestKey::class,
             'sentry.hook' => VerifySentryHookSignature::class,
+            'sentry.installation' => VerifySentryInstallation::class,
             'auth.registration' => EnsureRegistrationIsEnabled::class,
             // Validates client credentials tokens (machine-to-machine OAuth2)
             'client' => CheckToken::class,

--- a/routes/api.php
+++ b/routes/api.php
@@ -22,7 +22,7 @@ Route::webhooks('/webhooks/sentry', 'sentry');
 
 Route::prefix('sentry/options')
     ->name('sentry.options.')
-    ->middleware('sentry.hook')
+    ->middleware('sentry.installation')
     ->group(function (): void {
         Route::get('projects', [AlertRuleOptionsController::class, 'projects'])->name('projects');
         Route::get('issue-types', [AlertRuleOptionsController::class, 'issueTypes'])->name('issue-types');

--- a/tests/Feature/Integrations/Sentry/AlertRuleOptionsTest.php
+++ b/tests/Feature/Integrations/Sentry/AlertRuleOptionsTest.php
@@ -13,7 +13,7 @@ class AlertRuleOptionsTest extends TestCase
 {
     use RefreshDatabase;
 
-    private string $clientSecret = 'sentry-shh-secret';
+    private string $installationUuid = '9a89a822-0b62-4b62-9b99-905b9d742dd1';
 
     protected function setUp(): void
     {
@@ -26,20 +26,18 @@ class AlertRuleOptionsTest extends TestCase
         $s->enabled = true;
         $s->org_slug = 'acme';
         $s->client_id = 'cid';
-        $s->client_secret = $this->clientSecret;
+        $s->client_secret = 'cs';
         $s->auth_token = 'tok';
         $s->api_base = 'https://sentry.io/api/0';
+        $s->installation_uuid = $this->installationUuid;
         $s->save();
     }
 
-    public function test_projects_endpoint_returns_choices_when_signed(): void
+    public function test_projects_endpoint_returns_choices_when_installation_id_matches(): void
     {
         Project::factory()->count(2)->create();
 
-        $sig = hash_hmac('sha256', '', $this->clientSecret);
-        $response = $this->call('GET', '/api/sentry/options/projects', [], [], [], [
-            'HTTP_SENTRY_HOOK_SIGNATURE' => $sig,
-        ]);
+        $response = $this->get('/api/sentry/options/projects?installationId='.$this->installationUuid);
 
         $response->assertOk();
         $json = $response->json();
@@ -50,10 +48,7 @@ class AlertRuleOptionsTest extends TestCase
 
     public function test_issue_types_endpoint_returns_seeded_types(): void
     {
-        $sig = hash_hmac('sha256', '', $this->clientSecret);
-        $response = $this->call('GET', '/api/sentry/options/issue-types', [], [], [], [
-            'HTTP_SENTRY_HOOK_SIGNATURE' => $sig,
-        ]);
+        $response = $this->get('/api/sentry/options/issue-types?installationId='.$this->installationUuid);
 
         $response->assertOk();
         $labels = array_column($response->json('choices'), 1);
@@ -63,10 +58,7 @@ class AlertRuleOptionsTest extends TestCase
 
     public function test_priorities_endpoint_returns_seeded_priorities(): void
     {
-        $sig = hash_hmac('sha256', '', $this->clientSecret);
-        $response = $this->call('GET', '/api/sentry/options/priorities', [], [], [], [
-            'HTTP_SENTRY_HOOK_SIGNATURE' => $sig,
-        ]);
+        $response = $this->get('/api/sentry/options/priorities?installationId='.$this->installationUuid);
 
         $response->assertOk();
         $labels = array_column($response->json('choices'), 1);
@@ -74,12 +66,15 @@ class AlertRuleOptionsTest extends TestCase
         $this->assertContains('Low', $labels);
     }
 
-    public function test_endpoint_rejects_request_with_bad_signature(): void
+    public function test_endpoint_rejects_request_with_wrong_installation_id(): void
     {
-        $response = $this->call('GET', '/api/sentry/options/projects', [], [], [], [
-            'HTTP_SENTRY_HOOK_SIGNATURE' => 'bogus',
-        ]);
+        $response = $this->get('/api/sentry/options/projects?installationId=not-the-right-uuid');
+        $this->assertSame(401, $response->getStatusCode());
+    }
 
+    public function test_endpoint_rejects_request_with_no_installation_id(): void
+    {
+        $response = $this->get('/api/sentry/options/projects');
         $this->assertSame(401, $response->getStatusCode());
     }
 
@@ -89,11 +84,17 @@ class AlertRuleOptionsTest extends TestCase
         $s->enabled = false;
         $s->save();
 
-        $sig = hash_hmac('sha256', '', $this->clientSecret);
-        $response = $this->call('GET', '/api/sentry/options/projects', [], [], [], [
-            'HTTP_SENTRY_HOOK_SIGNATURE' => $sig,
-        ]);
+        $response = $this->get('/api/sentry/options/projects?installationId='.$this->installationUuid);
+        $this->assertSame(403, $response->getStatusCode());
+    }
 
+    public function test_endpoint_rejects_when_installation_not_yet_recorded(): void
+    {
+        $s = app(SentrySettings::class);
+        $s->installation_uuid = null;
+        $s->save();
+
+        $response = $this->get('/api/sentry/options/projects?installationId='.$this->installationUuid);
         $this->assertSame(403, $response->getStatusCode());
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Validate Sentry option endpoints using installation IDs instead of webhook signatures and improve connector settings UX for stored secrets.

Bug Fixes:
- Prevent 401 errors on Sentry option endpoints by authenticating requests via the Sentry installation UUID query parameter and rejecting missing or mismatched installation IDs.
- Ensure Sentry option endpoints correctly reject requests when the integration is disabled or the installation UUID has not yet been recorded.

Enhancements:
- Introduce middleware to centralize Sentry installation validation and wire it into the Sentry options API routes.
- Enhance the connectors and sync settings page to indicate when secrets and tokens are already configured, and keep its state in sync after saving.