### PR TITLE
fixes for 403 errors on Sentry integration

### DIFF
--- a/app/Http/Middleware/VerifySentryInstallation.php
+++ b/app/Http/Middleware/VerifySentryInstallation.php
@@ -5,6 +5,7 @@ namespace App\Http\Middleware;
 use App\Settings\SentrySettings;
 use Closure;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -13,8 +14,8 @@ use Symfony\Component\HttpFoundation\Response;
  * Sentry signs webhook deliveries (POSTs with a body) using HMAC-SHA256, but
  * UI component select-option requests are GETs with no body. Instead, Sentry
  * appends an `installationId` query parameter that identifies the installed
- * integration. We validate that against the installation UUID Sentry sent us
- * via the 'installation.created' webhook.
+ * integration. We validate that against the recorded installation UUID, or
+ * capture the first one Sentry sends when the webhook job has not run yet.
  */
 final class VerifySentryInstallation
 {
@@ -26,14 +27,21 @@ final class VerifySentryInstallation
             return response('Sentry integration disabled', 403);
         }
 
-        $expected = (string) ($settings->installation_uuid ?? '');
-        if ($expected === '') {
-            return response('Sentry installation not yet recorded', 403);
-        }
-
         $provided = (string) $request->query('installationId', '');
         if ($provided === '') {
             return response('Missing installationId', 401);
+        }
+
+        $expected = (string) ($settings->installation_uuid ?? '');
+        if ($expected === '') {
+            $settings->installation_uuid = $provided;
+            $settings->save();
+
+            Log::info('Sentry installation UUID captured from options request', [
+                'installation_uuid_hash' => hash('sha256', $provided),
+            ]);
+
+            return $next($request);
         }
 
         if (! hash_equals($expected, $provided)) {

--- a/tests/Feature/Integrations/Sentry/AlertRuleOptionsTest.php
+++ b/tests/Feature/Integrations/Sentry/AlertRuleOptionsTest.php
@@ -88,13 +88,15 @@ class AlertRuleOptionsTest extends TestCase
         $this->assertSame(403, $response->getStatusCode());
     }
 
-    public function test_endpoint_rejects_when_installation_not_yet_recorded(): void
+    public function test_endpoint_captures_first_installation_id_when_not_yet_recorded(): void
     {
         $s = app(SentrySettings::class);
         $s->installation_uuid = null;
         $s->save();
 
         $response = $this->get('/api/sentry/options/projects?installationId='.$this->installationUuid);
-        $this->assertSame(403, $response->getStatusCode());
+
+        $response->assertOk();
+        $this->assertSame($this->installationUuid, app(SentrySettings::class)->refresh()->installation_uuid);
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Capture and persist the first Sentry installation UUID received from UI options requests to prevent erroneous 403 responses when the installation has not yet been recorded.

Bug Fixes:
- Allow Sentry options requests to succeed when the installation UUID is not yet stored by capturing the first provided installationId value instead of rejecting the request with 403.

Enhancements:
- Log a hashed version of the captured Sentry installation UUID for observability when the integration is first used.

Tests:
- Update the Sentry alert rule options feature test to assert that the first installationId is accepted and stored rather than rejected.