### PR TITLE
Add Sentry alert rule creation functionality

### DIFF
--- a/app/Filament/Pages/ConnectorsAndSyncSettings.php
+++ b/app/Filament/Pages/ConnectorsAndSyncSettings.php
@@ -185,6 +185,49 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
             Action::make('testSentry')->label('Test Sentry')
                 ->visible(fn () => (bool) ($this->data['sentry_enabled'] ?? false))
                 ->action(fn () => $this->testSentry()),
+            Action::make('createSentryAlertRule')
+                ->label('Create Sentry Rule')
+                ->visible(fn () => (bool) ($this->data['sentry_enabled'] ?? false))
+                ->schema([
+                    TextInput::make('sentry_project_slug')
+                        ->label('Sentry project slug')
+                        ->required(),
+                    TextInput::make('rule_name')
+                        ->label('Rule name')
+                        ->default('Send new issues to Forge')
+                        ->required(),
+                    TextInput::make('frequency')
+                        ->label('Action frequency minutes')
+                        ->numeric()
+                        ->minValue(5)
+                        ->maxValue(43200)
+                        ->default(5)
+                        ->required(),
+                    Select::make('forge_project_id')
+                        ->label('Forge project')
+                        ->options(fn () => Project::query()->orderBy('name')->pluck('name', 'id')->all())
+                        ->default(fn () => $this->data['sentry_default_project_id'] ?? null)
+                        ->searchable()
+                        ->preload()
+                        ->required(),
+                    Select::make('forge_issue_type_id')
+                        ->label('Issue type')
+                        ->options(fn () => IssueType::query()->orderBy('name')->pluck('name', 'id')->all())
+                        ->default(fn () => $this->data['sentry_default_issue_type_id'] ?? null)
+                        ->searchable()
+                        ->preload()
+                        ->required(),
+                    Select::make('forge_priority_id')
+                        ->label('Priority')
+                        ->options(fn () => IssuePriority::query()->orderBy('name')->pluck('name', 'id')->all())
+                        ->default(fn () => $this->data['sentry_default_priority_id'] ?? null)
+                        ->searchable()
+                        ->preload()
+                        ->required(),
+                ])
+                ->action(function (array $data): void {
+                    $this->createSentryAlertRule($data);
+                }),
         ];
     }
 
@@ -267,6 +310,36 @@ final class ConnectorsAndSyncSettings extends Page implements HasForms
                 : Notification::make()->title('Sentry ping failed')->danger()->send();
         } catch (\Throwable $e) {
             Notification::make()->title('Sentry error')->body($e->getMessage())->danger()->send();
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $data
+     */
+    private function createSentryAlertRule(array $data): void
+    {
+        try {
+            $rule = app(SentryClient::class)->createIssueAlertRule(
+                sentryProjectSlug: trim((string) ($data['sentry_project_slug'] ?? '')),
+                ruleName: trim((string) ($data['rule_name'] ?? 'Send new issues to Forge')),
+                forgeProjectId: (string) ($data['forge_project_id'] ?? ''),
+                issueTypeId: (int) ($data['forge_issue_type_id'] ?? 0),
+                priorityId: (int) ($data['forge_priority_id'] ?? 0),
+                frequency: (int) ($data['frequency'] ?? 5),
+            );
+
+            $ruleId = (string) ($rule['id'] ?? '');
+            Notification::make()
+                ->title('Sentry rule created')
+                ->body($ruleId !== '' ? 'Rule ID: '.$ruleId : 'Sentry accepted the rule.')
+                ->success()
+                ->send();
+        } catch (\Throwable $e) {
+            Notification::make()
+                ->title('Could not create Sentry rule')
+                ->body($e->getMessage())
+                ->danger()
+                ->send();
         }
     }
 

--- a/app/Integrations/Sentry/Services/SentryClient.php
+++ b/app/Integrations/Sentry/Services/SentryClient.php
@@ -52,6 +52,58 @@ final class SentryClient
     }
 
     /**
+     * @return array<string,mixed>
+     *
+     * @throws ConnectionException
+     */
+    public function createIssueAlertRule(
+        string $sentryProjectSlug,
+        string $ruleName,
+        string $forgeProjectId,
+        int $issueTypeId,
+        int $priorityId,
+        int $frequency = 5,
+    ): array {
+        $this->ensureAlertRuleConfigured();
+
+        $resp = $this->client()->post(
+            sprintf(
+                '/projects/%s/%s/rules/',
+                rawurlencode((string) $this->settings->org_slug),
+                rawurlencode($sentryProjectSlug),
+            ),
+            [
+                'name' => $ruleName,
+                'frequency' => max(5, min(43200, $frequency)),
+                'actionMatch' => 'all',
+                'filterMatch' => 'all',
+                'conditions' => [
+                    ['id' => 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition'],
+                ],
+                'filters' => [],
+                'actions' => [
+                    [
+                        'id' => 'sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction',
+                        'settings' => [
+                            ['name' => 'forge_project_id', 'value' => $forgeProjectId],
+                            ['name' => 'forge_issue_type_id', 'value' => (string) $issueTypeId],
+                            ['name' => 'forge_priority_id', 'value' => (string) $priorityId],
+                        ],
+                        'sentryAppInstallationUuid' => (string) $this->settings->installation_uuid,
+                        'hasSchemaFormConfig' => true,
+                    ],
+                ],
+            ],
+        );
+
+        $this->assertOk($resp, 'create issue alert rule');
+
+        $json = $resp->json();
+
+        return is_array($json) ? $json : [];
+    }
+
+    /**
      * @throws ConnectionException
      */
     public function ping(): bool
@@ -91,6 +143,19 @@ final class SentryClient
     {
         if (! $this->isConfigured()) {
             throw new RuntimeException('Sentry integration is not enabled or missing an auth token.');
+        }
+    }
+
+    private function ensureAlertRuleConfigured(): void
+    {
+        $this->ensureConfigured();
+
+        if (! filled($this->settings->org_slug)) {
+            throw new RuntimeException('Sentry integration is missing an org slug.');
+        }
+
+        if (! filled($this->settings->installation_uuid)) {
+            throw new RuntimeException('Sentry installation UUID has not been recorded yet.');
         }
     }
 

--- a/tests/Feature/Integrations/Sentry/OutboundSyncTest.php
+++ b/tests/Feature/Integrations/Sentry/OutboundSyncTest.php
@@ -161,6 +161,48 @@ class OutboundSyncTest extends TestCase
         });
     }
 
