### PR TITLE
project feedback route fixes

### DIFF
--- a/resources/views/components/projects/nav-tabs.blade.php
+++ b/resources/views/components/projects/nav-tabs.blade.php
@@ -1,4 +1,7 @@
-@php use App\Models\Project; @endphp
+@php
+    use App\Models\Project;
+    use Symfony\Component\Routing\Exception\RouteNotFoundException;
+@endphp
 @props(['project'])
 
 @php
@@ -19,10 +22,17 @@
 
 <ul class="nav nav-tabs card-header-tabs">
     @foreach ($tabs as $t)
+        @php
+            try {
+                $url = route($t['route'], ['project' => $project]);
+            } catch (RouteNotFoundException) {
+                continue;
+            }
+        @endphp
         <li class="nav-item">
             <a
                 class="nav-link {{ request()->routeIs($t['route']) ? 'active' : '' }}"
-                href="{{ route($t['route'], ['project' => $project]) }}"
+                href="{{ $url }}"
             >
                 {{ __($t['label']) }}
             </a>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\TransitionStatusController;
 use App\Livewire\Feedback\AdminDiscussion;
 use App\Livewire\Settings\Appearance;
 use App\Livewire\Settings\Password;
+use App\Models\Project;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Route;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -107,6 +108,9 @@ Route::middleware([
     Route::get('/projects/{project}/calendar.ics', ProjectCalendarController::class)
         ->middleware(['auth', 'verified'])
         ->name('projects.calendar.ics');
+    Route::get('/projects/{project}/feedback', static fn (Project $project) => view('pages.projects.[Project].feedback', [
+        'project' => $project,
+    ]))->name('projects.feedback');
     Route::delete('/projects/{project}', ProjectController::class)
         ->name('projects.destroy');
     Route::delete('/projects/{project}/issues/{issue}', IssueController::class)

--- a/tests/Feature/ProjectFeedbackPostsTest.php
+++ b/tests/Feature/ProjectFeedbackPostsTest.php
@@ -10,6 +10,7 @@ use App\Models\Team;
 use App\Models\User;
 use Database\Seeders\PermissionSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
 use Spatie\Permission\PermissionRegistrar;
 use Tests\TestCase;
 
@@ -61,6 +62,14 @@ class ProjectFeedbackPostsTest extends TestCase
             ->assertOk()
             ->assertSee('Player Ideas')
             ->assertSee('Add a better map view');
+    }
+
+    public function test_project_feedback_route_is_registered_in_the_route_collection(): void
+    {
+        $route = Route::getRoutes()->getByName('projects.feedback');
+
+        $this->assertNotNull($route);
+        $this->assertSame('projects/{project}/feedback', $route->uri());
     }
 
     public function test_project_feedback_posts_respect_project_view_permission(): void


### PR DESCRIPTION
## Summary by Sourcery

Ensure the project feedback tab only links to existing routes and register a dedicated route for project feedback pages.

New Features:
- Add a named web route to render the project-specific feedback page.

Bug Fixes:
- Skip rendering project navigation tabs whose target route is not registered to avoid errors when generating URLs.

Tests:
- Add a feature test asserting that the projects.feedback route exists with the expected URI pattern.