### PR TITLE
Update Sentry middleware, routes, and tests for unified signature val…

### DIFF
--- a/app/Http/Middleware/VerifySentryHookSignature.php
+++ b/app/Http/Middleware/VerifySentryHookSignature.php
@@ -9,10 +9,10 @@ use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
- * Used by the alert-rule options endpoints, which Sentry signs the same way
+ * Used by Sentry UI-component POST callbacks, which Sentry signs the same way
  * as webhooks (HMAC-SHA256 of the raw body using the integration's client
  * secret). The Spatie webhook-client config handles signing for /webhooks/sentry;
- * this middleware applies the same check to GET option lookups.
+ * this middleware applies the same check to routes outside webhook-client.
  */
 final class VerifySentryHookSignature
 {

--- a/resources/integrations/sentry/schema.json
+++ b/resources/integrations/sentry/schema.json
@@ -3,7 +3,6 @@
     {
       "type": "alert-rule-action",
       "title": "Send to Forge",
-      "uri": "/api/webhooks/sentry",
       "settings": {
         "type": "alert-rule-settings",
         "uri": "/api/sentry/alert-rule",

--- a/routes/api.php
+++ b/routes/api.php
@@ -32,7 +32,7 @@ Route::prefix('sentry/options')
 
 Route::post('sentry/alert-rule', [AlertRuleSettingsController::class, 'store'])
     ->name('sentry.alert-rule.store')
-    ->middleware('sentry.installation');
+    ->middleware('sentry.hook');
 
 Route::prefix('v1')->name('api.v1.')->group(function () {
     // Public (throttled) ingest; optionally protect with 'ingest.key' later.

--- a/tests/Feature/Integrations/Sentry/AlertRuleOptionsTest.php
+++ b/tests/Feature/Integrations/Sentry/AlertRuleOptionsTest.php
@@ -108,7 +108,7 @@ class AlertRuleOptionsTest extends TestCase
         $type = IssueType::query()->where('key', 'BUG')->firstOrFail();
         $priority = IssuePriority::query()->where('key', 'HIGH')->firstOrFail();
 
-        $response = $this->postJson('/api/sentry/alert-rule?installationId='.$this->installationUuid, [
+        $response = $this->postSignedAlertRuleJson([
             'forge_project_id' => (string) $project->id,
             'forge_issue_type_id' => (string) $type->id,
             'forge_priority_id' => (string) $priority->id,
@@ -123,7 +123,7 @@ class AlertRuleOptionsTest extends TestCase
         $type = IssueType::query()->where('key', 'BUG')->firstOrFail();
         $priority = IssuePriority::query()->where('key', 'HIGH')->firstOrFail();
 
-        $response = $this->postJson('/api/sentry/alert-rule?installationId='.$this->installationUuid, [
+        $response = $this->postSignedAlertRuleJson([
             'settings' => [
                 ['name' => 'forge_project_id', 'value' => (string) $project->id],
                 ['name' => 'forge_issue_type_id', 'value' => (string) $type->id],
@@ -139,7 +139,7 @@ class AlertRuleOptionsTest extends TestCase
         $type = IssueType::query()->where('key', 'BUG')->firstOrFail();
         $priority = IssuePriority::query()->where('key', 'HIGH')->firstOrFail();
 
-        $response = $this->postJson('/api/sentry/alert-rule?installationId='.$this->installationUuid, [
+        $response = $this->postSignedAlertRuleJson([
             'forge_project_id' => 'missing-project',
             'forge_issue_type_id' => (string) $type->id,
             'forge_priority_id' => (string) $priority->id,
@@ -148,5 +148,34 @@ class AlertRuleOptionsTest extends TestCase
         $response
             ->assertStatus(400)
             ->assertJson(['message' => 'Choose a valid Forge project.']);
+    }
+
+    public function test_alert_rule_settings_endpoint_rejects_missing_signature(): void
+    {
+        $response = $this->postJson('/api/sentry/alert-rule', []);
+
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function postSignedAlertRuleJson(array $payload): \Illuminate\Testing\TestResponse
+    {
+        $body = json_encode($payload, JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($body);
+
+        return $this->call(
+            'POST',
+            '/api/sentry/alert-rule',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_SENTRY_HOOK_SIGNATURE' => hash_hmac('sha256', $body, 'cs'),
+            ],
+            $body,
+        );
     }
 }


### PR DESCRIPTION
…idation

- Refactor `VerifySentryHookSignature` to clarify its use across non-webhook-client routes.
- Update Sentry integration schema to remove unused webhook URI.
- Replace test requests with `postSignedAlertRuleJson` helper to validate signatures.
- Add test for missing signature scenario on alert rule endpoint.

## Summary by Sourcery

Enforce and test HMAC signature validation for Sentry alert rule callbacks and update related middleware and integration configuration.

Bug Fixes:
- Ensure the Sentry alert rule endpoint returns 401 when the hook signature is missing.

Enhancements:
- Apply the unified Sentry hook signature verification middleware to the alert rule endpoint instead of the installation middleware.
- Clarify the VerifySentryHookSignature middleware documentation to describe its use on non-webhook-client Sentry callbacks.
- Update the Sentry integration schema to remove an unused webhook URI configuration entry.

Tests:
- Refactor Sentry alert rule tests to send HMAC-signed JSON requests via a shared helper that sets the signature header.
- Add a test case verifying that the alert rule endpoint rejects requests without a Sentry hook signature.