+    public function test_sentry_client_creates_issue_alert_rule_for_sentry_app_action(): void
+    {
+        $project = Project::factory()->create();
+        $type = IssueType::query()->where('key', 'BUG')->firstOrFail();
+        $priority = IssuePriority::query()->where('key', 'HIGH')->firstOrFail();
+
+        $settings = app(SentrySettings::class);
+        $settings->installation_uuid = '9a89a822-6e0b-4b62-9b99-905b9d742dd1';
+        $settings->save();
+
+        Http::fake([
+            'sentry.io/api/0/projects/acme/crash-game/rules/' => Http::response(['id' => 'rule-123'], 201),
+        ]);
+
+        $rule = app(SentryClient::class)->createIssueAlertRule(
+            sentryProjectSlug: 'crash-game',
+            ruleName: 'Send new issues to Forge',
+            forgeProjectId: (string) $project->id,
+            issueTypeId: $type->id,
+            priorityId: $priority->id,
+            frequency: 5,
+        );
+
+        $this->assertSame('rule-123', $rule['id']);
+
+        Http::assertSent(function ($request) use ($project, $type, $priority) {
+            $action = $request['actions'][0] ?? [];
+
+            return $request->method() === 'POST'
+                && str_ends_with($request->url(), '/projects/acme/crash-game/rules/')
+                && $request['conditions'][0]['id'] === 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition'
+                && $action['id'] === 'sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction'
+                && $action['sentryAppInstallationUuid'] === '9a89a822-6e0b-4b62-9b99-905b9d742dd1'
+                && $action['hasSchemaFormConfig'] === true
+                && $action['settings'] === [
+                    ['name' => 'forge_project_id', 'value' => (string) $project->id],
+                    ['name' => 'forge_issue_type_id', 'value' => (string) $type->id],
+                    ['name' => 'forge_priority_id', 'value' => (string) $priority->id],
+                ];
+        });
+    }
+
     private function makeIssue(): Issue
     {
         $project = Project::factory()->create();


### PR DESCRIPTION
- Implement `createIssueAlertRule` in `SentryClient` to create Sentry issue alert rules.
- Add `ensureAlertRuleConfigured` for Sentry rule prerequisites validation.
- Extend `ConnectorsAndSyncSettings` with a new action to create Sentry alert rules via user inputs.
- Add feature tests for creating Sentry alert rules and validating API requests.

## Summary by Sourcery

Add UI and backend support for creating Sentry issue alert rules wired to the Forge Sentry app action.

New Features:
- Introduce a Filament action that lets users create Sentry issue alert rules from the connectors and sync settings page using Forge project, issue type, and priority inputs.
- Add a Sentry client API method to create issue alert rules for a given Sentry project, integrating with the Forge Sentry app action.

Enhancements:
- Add Sentry configuration validation specific to alert rule creation, ensuring organisation slug and installation UUID are present before calling the Sentry API.

Tests:
- Extend Sentry outbound sync feature tests to cover issue alert rule creation payloads and responses.