### PR TITLE
Remove unused `hasSchemaFormConfig` and update Sentry schema with new…

### DIFF
--- a/app/Integrations/Sentry/Services/SentryClient.php
+++ b/app/Integrations/Sentry/Services/SentryClient.php
@@ -90,7 +90,6 @@ final class SentryClient
                             ['name' => 'forge_priority_id', 'value' => (string) $priorityId],
                         ],
                         'sentryAppInstallationUuid' => (string) $this->settings->installation_uuid,
-                        'hasSchemaFormConfig' => true,
                     ],
                 ],
             ],

--- a/resources/integrations/sentry/schema.json
+++ b/resources/integrations/sentry/schema.json
@@ -3,6 +3,7 @@
     {
       "type": "alert-rule-action",
       "title": "Send to Forge",
+      "uri": "/api/webhooks/sentry",
       "settings": {
         "type": "alert-rule-settings",
         "uri": "/api/sentry/alert-rule",

--- a/tests/Feature/Integrations/Sentry/OutboundSyncTest.php
+++ b/tests/Feature/Integrations/Sentry/OutboundSyncTest.php
@@ -194,7 +194,7 @@ class OutboundSyncTest extends TestCase
                 && $request['conditions'][0]['id'] === 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition'
                 && $action['id'] === 'sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction'
                 && $action['sentryAppInstallationUuid'] === '9a89a822-6e0b-4b62-9b99-905b9d742dd1'
-                && $action['hasSchemaFormConfig'] === true
+                && ! array_key_exists('hasSchemaFormConfig', $action)
                 && $action['settings'] === [
                     ['name' => 'forge_project_id', 'value' => (string) $project->id],
                     ['name' => 'forge_issue_type_id', 'value' => (string) $type->id],


### PR DESCRIPTION
… webhook URI

## Summary by Sourcery

Remove deprecated Sentry issue alert action field and update Sentry integration schema.

Enhancements:
- Stop sending the obsolete hasSchemaFormConfig flag in Sentry issue alert rule actions.
- Update the Sentry integration schema to reflect the new webhook URI and payload shape without hasSchemaFormConfig.

Tests:
- Adjust Sentry outbound sync test to assert the hasSchemaFormConfig field is no longer present in the action payload.