### PR TITLE
Add Sentry alert rule settings endpoint

### DIFF
--- a/app/Http/Controllers/Sentry/AlertRuleSettingsController.php
+++ b/app/Http/Controllers/Sentry/AlertRuleSettingsController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers\Sentry;
+
+use App\Models\IssuePriority;
+use App\Models\IssueType;
+use App\Models\Project;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Routing\Controller;
+
+final class AlertRuleSettingsController extends Controller
+{
+    public function store(Request $request): JsonResponse|Response
+    {
+        $projectId = $this->setting($request, 'forge_project_id');
+        $issueTypeId = $this->setting($request, 'forge_issue_type_id');
+        $priorityId = $this->setting($request, 'forge_priority_id');
+
+        if ($projectId === '' || ! Project::query()->whereKey($projectId)->exists()) {
+            return $this->error('Choose a valid Forge project.');
+        }
+
+        if ($issueTypeId === '' || ! IssueType::query()->whereKey($issueTypeId)->exists()) {
+            return $this->error('Choose a valid issue type.');
+        }
+
+        if ($priorityId === '' || ! IssuePriority::query()->whereKey($priorityId)->exists()) {
+            return $this->error('Choose a valid priority.');
+        }
+
+        return response()->noContent();
+    }
+
+    private function setting(Request $request, string $name): string
+    {
+        $direct = $request->input($name);
+        if (is_scalar($direct)) {
+            return trim((string) $direct);
+        }
+
+        $settings = $request->input('settings', []);
+        if (is_array($settings)) {
+            foreach ($settings as $setting) {
+                if (! is_array($setting) || (string) ($setting['name'] ?? '') !== $name) {
+                    continue;
+                }
+
+                $value = $setting['value'] ?? '';
+
+                return is_scalar($value) ? trim((string) $value) : '';
+            }
+        }
+
+        return '';
+    }
+
+    private function error(string $message): JsonResponse
+    {
+        return new JsonResponse(['message' => $message], 400);
+    }
+}

--- a/app/Http/Middleware/VerifySentryInstallation.php
+++ b/app/Http/Middleware/VerifySentryInstallation.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Auth for Sentry UI-component option lookups (e.g. /api/sentry/options/*).
+ * Auth for Sentry UI-component requests (e.g. /api/sentry/options/*).
  *
  * Sentry signs webhook deliveries (POSTs with a body) using HMAC-SHA256, but
  * UI component select-option requests are GETs with no body. Instead, Sentry

--- a/resources/integrations/sentry/schema.json
+++ b/resources/integrations/sentry/schema.json
@@ -5,7 +5,7 @@
       "title": "Send to Forge",
       "settings": {
         "type": "alert-rule-settings",
-        "uri": "/api/webhooks/sentry",
+        "uri": "/api/sentry/alert-rule",
         "required_fields": [
           {
             "type": "select",

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Api\V1\SystemIssueController;
 use App\Http\Controllers\Api\V1\SystemOrganizationController;
 use App\Http\Controllers\Api\V1\SystemProjectController;
 use App\Http\Controllers\Sentry\AlertRuleOptionsController;
+use App\Http\Controllers\Sentry\AlertRuleSettingsController;
 use App\Http\Controllers\Webhooks\GitHubWebhookController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -28,6 +29,10 @@ Route::prefix('sentry/options')
         Route::get('issue-types', [AlertRuleOptionsController::class, 'issueTypes'])->name('issue-types');
         Route::get('priorities', [AlertRuleOptionsController::class, 'priorities'])->name('priorities');
     });
+
+Route::post('sentry/alert-rule', [AlertRuleSettingsController::class, 'store'])
+    ->name('sentry.alert-rule.store')
+    ->middleware('sentry.installation');
 
 Route::prefix('v1')->name('api.v1.')->group(function () {
     // Public (throttled) ingest; optionally protect with 'ingest.key' later.

--- a/tests/Feature/Integrations/Sentry/AlertRuleOptionsTest.php
+++ b/tests/Feature/Integrations/Sentry/AlertRuleOptionsTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature\Integrations\Sentry;
 
+use App\Models\IssuePriority;
+use App\Models\IssueType;
 use App\Models\Project;
 use App\Settings\SentrySettings;
 use Database\Seeders\IssueEnumsSeeder;
@@ -98,5 +100,53 @@ class AlertRuleOptionsTest extends TestCase
 
         $response->assertOk();
         $this->assertSame($this->installationUuid, app(SentrySettings::class)->refresh()->installation_uuid);
+    }
+
+    public function test_alert_rule_settings_endpoint_accepts_valid_configuration(): void
+    {
+        $project = Project::factory()->create();
+        $type = IssueType::query()->where('key', 'BUG')->firstOrFail();
+        $priority = IssuePriority::query()->where('key', 'HIGH')->firstOrFail();
+
+        $response = $this->postJson('/api/sentry/alert-rule?installationId='.$this->installationUuid, [
+            'forge_project_id' => (string) $project->id,
+            'forge_issue_type_id' => (string) $type->id,
+            'forge_priority_id' => (string) $priority->id,
+        ]);
+
+        $response->assertNoContent();
+    }
+
+    public function test_alert_rule_settings_endpoint_accepts_settings_array_payload(): void
+    {
+        $project = Project::factory()->create();
+        $type = IssueType::query()->where('key', 'BUG')->firstOrFail();
+        $priority = IssuePriority::query()->where('key', 'HIGH')->firstOrFail();
+
+        $response = $this->postJson('/api/sentry/alert-rule?installationId='.$this->installationUuid, [
+            'settings' => [
+                ['name' => 'forge_project_id', 'value' => (string) $project->id],
+                ['name' => 'forge_issue_type_id', 'value' => (string) $type->id],
+                ['name' => 'forge_priority_id', 'value' => (string) $priority->id],
+            ],
+        ]);
+
+        $response->assertNoContent();
+    }
+
+    public function test_alert_rule_settings_endpoint_returns_sentry_error_shape_for_invalid_configuration(): void
+    {
+        $type = IssueType::query()->where('key', 'BUG')->firstOrFail();
+        $priority = IssuePriority::query()->where('key', 'HIGH')->firstOrFail();
+
+        $response = $this->postJson('/api/sentry/alert-rule?installationId='.$this->installationUuid, [
+            'forge_project_id' => 'missing-project',
+            'forge_issue_type_id' => (string) $type->id,
+            'forge_priority_id' => (string) $priority->id,
+        ]);
+
+        $response
+            ->assertStatus(400)
+            ->assertJson(['message' => 'Choose a valid Forge project.']);
     }
 }


### PR DESCRIPTION
- Introduce `AlertRuleSettingsController` to handle alert rule settings validation and storage.
- Add validation for project, issue type, and priority via model lookups.
- Update `routes/api.php` to include the new route with middleware.
- Modify Sentry integration schema to use the new endpoint.
- Add feature tests for valid and invalid alert rule configurations.

## Summary by Sourcery

Add a Sentry alert rule settings endpoint that validates Forge project, issue type, and priority selections for Sentry UI components.

New Features:
- Expose a secured Sentry alert rule settings API endpoint that validates Forge project, issue type, and priority against existing models before accepting configurations.

Enhancements:
- Update Sentry middleware documentation comment and integration schema wiring to route alert rule settings through the new endpoint.

Tests:
- Add feature tests covering valid and invalid Sentry alert rule configurations, including support for direct and array-based settings payloads.