### PR TITLE
Add `hasSchemaFormConfig` to Sentry client payload and update related…

### DIFF
--- a/app/Integrations/Sentry/Services/SentryClient.php
+++ b/app/Integrations/Sentry/Services/SentryClient.php
@@ -90,6 +90,7 @@ final class SentryClient
                             ['name' => 'forge_priority_id', 'value' => (string) $priorityId],
                         ],
                         'sentryAppInstallationUuid' => (string) $this->settings->installation_uuid,
+                        'hasSchemaFormConfig' => true,
                     ],
                 ],
             ],

--- a/tests/Feature/Integrations/Sentry/OutboundSyncTest.php
+++ b/tests/Feature/Integrations/Sentry/OutboundSyncTest.php
@@ -194,7 +194,7 @@ class OutboundSyncTest extends TestCase
                 && $request['conditions'][0]['id'] === 'sentry.rules.conditions.first_seen_event.FirstSeenEventCondition'
                 && $action['id'] === 'sentry.rules.actions.notify_event_sentry_app.NotifyEventSentryAppAction'
                 && $action['sentryAppInstallationUuid'] === '9a89a822-6e0b-4b62-9b99-905b9d742dd1'
-                && ! array_key_exists('hasSchemaFormConfig', $action)
+                && $action['hasSchemaFormConfig'] === true
                 && $action['settings'] === [
                     ['name' => 'forge_project_id', 'value' => (string) $project->id],
                     ['name' => 'forge_issue_type_id', 'value' => (string) $type->id],


### PR DESCRIPTION
… test assertions

## Summary by Sourcery

Include the hasSchemaFormConfig flag in Sentry issue alert rule payloads and update tests to assert its presence.

New Features:
- Add hasSchemaFormConfig flag to Sentry issue alert rule action payloads sent to Sentry.

Tests:
- Adjust Sentry outbound sync tests to expect the hasSchemaFormConfig flag in the action payload.